### PR TITLE
Fixed #27 기본 ionic tab template으로 android에서 하단에 tab이 위치하도록 변경

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -23,7 +23,7 @@ angular.module('starter', ['ionic', 'starter.controllers', 'starter.services', '
         });
     })
 
-    .config(function($stateProvider, $urlRouterProvider) {
+    .config(function($stateProvider, $urlRouterProvider, $ionicConfigProvider) {
 
         // Ionic uses AngularUI Router which uses the concept of states
         // Learn more here: https://github.com/angular-ui/ui-router
@@ -82,4 +82,5 @@ angular.module('starter', ['ionic', 'starter.controllers', 'starter.services', '
         // if none of the above states are matched, use this as the fallback
         $urlRouterProvider.otherwise('/tab/dash');
 
+        $ionicConfigProvider.tabs.position('bottom');
     });


### PR DESCRIPTION
* ionicConfigProvider에서 tabs.position을 bottom으로 설정