### PR TITLE
61 pull to refresh

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -47,6 +47,10 @@ $ionicons-font-path: "../lib/ionic/fonts" !default;
   height: 100%;
 }
 
+.overflow-scroll {
+  margin-bottom: 0;
+}
+
 .col {
   font-family: "Nanum Barun Gothic UltraLight";
 }

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -19,10 +19,8 @@ angular.module('starter', ['ionic', 'starter.controllers', 'starter.services', '
             if (window.StatusBar) {
                 // org.apache.cordova.statusbar required
                 //StatusBar.styleLightContent();
-                StatusBar.overlaysWebView(false);
-                StatusBar.backgroundColorByHexString('#22a1db');
-                //StatusBar.hide();
-                //ionic.Platform.fullScreen();
+                StatusBar.hide();
+                ionic.Platform.fullScreen();
             }
         });
     })

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -14,6 +14,22 @@ angular.module('starter.controllers', [])
             }
         }
 
+        $scope.doRefresh = function() {
+            setTimeout(function() {
+                    // Stop the ion-refresher from spinning
+                    $scope.$broadcast('scroll.refreshComplete');
+                },
+                3000);
+            //$http.get('/new-items')
+            //    .success(function(newItems) {
+            //        $scope.items = newItems;
+            //    })
+            //    .finally(function() {
+            //        // Stop the ion-refresher from spinning
+            //        $scope.$broadcast('scroll.refreshComplete');
+            //    });
+        };
+
         $cordovaGeolocation.getCurrentPosition().then(function(position) {
             var lat  = position.coords.latitude;
             var long = position.coords.longitude;

--- a/client/www/templates/tab-dash.html
+++ b/client/www/templates/tab-dash.html
@@ -1,5 +1,10 @@
 <ion-view hide-nav-bar="true">
     <ion-content overflow-scroll="true">
+        <ion-refresher
+                pulling-text="위치,날씨정보"
+                refreshing-text="업데이트 중"
+                on-refresh="doRefresh()">
+        </ion-refresher>
         <div class="main-content">
             <div class="row row-no-padding" style="height: 35%;">
                 <div class="col" style="height: 100%">
@@ -30,8 +35,8 @@
                 </div>
             </div>
             <div class="row row-no-padding" style="height: 5%;"></div>
-            <div class="row row-no-padding" style="height: 60%;">
-                <ion-scroll zooming="false" direction="x" has-bouncing="false" style="width: 100%; height: 100%">
+            <div class="row row-no-padding" style="height: 55%;">
+                <ion-scroll zooming="false" direction="x" has-bouncing="false" scrollbar-x="false" style="width: 100%; height: 100%">
                     <div class="col" style="padding: 0; height: 100%; width: 1290px;">
                         <div class="row row-no-padding" style="height: 50%;"></div>
                         <div class="row row-no-padding" style="height: 2%;"></div>
@@ -62,7 +67,7 @@
                     </div>
                 </ion-scroll>
             </div>
-            <!--<hr style="color: white; opacity: 0.6">-->
+            <div class="row row-no-padding" style="height: 5%;"></div>
         </div>
     </ion-content>
 </ion-view>

--- a/client/www/templates/tabs.html
+++ b/client/www/templates/tabs.html
@@ -3,7 +3,7 @@ Create tabs with an icon and label, using the tabs-positive style.
 Each tab's child <ion-nav-view> directive will have its own
 navigation history that also transitions its views in and out.
 -->
-<ion-tabs class="tabs-icon-only tabs-calm">
+<ion-tabs class="tabs-calm tabs-item-hide">
 
     <!-- Dashboard Tab -->
     <ion-tab title="Status" icon-off="ion-ios-plus-empty" icon-on="ion-ios-plus-empty" href="#/tab/dash">


### PR DESCRIPTION
scroll을 위한 overflow-scroll와 함께, ion-refresher를 사용하면, ion-content의 height값이 pull-to-refresh할 때 변경되는 문제가 있음.
nav-bar를 제거하는 것으로 문제 해결.
chart 하단에 nav-bar 대신으로 5% 공백 추가.
chart-scroll 에서 scrollbar-x 제거.
tabs-item-hide 옵션을 주어 tabs menu제거.
status bar를 제거하고, fullscreen 화면으로 변경.