### PR TITLE
Fixed  #78 차트의 디자인 시안 적용 작업

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -174,25 +174,37 @@ $ionicons-font-path: "../lib/ionic/fonts" !default;
 /* chart style */
 .line-today {
   stroke: #ffffff;
-  stroke-width: 3px;
+  stroke-width: 2px;
   fill: none;
 }
 
 .line-yesterday {
   stroke: #d0d0d0;
-  stroke-width: 3px;
+  stroke-width: 1px;
   fill: none;
 }
 
 .circle-today {
   stroke: #ffffff;
-  stroke-width: 3px;
-  fill: #ff0000;
+  stroke-width: 1px;
+  fill: #ffffff;
 }
 
 .circle-yesterday {
   stroke: #d0d0d0;
-  stroke-width: 3px;
+  stroke-width: 1px;
+  fill: #d0d0d0;
+}
+
+.circle-today-current {
+  stroke: #ffffff;
+  stroke-width: 2px;
+  fill: #ff0000;
+}
+
+.circle-yesterday-current {
+  stroke: #d0d0d0;
+  stroke-width: 2px;
   fill: #d0d0d0;
 }
 

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -108,7 +108,7 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
             restrict: 'A',
             transclude: true,
             link: function (scope, iElement) {
-                var margin = {top: 20, right: 0, bottom: 20, left: 0},
+                var margin = {top: 30, right: 0, bottom: 10, left: 0},
                     width = iElement[0].getBoundingClientRect().width - margin.left - margin.right,
                     height = iElement[0].getBoundingClientRect().height - margin.top - margin.bottom;
 
@@ -119,21 +119,21 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
                 var x = d3.scale.ordinal()
-                    .rangeRoundBands([width, 0]);
+                    .rangeBands([width, 0]);
 
                 var y = d3.scale.linear()
                     .range([height, 0]);
 
                 var line = d3.svg.line()
                     .defined(function (d) {
-                        return d.value != '';
+                        return d.value.t3h != '';
                     })
-                    .interpolate("monotone")
+                    .interpolate("linear")
                     .x(function (d, i) {
                         return x.rangeBand() * i + x.rangeBand() / 2;
                     })
                     .y(function (d) {
-                        return y(d.value);
+                        return y(d.value.t3h);
                     });
 
                 scope.$watch('temp', function (newVal) {
@@ -144,12 +144,12 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                         y.domain([
                             d3.min(column, function (c) {
                                 return d3.min(c.values, function (v) {
-                                    return v.value;
+                                    return v.value.t3h;
                                 });
                             }),
                             d3.max(column, function (c) {
                                 return d3.max(c.values, function (v) {
-                                    return v.value;
+                                    return v.value.t3h;
                                 });
                             })
                         ]).nice();
@@ -186,13 +186,18 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                             .data(function(d) { return d.values; })
                             .enter().append('circle')
                             .attr("cx", function(d, i) { return x.rangeBand() * i + x.rangeBand() / 2; })
-                            .attr("cy", function(d) { return y(d.value); })
-                            .attr("r", 8)
+                            .attr("cy", function(d) { return y(d.value.t3h); })
+                            .attr("r", function(d, i) {
+                                if (i === 8) {
+                                    return 5;
+                                }
+                                return 2;
+                            })
                             .attr("class", function(d, i) {
                                 if (i === 8) {
-                                    return "circle-"+d.name;
+                                    return "circle-"+d.name+"-current";
                                 }
-                                return "circle-hidden";
+                                return "circle-"+d.name;
                             });
 
                         // update point
@@ -200,7 +205,7 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                             .selectAll('circle')
                             .data(function(d) { return d.values; })
                             .attr("cx", function(d, i) { return x.rangeBand() * i + x.rangeBand() / 2; })
-                            .attr("cy", function(d) { return y(d.value); });
+                            .attr("cy", function(d) { return y(d.value.t3h); });
 
                         // draw value
                         var value = group_enter.append('g')
@@ -210,12 +215,12 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                             .data(function(d) { return d.values; })
                             .enter().append('text')
                             .attr("x", function(d, i) { return x.rangeBand() * i + x.rangeBand() / 2; })
-                            .attr("y", function(d) { return y(d.value); })
+                            .attr("y", function(d) { return y(d.value.t3h); })
                             .attr('dy', -10)
                             .attr("text-anchor", "middle")
-                            .text(function(d) { return d.value + "˚"; })
+                            .text(function(d) { return d.value.t3h + "˚"; })
                             .attr("class", function(d, i) {
-                                if (d.min === true || d.max === true) {
+                                if (d.name === "today" && (d.value.tempInfo === "min" || d.value.tempInfo === "max")) {
                                     return "text-" + d.name;
                                 }
                                 return "text-hidden";
@@ -226,8 +231,8 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                             .selectAll('text')
                             .data(function(d) { return d.values; })
                             .attr("x", function(d, i) { return x.rangeBand() * i + x.rangeBand() / 2; })
-                            .attr("y", function(d) { return y(d.value); })
-                            .text(function(d) { return d.value + "˚"; });
+                            .attr("y", function(d) { return y(d.value.t3h); })
+                            .text(function(d) { return d.value.t3h + "˚"; });
                     }
                 });
             }

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -186,9 +186,10 @@ angular.module('starter.controllers', [])
          * @param {Date} current
          * @returns {{timeTable: Array, chartTable: Array}}
          */
-        function parseShortTownWeather(shortForecastList, current) {
+        function parseShortTownWeather(shortForecastList, currentForecast, current) {
             var data = [];
             var positionHours = getPositionHours(current.getHours());
+            var prevDiffDays = null;
             var max = null;
             var min = null;
 
@@ -205,15 +206,30 @@ angular.module('starter.controllers', [])
                 tempObject.sky = parseSkyState(shortForecast.하늘상태, shortForecast.강수형태, shortForecast.낙뢰, isNight);
                 tempObject.pop = shortForecast.강수확률;
                 tempObject.tempIcon = decideTempIcon(shortForecast.기온, shortForecast.최고기온, shortForecast.최저기온);
-                // 오늘의 최고, 최저 온도 찾기
-                if (diffDays === 0) {
-                    if (max === null || max.t3h < tempObject.t3h) {
-                        max = tempObject;
-                    }
-                    if (min === null || min.t3h > tempObject.t3h) {
-                        min = tempObject;
-                    }
+                tempObject.tempInfo = "";
+
+                // 단기 예보의 현재(지금) 데이터를 currentForecast 정보로 업데이트
+                if (data.length === 16) {
+                    tempObject.t3h = currentForecast.t1h;
+                    tempObject.sky = currentForecast.sky;
+                    tempObject.tempIcon = decideTempIcon(currentForecast.t1h, currentForecast.tmx, currentForecast.tmn);
                 }
+
+                // 하루 기준의 최고, 최저 온도 찾기
+                if (prevDiffDays !== null && prevDiffDays !== diffDays) {
+                    max.tempInfo = "max";
+                    min.tempInfo = "min";
+                    max = null;
+                    min = null;
+                }
+                if (max === null || max.t3h < tempObject.t3h) {
+                    max = tempObject;
+                }
+                if (min === null || min.t3h > tempObject.t3h) {
+                    min = tempObject;
+                }
+                prevDiffDays = diffDays;
+
                 data.push(tempObject);
             });
 
@@ -222,19 +238,13 @@ angular.module('starter.controllers', [])
                 {
                     name: 'yesterday',
                     values: data.slice(0, shortForecastList.length - 8).map(function (d) {
-                        return { name: 'yesterday', value: d.t3h, min: false, max: false };
+                        return { name: 'yesterday', value: d };
                     })
                 },
                 {
                     name: 'today',
                     values: data.slice(8).map(function (d) {
-                        if (d === max) {
-                            return { name: 'today', value: d.t3h, min: false, max: true };
-                        }
-                        else if (d === min) {
-                            return { name: 'today', value: d.t3h, min: true, max: false };
-                        }
-                        return { name: 'today', value: d.t3h, min: false, max: false };
+                        return { name: 'today', value: d };
                     })
                 }
             ];
@@ -396,19 +406,6 @@ angular.module('starter.controllers', [])
         /**
          *
          * @param {Object} current
-         * @param {Object} tempObject
-         * @returns {*}
-         */
-        function updateCurrentOnTempTable(current, tempObject) {
-            tempObject.t3h = current.t1h;
-            tempObject.sky = current.sky;
-            tempObject.tempIcon = decideTempIcon(current.t1h, current.tmx, current.tmn);
-            return tempObject;
-        }
-
-        /**
-         *
-         * @param {Object} current
          * @param {Object} yesterday
          * @returns {String}
          */
@@ -439,9 +436,7 @@ angular.module('starter.controllers', [])
             currentForecast.tmx = weatherData.short[0].최고기온;
             currentForecast.tmn = weatherData.short[0].최저기온;
 
-            var parsedWeather = parseShortTownWeather(weatherData.short, $scope.currentTime);
-            parsedWeather.timeTable[8] = updateCurrentOnTempTable(currentForecast, parsedWeather.timeTable[8]);
-
+            var parsedWeather = parseShortTownWeather(weatherData.short, currentForecast, $scope.currentTime);
             currentForecast.summary = makeSummary(currentForecast, parsedWeather.timeTable[0]);
 
             $scope.currentWeather = currentForecast;


### PR DESCRIPTION
#78 차트의 디자인 시안 적용 작업
* 단기 예보의 현재(지금) 데이터를 currentForecast 정보로 업데이트 후 timeTable, chartTable의 데이터로 사용
* 차트 선을 monotone에서 linear로 변경
* 모든 데이터에 점으로 표시 추가(현재만 다른 스타일로 적용)
* 날짜 별 최대, 최소 온도 표시
* timeTable 데이터와 차트 점의 위치가 맞지 않는 문제 수정
 -  x축의 range을 rangeRoundBands에서 rangeBands로 변경(보정 처리 제외)