### PR TITLE
 Fixed #128 차트의 최고,최저 온도 표시가 두번째 업데이트때 부터 표시되거나, 잘못 표기 되는 문제

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -218,13 +218,13 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                             .attr("y", function(d) { return y(d.value.t3h); })
                             .attr('dy', -10)
                             .attr("text-anchor", "middle")
-                            .text(function(d) { return d.value.t3h + "˚"; })
-                            .attr("class", function(d, i) {
-                                if (d.name === "today" && (d.value.tempInfo === "min" || d.value.tempInfo === "max")) {
-                                    return "text-" + d.name;
+                            .text(function(d) {
+                                if (d.name === "today" && (d.value.tmn !== undefined || d.value.tmx !== undefined)) {
+                                    return (d.value.tmn | d.value.tmx) + "˚";
                                 }
-                                return "text-hidden";
-                            });
+                                return "";
+                            })
+                            .attr("class", function(d, i) { return "text-today"; });
 
                         // update value
                         group.select('.line-value')
@@ -232,7 +232,12 @@ angular.module('starter', ['ionic','ionic.service.core','ionic.service.analytics
                             .data(function(d) { return d.values; })
                             .attr("x", function(d, i) { return x.rangeBand() * i + x.rangeBand() / 2; })
                             .attr("y", function(d) { return y(d.value.t3h); })
-                            .text(function(d) { return d.value.t3h + "˚"; });
+                            .text(function(d) {
+                                if (d.name === "today" && (d.value.tmn !== undefined || d.value.tmx !== undefined)) {
+                                    return (d.value.tmn | d.value.tmx) + "˚";
+                                }
+                                return "";
+                            });
                     }
                 });
             }

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -215,9 +215,6 @@ angular.module('starter.controllers', [])
         function parseShortTownWeather(shortForecastList, currentForecast, current) {
             var data = [];
             var positionHours = getPositionHours(current.getHours());
-            var prevDiffDays = null;
-            var max = null;
-            var min = null;
 
             shortForecastList.every(function (shortForecast) {
                 var tempObject = {};
@@ -237,34 +234,23 @@ angular.module('starter.controllers', [])
                 tempObject.sky = parseSkyState(shortForecast.sky, shortForecast.pty, shortForecast.lgt, isNight);
                 tempObject.pop = shortForecast.pop;
                 tempObject.tempIcon = decideTempIcon(shortForecast.t3h, shortForecast.tmx, shortForecast.tmn);
-                tempObject.tempInfo = "";
 
                 // 단기 예보의 현재(지금) 데이터를 currentForecast 정보로 업데이트
-                if (diffDays === 0 && time === positionHours) {
+                if (diffDays === 0 && time === positionHours && time === currentForecast.time) {
                     tempObject.t3h = currentForecast.t1h;
                     tempObject.sky = currentForecast.sky;
                     tempObject.tempIcon = decideTempIcon(currentForecast.t1h, currentForecast.tmx, currentForecast.tmn);
                 }
 
                 // 하루 기준의 최고, 최저 온도 찾기
-                if (prevDiffDays !== null && prevDiffDays !== diffDays) {
-                    max.tempInfo = "max";
-                    min.tempInfo = "min";
-
-                    //set null to find next item
-                    max = null;
-                    min = null;
+                if (shortForecast.tmx !== 0) {
+                    tempObject.tmx = shortForecast.tmx;
                 }
-                if (max === null || max.t3h < tempObject.t3h) {
-                    max = tempObject;
+                else if (shortForecast.tmn !== 0) {
+                    tempObject.tmn = shortForecast.tmn;
                 }
-                if (min === null || min.t3h > tempObject.t3h) {
-                    min = tempObject;
-                }
-                prevDiffDays = diffDays;
 
                 data.push(tempObject);
-
                 if (data.length >= 32) {
                     return false;
                 }
@@ -281,7 +267,6 @@ angular.module('starter.controllers', [])
                     tempObject.sky = "Sun";
                     tempObject.pop = 0;
                     tempObject.tempIcon = "Temp-01";
-                    tempObject.tempInfo = "";
                     data.push(tempObject);
                 }
             }
@@ -351,8 +336,8 @@ angular.module('starter.controllers', [])
          */
         function getWeatherInfo(addressArray, callback) {
             //var url = 'town';
-            //var url = 'http://d2ibo8bwl7ifj5.cloudfront.net/town';
-            var url = 'http://todayweather-wizardfactory.rhcloud.com/town';
+            var url = 'http://d2ibo8bwl7ifj5.cloudfront.net/town';
+            //var url = 'http://todayweather-wizardfactory.rhcloud.com/town';
 
             if (!Array.isArray(addressArray) || addressArray.length === 0) {
                 return callback(error);
@@ -599,34 +584,34 @@ angular.module('starter.controllers', [])
             $scope.currentWeather = {time: 7, t1h: 19, sky: "SunWithCloud", tmn: 14, tmx: 28, summary: "어제보다 1도 낮음"};
 
             var data = [];
-            data[0] = {day: "", time: "6시", t3h: 17, sky:"Cloud", pop: 10, tempIcon:"Temp-01", tempInfo: "min"};
+            data[0] = {day: "", time: "6시", t3h: 17, sky:"Cloud", pop: 10, tempIcon:"Temp-01", tmn: 17};
             data[1] = {day: "", time: "9시", t3h: 21, sky:"Lightning", pop: 20, tempIcon:"Temp-02"};
             data[2] = {day: "", time: "12시", t3h: 26, sky:"Moon", pop: 30, tempIcon:"Temp-03"};
-            data[3] = {day: "", time: "15시", t3h: 28, sky:"MoonWithCloud", pop: 40, tempIcon:"Temp-04", tempInfo: "max"};
+            data[3] = {day: "", time: "15시", t3h: 28, sky:"MoonWithCloud", pop: 40, tempIcon:"Temp-04", tmx: 28};
             data[4] = {day: "", time: "18시", t3h: 26, sky:"Rain", pop: 50, tempIcon:"Temp-05"};
             data[5] = {day: "", time: "21시", t3h: 21, sky:"RainWithLightning", pop: 60, tempIcon:"Temp-06"};
             data[6] = {day: "어제", time: "0시", t3h: 18, sky:"RainWithSnow", pop: 70, tempIcon:"Temp-07"};
             data[7] = {day: "", time: "3시", t3h: 16, sky:"Snow", pop: 80, tempIcon:"Temp-08"};
-            data[8] = {day: "", time: "6시", t3h: 15, sky:"SnowWithLightning-Big", pop: 90, tempIcon:"Temp-09", tempInfo: "min"};
+            data[8] = {day: "", time: "6시", t3h: 15, sky:"SnowWithLightning-Big", pop: 90, tempIcon:"Temp-09", tmn: 15};
             data[9] = {day: "", time: "9시", t3h: 21, sky:"Sun", pop: 10, tempIcon:"Temp-10"};
             data[10] = {day: "", time: "12시", t3h: 26, sky:"SunWithCloud", pop: 20, tempIcon:"Temp-10"};
             data[11] = {day: "", time: "15시", t3h: 28, sky:"WindWithCloud", pop: 30, tempIcon:"Temp-01"};
-            data[12] = {day: "", time: "18시", t3h: 29, sky:"Rain", pop: 50, tempIcon:"Temp-04", tempInfo: "max"};
+            data[12] = {day: "", time: "18시", t3h: 29, sky:"Rain", pop: 50, tempIcon:"Temp-04", tmx: 29};
             data[13] = {day: "", time: "21시", t3h: 21, sky:"RainWithLightning", pop: 60, tempIcon:"Temp-05"};
             data[14] = {day: "오늘", time: "0시", t3h: 18, sky:"RainWithSnow", pop: 70, tempIcon:"Temp-06"};
             data[15] = {day: "", time: "3시", t3h: 15, sky:"Snow", pop: 80, tempIcon:"Temp-07"};
-            data[16] = {day: "", time: "지금", t3h: 14, sky:"SnowWithLightning-Big", pop: 90, tempIcon:"Temp-08", tempInfo: "min"};
+            data[16] = {day: "", time: "지금", t3h: 14, sky:"SnowWithLightning-Big", pop: 90, tempIcon:"Temp-08", tmn: 14};
             data[17] = {day: "", time: "9시", t3h: 21, sky:"Cloud", pop: 10, tempIcon:"Temp-09"};
             data[18] = {day: "", time: "12시", t3h: 26, sky:"Lightning", pop: 20, tempIcon:"Temp-10"};
-            data[19] = {day: "", time: "15시", t3h: 29, sky:"Moon", pop: 30, tempIcon:"Temp-01", tempInfo: "max"};
+            data[19] = {day: "", time: "15시", t3h: 29, sky:"Moon", pop: 30, tempIcon:"Temp-01", tmx: 29};
             data[20] = {day: "", time: "18시", t3h: 28, sky:"MoonWithCloud", pop: 50, tempIcon:"Temp-04"};
             data[21] = {day: "", time: "21시", t3h: 22, sky:"Rain", pop: 60, tempIcon:"Temp-05"};
             data[22] = {day: "모레", time: "0시", t3h: 20, sky:"RainWithSnow", pop: 70, tempIcon:"Temp-06"};
             data[23] = {day: "", time: "3시", t3h: 18, sky:"RainWithLightning", pop: 80, tempIcon:"Temp-07"};
-            data[24] = {day: "", time: "6시", t3h: 17, sky:"SnowWithLightning-Big", pop: 90, tempIcon:"Temp-08", tempInfo: "min"};
+            data[24] = {day: "", time: "6시", t3h: 17, sky:"SnowWithLightning-Big", pop: 90, tempIcon:"Temp-08", tmn: 17};
             data[25] = {day: "", time: "9시", t3h: 21, sky:"Sun", pop: 10, tempIcon:"Temp-09"};
             data[26] = {day: "", time: "12시", t3h: 27, sky:"SunWithCloud", pop: 20, tempIcon:"Temp-10"};
-            data[27] = {day: "", time: "15시", t3h: 29, sky:"WindWithCloud", pop: 30, tempIcon:"Temp-01", tempInfo: "min"};
+            data[27] = {day: "", time: "15시", t3h: 29, sky:"WindWithCloud", pop: 30, tempIcon:"Temp-01", tmn: 29};
             data[28] = {day: "", time: "18시", t3h: 28, sky:"Rain", pop: 50, tempIcon:"Temp-04"};
             data[29] = {day: "", time: "21시", t3h: 24, sky:"RainWithLightning", pop: 60, tempIcon:"Temp-05"};
             data[30] = {day: "글피", time: "0시", t3h: 21, sky:"RainWithSnow", pop: 70, tempIcon:"Temp-06"};


### PR DESCRIPTION
* 처음에 차트에 표시된 최고, 최저가 데이터가 업데이트되면 최고, 최저를 표시해주는 시간이 변경되지 않아 이전 위치에 온도만 변경되어 표시되는 문제가 생김
* 최저, 최저 값을 모두 표시 & css로 show/hide 처리 -> 최고, 최저만 값을 가짐 & css는 항상 show 처리하도록 수정
* 하루의 전체 데이터가 표시되지 않는 경우 최고, 최저값을 계산할 수 없으므로 서버에서 받은 shortForecast의 tmx와 tmn 값을 그대로 표시하도록 수정
* currentForecast.time가 shortForecast의 time이 같은 경우에만 현재 온도를 업데이트 함