### PR TITLE
#169 앱 실행 시 사용자 가이드 페이지가 잠깐 보였다 사라지는 문제

### DIFF
--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -4,6 +4,11 @@ angular.module('starter.controllers', [])
                                      $cordovaGeolocation, $timeout, $interval, $http)
     {
         $scope.skipGuide = false;
+        if(typeof(Storage) !== "undefined") {
+            if (localStorage.getItem("skipGuide") !== null) {
+                $scope.skipGuide = localStorage.getItem("skipGuide");
+            }
+        }
         $scope.shortForecast = true;
 
         //String
@@ -822,12 +827,6 @@ angular.module('starter.controllers', [])
         };
 
         $ionicPlatform.ready(function() {
-            if(typeof(Storage) !== "undefined") {
-                if (localStorage.getItem("skipGuide") !== null) {
-                    $scope.skipGuide = localStorage.getItem("skipGuide");
-                }
-            }
-
             //It starts first times
             if (!$scope.skipGuide) {
                 loadGuideDate();


### PR DESCRIPTION
#169 앱 실행 시 사용자 가이드 페이지가 잠깐 보였다 사라지는 문제
* skipGuide의 초기 값에 의해 가이드 페이지가 보인 후에 $ionicPlatform.ready()에서 WebStorage에서 true를 가져와서 사라지게 됨
* $ionicPlatform.ready()에서 설정하는 시점이 느려서 발생하는 문제로 controller 시작 시에 설정하도록 시점 이동