### PR TITLE
Fixed #272 탭 추가 이후에 차트가 크기 맞지 않는 이슈.

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -102,37 +102,40 @@ angular.module('starter', [
             transclude: true,
             link: function (scope, iElement) {
                 var duration = 1000;
-                var margin = {top: 30, right: 0, bottom: 10, left: 0},
-                    width = iElement[0].getBoundingClientRect().width - margin.left - margin.right,
+                var margin = {top: 30, right: 0, bottom: 10, left: 0};
+                var width, height, x, y;
+                var svg, initLine, line;
+
+                // document가 rendering이 될 때 tabs가 있으면 ion-content에 has-tabs class가 추가됨
+                // has-tabs에 의해 ion-content의 영역이 tabs을 제외한 나머지 영역으로 설정되므로 그 후에 차트를 생성하도록 함
+                scope.$watch('$hasTabs', function(val) {
+                    width = iElement[0].getBoundingClientRect().width - margin.left - margin.right;
                     height = iElement[0].getBoundingClientRect().height - margin.top - margin.bottom;
+                    x = d3.scale.ordinal().rangeBands([width, 0]);
+                    y = d3.scale.linear().range([height, 0]);
 
-                var svg = d3.select(iElement[0]).append('svg')
-                    .attr('width', width + margin.left + margin.right)
-                    .attr('height', height + margin.top + margin.bottom)
-                    .append('g')
-                    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+                    svg = d3.select(iElement[0]).append('svg')
+                        .attr('width', width + margin.left + margin.right)
+                        .attr('height', height + margin.top + margin.bottom)
+                        .append('g')
+                        .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-                var x = d3.scale.ordinal()
-                    .rangeBands([width, 0]);
+                    initLine = d3.svg.line()
+                        .interpolate('linear')
+                        .x(function (d, i) {
+                            return x.rangeBand() * i + x.rangeBand() / 2;
+                        })
+                        .y(height);
 
-                var y = d3.scale.linear()
-                    .range([height, 0]);
-
-                var initLine = d3.svg.line()
-                    .interpolate('linear')
-                    .x(function (d, i) {
-                        return x.rangeBand() * i + x.rangeBand() / 2;
-                    })
-                    .y(height);
-
-                var line = d3.svg.line()
-                    .interpolate('linear')
-                    .x(function (d, i) {
-                        return x.rangeBand() * i + x.rangeBand() / 2;
-                    })
-                    .y(function (d) {
-                        return y(d.value.t3h);
-                    });
+                    line = d3.svg.line()
+                        .interpolate('linear')
+                        .x(function (d, i) {
+                            return x.rangeBand() * i + x.rangeBand() / 2;
+                        })
+                        .y(function (d) {
+                            return y(d.value.t3h);
+                        });
+                });
 
                 var chart = function () {
                     var data = scope.timeChart;


### PR DESCRIPTION
* document가 rendering이 될 때 tabs가 있으면 ion-content에 has-tabs class가 추가됨
* has-tabs에 의해 ion-content의 영역이 tabs을 제외한 나머지 영역으로 설정되므로 그 후에 차트를 생성하도록 함