### PR TITLE
중기예보에 오늘 정보가 없으면 도시검색에서 에러나는 문제. #380 Fixed #389

### DIFF
--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -201,7 +201,7 @@ angular.module('starter.controllers', [])
                 else {
                     $scope.address = "위치 찾는 중";
                 }
-            }, function (err) {
+            }, function () {
                 // 1: resolved, 2: rejected
                 if (deferred.promise.$$state.status === 1 || deferred.promise.$$state.status === 2) {
                     return;
@@ -232,11 +232,11 @@ angular.module('starter.controllers', [])
                                 loadWeatherData();
                                 deferred.notify();
                                 deferred.resolve();
-                            }, function (err) {
+                            }, function () {
                                 deferred.reject();
                             });
                         }
-                    }, function (err) {
+                    }, function () {
                         var str = "현재 위치에 대한 정보를 찾을 수 없습니다.";
                         showAlert("에러", str);
                         deferred.reject();
@@ -292,7 +292,7 @@ angular.module('starter.controllers', [])
                 title: title,
                 template: msg
             });
-            alertPopup.then(function(res) {
+            alertPopup.then(function() {
                 console.log("alertPopup close");
             });
         }
@@ -345,7 +345,7 @@ angular.module('starter.controllers', [])
             $ionicNavBarDelegate.title("위치,날씨정보 업데이트 중");
             isShowingBar = !isShowingBar;
             $ionicNavBarDelegate.showBar(isShowingBar);
-            updateWeatherData(true).finally(function (res) {
+            updateWeatherData(true).finally(function () {
                 $scope.address = WeatherUtil.getShortenAddress(cityData.address);
 
                 isShowingBar = !isShowingBar;
@@ -398,8 +398,8 @@ angular.module('starter.controllers', [])
             WeatherInfo.loadTowns().then(function () {
                 WeatherInfo.updateCities();
                 loadWeatherData();
-                checkForUpdates().finally(function (res) {
-                    updateWeatherData(false).finally(function (res) {
+                checkForUpdates().finally(function () {
+                    updateWeatherData(false).finally(function () {
                         $scope.address = WeatherUtil.getShortenAddress(cityData.address);
                     });
                 });
@@ -422,6 +422,20 @@ angular.module('starter.controllers', [])
             var todayData = city.dayTable.filter(function (data) {
                 return (data.week === "오늘");
             });
+
+            if (!city.currentWeather) {
+                city.currentWeather = {};
+            }
+            if (!city.currentWeather.skyIcon) {
+                city.currentWeather.skyIcon = 'Sun';
+            }
+            if (city.currentWeather.t1h === undefined) {
+                city.currentWeather.t1h = '-';
+            }
+
+            if (!todayData || todayData.length === 0) {
+                todayData.push({tmn:'-', tmx:'-'});
+            }
 
             var data = {
                 address: address,
@@ -488,7 +502,7 @@ angular.module('starter.controllers', [])
                             $location.path('/tab/forecast');
                         }
                         $scope.isLoading = false;
-                    }, function (err) {
+                    }, function () {
                         $scope.isLoading = false;
                     });
                 }, function () {


### PR DESCRIPTION
add week to dayInfo in parsePreShortTownWeather
When fail to find starting day of dayInfo in midData, insert dayInfo data in tmpDayTable
make dummay data for cityList

short에 최저/최고가 없는 경우, 일별예보에서 최고/최저 값이 잘 못 되는 경우 수정
  먼저 short에 tmx, tmn값을 dayInfo에 저장하고, short를 한번 더 돌아서 t3h가 최고/최저를 넘어서면 t3h로 변경
getAddressToGeolocation의 경우에도 daum, google 두개 api사용하게 수정