### PR TITLE
Fixed #390 도시가 여러 개일 때 처음 보여지는 도시만 데이터가 업데이트되고 나머지 도시는 업데이트 되지 않는 문제

### DIFF
--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -213,6 +213,7 @@ angular.module('starter.services', [])
                 WeatherUtil.getWeatherInfo(city.address, that.towns).then(function (weatherDatas) {
                     var city = WeatherUtil.convertWeatherData(weatherDatas);
                     that.updateCity(that.loadIndex, city);
+                }).finally(function() {
                     that.updateCities();
                 });
             }


### PR DESCRIPTION
Fixed #390 도시가 여러 개일 때 처음 보여지는 도시만 데이터가 업데이트되고 나머지 도시는 업데이트 되지 않는 문제
* "하늘시 구름동"인 경우에 WeatherUtil.getWeatherInfo가 reject로 처리되어 다음 도시의 정보를 업데이트하지 않음
* resolve, reject 관계없이 finally에서 다음 도시 정보를 업데이트하도록 수정