### PR TITLE
Fixed #399 0도 일 때 reddot 이미지가 보이지 않는 문제

### DIFF
--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -27,7 +27,7 @@
                                      style="width: 45%; height: 100%; display: table-cell; vertical-align: middle">
                                     <div class="row-no-padding" style="height: 10%"></div>
                                     <div class="row-no-padding big-temp-point" style="height: 30%"
-                                         ng-if="currentWeather.t1h">
+                                         ng-if="currentWeather.t1h!==undefined">
                                         <img src="img/reddot.png">
                                     </div>
                                     <div class="row-no-padding big-temp-sky-state" style="height: 60%"


### PR DESCRIPTION
Fixed #399 0도 일 때 reddot 이미지가 보이지 않는 문제
* currentWeather.t1h가 undefined일 때만 reddot 이미지를 표시하지 않도록 ng-if 조건문 변경