### PR TITLE
short forecast에서 중간에 데이터가 빠져서 차트가 제대로 그려지지 못하는 문제. #402

### DIFF
--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -1101,6 +1101,11 @@ angular.module('starter.services', [])
                     tempObject.wsd = undefined;
                     tempObject.skyIcon = "Sun";
                     tempObject.tempIcon = "Temp-01";
+
+                    //related to #402
+                    if (prevT3H) {
+                        tempObject.t3h = prevT3H;
+                    }
                 }
                 else {
                     tempObject = shortForecast;


### PR DESCRIPTION
short 정보가 invalid하면, 이전 t3h값으로 라인이 연결되게 만든다.