### PR TITLE
DB gather - 데이터 모니터링 기능 추가 #427

### DIFF
--- a/server/lib/collectTownForecast.js
+++ b/server/lib/collectTownForecast.js
@@ -127,9 +127,9 @@ function CollectData(options, callback){
     });
 
     self.DATA_URL = Object.freeze({
-        TOWN_CURRENT: 'http://newsky2.kma.go.kr/service/SecndSrtpdFrcstInfoService/ForecastGrib',
+        TOWN_CURRENT: 'http://newsky2.kma.go.kr/service/SecndSrtpdFrcstInfoService2/ForecastGrib',
         TOWN_SHORTEST: 'http://newsky2.kma.go.kr/service/SecndSrtpdFrcstInfoService2/ForecastTimeData',
-        TOWN_SHORT: 'http://newsky2.kma.go.kr/service/SecndSrtpdFrcstInfoService/ForecastSpaceData',
+        TOWN_SHORT: 'http://newsky2.kma.go.kr/service/SecndSrtpdFrcstInfoService2/ForecastSpaceData',
         MID_FORECAST: 'http://newsky2.kma.go.kr/service/MiddleFrcstInfoService/getMiddleForecast',
         MID_LAND: 'http://newsky2.kma.go.kr/service/MiddleFrcstInfoService/getMiddleLandWeather',
         MID_TEMP: 'http://newsky2.kma.go.kr/service/MiddleFrcstInfoService/getMiddleTemperature',

--- a/server/lib/collectTownForecast.js
+++ b/server/lib/collectTownForecast.js
@@ -413,8 +413,9 @@ CollectData.prototype.organizeShortData = function(index, listData){
         var result = {};
         var insertItem;
         var template = {
-            date: '',
-            time: '',
+            pubDate: '', /*baseDate+baseTime*/
+            date: '',   /* fcstDate */
+            time: '',   /* fcstTime */
             mx: -1,
             my: -1,
             pop: -1,    /* 강수 확률 : 1% 단위, invalid : -1 */
@@ -464,6 +465,7 @@ CollectData.prototype.organizeShortData = function(index, listData){
                     result = template;
                 }
 
+                result.pubDate = item.baseDate[0] + item.baseTime[0];
                 result.date = item.fcstDate[0];
                 result.time = item.fcstTime[0];
                 result.mx = parseInt(item.nx[0]);
@@ -510,7 +512,7 @@ CollectData.prototype.organizeShortestData = function(index, listData) {
     var self = this;
     var listResult = [];
     var template = {
-        lastUpdateTime: '', /*baseDate+baseTime*/
+        pubDate: '', /*baseDate+baseTime*/
         date: '',
         time: '',
         mx: -1,
@@ -544,14 +546,14 @@ CollectData.prototype.organizeShortestData = function(index, listData) {
             if((item.fcstDate === undefined)
                 && (item.fcstTime === undefined)
                 && (item.fcstValue === undefined)){
-                log.error('organizeShortestData : There is not shortest forecast date');
+                log.error(new Error('There is not shortest forecast date'));
                 continue;
             }
 
             if((item.fcstDate[0].length > 1) && (item.fcstTime[0].length > 1)){
                 var result = getListResult(item.fcstDate[0], item.fcstTime[0]);
 
-                result.lastUpdateTime = item.baseDate[0] + item.baseTime[0];
+                result.pubDate = item.baseDate[0] + item.baseTime[0];
                 result.date = item.fcstDate[0];
                 result.time = item.fcstTime[0];
                 result.mx = parseInt(item.nx[0]);
@@ -562,7 +564,7 @@ CollectData.prototype.organizeShortestData = function(index, listData) {
                 else if(item.category[0] === 'SKY') {result.sky = parseInt(item.fcstValue[0]);}
                 else if(item.category[0] === 'LGT') {result.lgt = parseInt(item.fcstValue[0]);}
                 else{
-                    log.error('organizeShortestData : Known property', item.category[0]);
+                    log.error(new Error('Known property '+item.category[0]));
                 }
             }
         }
@@ -575,7 +577,7 @@ CollectData.prototype.organizeShortestData = function(index, listData) {
         self.emit('recvData', index, listResult);
     }
     catch(e){
-        log.error('Error!! organizeShortestData : failed data organized');
+        log.error(e);
     }
 };
 
@@ -592,6 +594,7 @@ CollectData.prototype.organizeCurrentData = function(index, listData) {
         var result = {};
         var insertItem;
         var template = {
+            pubDate: '', /*baseDate+baseTime*/
             date: '',
             time: '',
             mx: -1,
@@ -641,6 +644,7 @@ CollectData.prototype.organizeCurrentData = function(index, listData) {
                     result = template;
                 }
 
+                result.pubDate = item.baseDate[0] + item.baseTime[0];
                 result.date = item.baseDate[0];
                 result.time = item.baseTime[0];
                 result.mx = parseInt(item.nx[0]);
@@ -691,6 +695,7 @@ CollectData.prototype.organizeForecastData = function(index, listData, options){
     try{
         var result = {};
         var template = {
+            pubDate: options.date + options.time,
             date: options.date,
             time: options.time,
             pointNumber: options.code,
@@ -736,6 +741,7 @@ CollectData.prototype.organizeLandData = function(index, listData, options){
     try{
         var result = {};
         var template = {
+            pubDate: options.date + options.time,
             date: options.date,
             time: options.time,
             regId: 0, /* 예보 구역 코드 */
@@ -805,6 +811,7 @@ CollectData.prototype.organizeTempData = function(index, listData, options){
     try{
         var result = {};
         var template = {
+            pubDate: options.date + options.time,
             date: options.date,
             time: options.time,
             regId: 0, /* 예보 구역 코드 */
@@ -880,6 +887,7 @@ CollectData.prototype.organizeSeaData = function(index, listData, options){
     try{
         var result = {};
         var template = {
+            pubDate: options.date + options.time,
             date: options.date,
             time: options.time,
             regId: 0, /* 예보 구역 코드 */

--- a/server/models/modelCurrent.js
+++ b/server/models/modelCurrent.js
@@ -8,6 +8,7 @@ var currentSchema = new mongoose.Schema({
         mx : Number,
         my : Number
     },
+    pubDate : String, //YYYYMMDDHHMM last baseDate+baseTime
     currentData : [{
         date: String, // get시 sort용
         time: String,

--- a/server/models/modelMidForecast.js
+++ b/server/models/modelMidForecast.js
@@ -5,6 +5,7 @@ var mongoose = require('mongoose');
 
 var midForecastSchema = mongoose.Schema({
     regId : String,
+    pubDate: String, //last data.date+data.time
     data : [{
         date: String,
         time: String,

--- a/server/models/modelMidLand.js
+++ b/server/models/modelMidLand.js
@@ -5,6 +5,7 @@ var mongoose = require('mongoose');
 
 var midLandSchema = mongoose.Schema({
     regId : String,
+    pubDate: String, //last data.date+data.time
     data : [{
         date: String,
         time: String,

--- a/server/models/modelMidSea.js
+++ b/server/models/modelMidSea.js
@@ -5,6 +5,7 @@ var mongoose = require('mongoose');
 
 var midSeaSchema = mongoose.Schema({
     regId: String,
+    pubDate: String, //last data.date+data.time
     data: [{
         date: String,
         time: String,

--- a/server/models/modelMidTemp.js
+++ b/server/models/modelMidTemp.js
@@ -7,6 +7,7 @@ var mongoose = require('mongoose');
 
 var midTempSchema = mongoose.Schema({
     regId : String,
+    pubDate: String, //last data.date+data.time
     data :[{
         date: String,
         time: String,

--- a/server/models/modelShort.js
+++ b/server/models/modelShort.js
@@ -9,9 +9,10 @@ var shortSchema = new mongoose.Schema({
         mx : Number,
         my : Number
     },
+    pubDate : String, //YYYYMMDDHHMM last baseDate+baseTime
     shortData : [{
-        date : String,
-        time : String,
+        date : String, //fcstDate
+        time : String, //fcstTime
         mx : {type : Number, default : -1},
         my : {type : Number, default : -1},
         pop: {type : Number, default : -1},

--- a/server/models/modelShortest.js
+++ b/server/models/modelShortest.js
@@ -9,7 +9,7 @@ var shortestSchema = new mongoose.Schema({
         mx:Number,
         my:Number
     },
-    lastUpdateTime : String, //YYYYMMDDHHMM baseDate+baseTime
+    pubDate : String, //YYYYMMDDHHMM baseDate+baseTime
     shortestData:[{
         date: String,   //fcstDate
         time: String,   //fcstTime

--- a/server/test/testControllerManager.js
+++ b/server/test/testControllerManager.js
@@ -49,7 +49,7 @@ describe('unit test - controller manager', function() {
 
     //it('test mid forecast', function (done) {
     //    this.timeout(60 * 1000 * 60 * 100); //100mins
-    //    manager.getMidForecast(9, config.keyString.test_cert, function (err, results) {
+    //    manager.getMidForecast(9, config.keyString.test_normal, function (err, results) {
     //        if (err) {
     //            log.error(err);
     //        }
@@ -59,7 +59,7 @@ describe('unit test - controller manager', function() {
 
     //it('test mid land', function (done) {
     //    this.timeout(60 * 1000 * 60 * 100); //100mins
-    //    manager.getMidLand(9, config.keyString.test_cert, function (err, results) {
+    //    manager.getMidLand(9, config.keyString.test_normal, function (err, results) {
     //        if (err) {
     //            log.error(err);
     //        }
@@ -69,7 +69,7 @@ describe('unit test - controller manager', function() {
 
     //it('test mid temp', function (done) {
     //    this.timeout(60 * 1000 * 60 * 100); //100mins
-    //    manager.getMidTemp(9, config.keyString.test_cert, function (err, results) {
+    //    manager.getMidTemp(9, config.keyString.test_normal, function (err, results) {
     //        if (err) {
     //            log.error(err);
     //        }
@@ -79,7 +79,7 @@ describe('unit test - controller manager', function() {
 
     //it('test mid sea', function (done) {
     //    this.timeout(60 * 1000 * 60 * 100); //100mins
-    //    manager.getMidSea(9, config.keyString.test_cert, function (err, results) {
+    //    manager.getMidSea(9, config.keyString.test_normal, function (err, results) {
     //        if (err) {
     //            log.error(err);
     //        }

--- a/server/test/testControllerManager.js
+++ b/server/test/testControllerManager.js
@@ -15,24 +15,80 @@ describe('unit test - controller manager', function() {
     //var mongoose = require('mongoose');
     //mongoose.connect(config.db.path, function(err) {
     //    if (err) {
-    //        console.error('Could not connect to MongoDB!');
+    //        log.error('Could not connect to MongoDB!');
     //        console.log(err);
     //        done();
     //    }
     //});
     //
     //mongoose.connection.on('error', function(err) {
-    //    console.error('MongoDB connection error: ' + err);
+    //    log.error('MongoDB connection error: ' + err);
     //    done();
     //});
-    //
-    //
-    //it('test appendData', function(done) {
-    //    this.timeout(60*1000);
+
+    //it('test shortest appendData', function(done) {
+    //    this.timeout(60*1000*60*100); //100mins
     //    manager.getTownShortestData(9, config.keyString.test_cert, function (err, results) {
     //        done();
     //    });
     //});
+
+    //it('test current appendData', function(done) {
+    //    this.timeout(60*1000*60*100); //100mins
+    //    manager.getTownCurrentData(9, config.keyString.test_cert, function (err, results) {
+    //        done();
+    //    });
+    //});
+
+    //it('test short appendData', function (done) {
+    //    this.timeout(60*1000*60*100); //100mins
+    //    manager.getTownShortData(9, config.keyString.test_cert, function (err, results) {
+    //        done();
+    //    });
+    //});
+
+    //it('test mid forecast', function (done) {
+    //    this.timeout(60 * 1000 * 60 * 100); //100mins
+    //    manager.getMidForecast(9, config.keyString.test_cert, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
+
+    //it('test mid land', function (done) {
+    //    this.timeout(60 * 1000 * 60 * 100); //100mins
+    //    manager.getMidLand(9, config.keyString.test_cert, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
+
+    //it('test mid temp', function (done) {
+    //    this.timeout(60 * 1000 * 60 * 100); //100mins
+    //    manager.getMidTemp(9, config.keyString.test_cert, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
+
+    //it('test mid sea', function (done) {
+    //    this.timeout(60 * 1000 * 60 * 100); //100mins
+    //    manager.getMidSea(9, config.keyString.test_cert, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
+    it('test stop manager', function () {
+        manager.stopManager();
+    });
 });
 
 

--- a/server/test/testControllerManager.js
+++ b/server/test/testControllerManager.js
@@ -29,6 +29,9 @@ describe('unit test - controller manager', function() {
     //it('test shortest appendData', function(done) {
     //    this.timeout(60*1000*60*100); //100mins
     //    manager.getTownShortestData(9, config.keyString.test_cert, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
     //        done();
     //    });
     //});
@@ -36,6 +39,9 @@ describe('unit test - controller manager', function() {
     //it('test current appendData', function(done) {
     //    this.timeout(60*1000*60*100); //100mins
     //    manager.getTownCurrentData(9, config.keyString.test_cert, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
     //        done();
     //    });
     //});
@@ -43,6 +49,9 @@ describe('unit test - controller manager', function() {
     //it('test short appendData', function (done) {
     //    this.timeout(60*1000*60*100); //100mins
     //    manager.getTownShortData(9, config.keyString.test_cert, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
     //        done();
     //    });
     //});
@@ -86,6 +95,7 @@ describe('unit test - controller manager', function() {
     //        done();
     //    });
     //});
+
     it('test stop manager', function () {
         manager.stopManager();
     });

--- a/server/utils/initTownDataToMongo.js
+++ b/server/utils/initTownDataToMongo.js
@@ -17,6 +17,8 @@ mongoose.connect(config.db.path, config.db.options, function(err){
 });
 
 var fs = require('fs');
+console.log('load '+targetName);
+
 var lineList = fs.readFileSync(targetName).toString().split('\n');
 // header remove
 lineList.shift();


### PR DESCRIPTION
_recursiveRequestData를 사용하여, current, shortest, short, mid_forecast, mid_land, mid_temp, mid_sea 모두 실패한 경우에 대하여 재시도 하게 수정.
current, short, shortest는 30번까지 재시도, mid_XXXX는 10번까지 재시도함.
ram mode 의 경우 기존 방식으로 retrycount 3으로 시도함
CollectData 에서 기본 retrycount와 timeout은 0으로 설정

error 발생시에 error object를 callback으로 전달하여 최종에서 error stack과 함께 출력하도록 조정
save 관한 callback 위치 잘 못된것 수정

warnning 수정