### PR TITLE
short data가 fcstDate, fcstTime이 중복되어서 저장되거나, 썪여서 저장되는 문제. #463

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -79,15 +79,16 @@ global.landString = ['wf3Am', 'wf3Pm', 'wf4Am', 'wf4Pm', 'wf5Am', 'wf5Pm',
 global.manager = new controllerManager();
 global.townRss = new controllerShortRss();
 
-if (config.mode === 'gather' || config.mode === 'local') {
-    manager.startManager();
-    townRss.StartShortRss();
-}
 
 var keyBox = require('./config/config').keyString;
 
-var midRssKmaRequester = new (require('./lib/midRssKmaRequester'))();
-midRssKmaRequester.start();
+if (config.mode === 'gather' || config.mode === 'local') {
+    manager.startManager();
+    townRss.StartShortRss();
+
+    var midRssKmaRequester = new (require('./lib/midRssKmaRequester'))();
+    midRssKmaRequester.start();
+}
 
 var taskKmaIndexService = new (require('./lib/lifeIndexKmaRequester'))();
 taskKmaIndexService.setServiceKey(keyBox.cert_key);

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -40,6 +40,7 @@ function Manager(){
         MID_SEA: (1000*60*60*12)
     };
 
+    self.saveOnlyLastOne = true;
     self.MAX_SHORT_COUNT = 60;
     self.MAX_CURRENT_COUNT = 60;
     self.MAX_SHORTEST_COUNT = 240; //24 hours * 10 days
@@ -900,63 +901,68 @@ Manager.prototype.saveShort = function(newData, callback){
 
             list.forEach(function(dbShortList){
                 //log.info('S> coord :', dbShortList.mCoord.mx, dbShortList.mCoord.my);
-                newData.forEach(function(newItem){
-                    var isNew = 1;
-                    //log.info('S> newItem : ', newItem);
-                    //log.info('S> dbshortlist count : ', dbShortList.shortData.length);
-                    //for(var i in dbShortList.shortData){
-                    for(var i=0 ; i < dbShortList.shortData.length ; i++){
-                        //log.info(i,'>', dbShortList.shortData[i].date, '|', dbShortList.shortData[i].time);
-                        var comparedDate = self.compareDate(
-                            {date:dbShortList.shortData[i].date, time:dbShortList.shortData[i].time},
-                            {date:newItem.date, time:newItem.time}
-                        );
-                        if(comparedDate === 0){
-                            //log.info('S> over write :', newItem);
-                            //dbShortList.shortData[i] = newItem;
-                            isNew = 0;
-                            dbShortList.shortData[i].pop = newItem.pop;
-                            dbShortList.shortData[i].pty = newItem.pty;
-                            dbShortList.shortData[i].r06 = newItem.r06;
-                            dbShortList.shortData[i].reh = newItem.reh;
-                            dbShortList.shortData[i].s06 = newItem.s06;
-                            dbShortList.shortData[i].sky = newItem.sky;
-                            dbShortList.shortData[i].t3h = newItem.t3h;
-                            dbShortList.shortData[i].tmn = newItem.tmn;
-                            dbShortList.shortData[i].tmx = newItem.tmx;
-                            dbShortList.shortData[i].uuu = newItem.uuu;
-                            dbShortList.shortData[i].vvv = newItem.vvv;
-                            dbShortList.shortData[i].wav = newItem.wav;
-                            dbShortList.shortData[i].vec = newItem.vec;
-                            dbShortList.shortData[i].wsd = newItem.wsd;
-                            break;
+                if (self.saveOnlyLastOne) {
+                    dbShortList.shortData = newData;
+                }
+                else {
+                    newData.forEach(function(newItem){
+                        var isNew = 1;
+                        //log.info('S> newItem : ', newItem);
+                        //log.info('S> dbshortlist count : ', dbShortList.shortData.length);
+                        //for(var i in dbShortList.shortData){
+                        for(var i=0 ; i < dbShortList.shortData.length ; i++){
+                            //log.info(i,'>', dbShortList.shortData[i].date, '|', dbShortList.shortData[i].time);
+                            var comparedDate = self.compareDate(
+                                {date:dbShortList.shortData[i].date, time:dbShortList.shortData[i].time},
+                                {date:newItem.date, time:newItem.time}
+                            );
+                            if(comparedDate === 0){
+                                //log.info('S> over write :', newItem);
+                                //dbShortList.shortData[i] = newItem;
+                                isNew = 0;
+                                dbShortList.shortData[i].pop = newItem.pop;
+                                dbShortList.shortData[i].pty = newItem.pty;
+                                dbShortList.shortData[i].r06 = newItem.r06;
+                                dbShortList.shortData[i].reh = newItem.reh;
+                                dbShortList.shortData[i].s06 = newItem.s06;
+                                dbShortList.shortData[i].sky = newItem.sky;
+                                dbShortList.shortData[i].t3h = newItem.t3h;
+                                dbShortList.shortData[i].tmn = newItem.tmn;
+                                dbShortList.shortData[i].tmx = newItem.tmx;
+                                dbShortList.shortData[i].uuu = newItem.uuu;
+                                dbShortList.shortData[i].vvv = newItem.vvv;
+                                dbShortList.shortData[i].wav = newItem.wav;
+                                dbShortList.shortData[i].vec = newItem.vec;
+                                dbShortList.shortData[i].wsd = newItem.wsd;
+                                break;
+                            }
                         }
-                    }
 
-                    if(isNew){
-                        //log.info('push data :', newItem);
-                        dbShortList.shortData.push(newItem);
-                    }
-                });
+                        if(isNew){
+                            //log.info('push data :', newItem);
+                            dbShortList.shortData.push(newItem);
+                        }
+                    });
 
-                dbShortList.shortData.sort(function(a, b){
-                    if(a.date > b.date){
-                        return 1;
-                    }
-                    if(a.date < b.date){
-                        return -1;
-                    }
-                    if(a.date === b.date && a.time > b.time){
-                        return 1;
-                    }
-                    if(a.date === b.date && a.time < b.time){
-                        return -1;
-                    }
-                    return 0;
-                });
+                    dbShortList.shortData.sort(function(a, b){
+                        if(a.date > b.date){
+                            return 1;
+                        }
+                        if(a.date < b.date){
+                            return -1;
+                        }
+                        if(a.date === b.date && a.time > b.time){
+                            return 1;
+                        }
+                        if(a.date === b.date && a.time < b.time){
+                            return -1;
+                        }
+                        return 0;
+                    });
 
-                if(dbShortList.shortData.length > self.MAX_SHORT_COUNT){
-                    dbShortList.shortData = dbShortList.shortData.slice((dbShortList.shortData.length - self.MAX_SHORT_COUNT));
+                    if(dbShortList.shortData.length > self.MAX_SHORT_COUNT){
+                        dbShortList.shortData = dbShortList.shortData.slice((dbShortList.shortData.length - self.MAX_SHORT_COUNT));
+                    }
                 }
 
                 dbShortList.pubDate = pubDate;
@@ -1026,58 +1032,63 @@ Manager.prototype.saveCurrent = function(newData, callback){
 
             list.forEach(function(dbCurrentList){
                 //log.info('C> coord :', dbCurrentList.mCoord.mx, dbCurrentList.mCoord.my);
-                newData.forEach(function(newItem){
-                    var isNew = 1;
-                    //log.info('C> newItem : ', newItem);
-                    //log.info('C> dbCurrentList count : ', dbCurrentList.currentData.length);
-                    //for(var i in dbCurrentList.currentData){
-                    for(var i=0 ; i < dbCurrentList.currentData.length ; i++){
-                        //log.info(i,'>', dbCurrentList.currentData[i].date, '|', dbCurrentList.currentData[i].time);
-                        var comparedDate = self.compareDate(
-                            {date:dbCurrentList.currentData[i].date, time:dbCurrentList.currentData[i].time},
-                            {date:newItem.date, time:newItem.time}
-                        );
-                        if(comparedDate === 0){
-                            //log.info('C> over write :', newItem);
-                            dbCurrentList.currentData[i].t1h = newItem.t1h;
-                            dbCurrentList.currentData[i].rn1 = newItem.rn1;
-                            dbCurrentList.currentData[i].sky = newItem.sky;
-                            dbCurrentList.currentData[i].uuu = newItem.uuu;
-                            dbCurrentList.currentData[i].vvv = newItem.vvv;
-                            dbCurrentList.currentData[i].reh = newItem.reh;
-                            dbCurrentList.currentData[i].pty = newItem.pty;
-                            dbCurrentList.currentData[i].lgt = newItem.lgt;
-                            dbCurrentList.currentData[i].vec = newItem.vec;
-                            dbCurrentList.currentData[i].wsd = newItem.wsd;
-                            isNew = 0;
-                            break;
+                if (self.saveOnlyLastOne) {
+                    dbCurrentList.currentData = newData;
+                }
+                else {
+                    newData.forEach(function(newItem){
+                        var isNew = 1;
+                        //log.info('C> newItem : ', newItem);
+                        //log.info('C> dbCurrentList count : ', dbCurrentList.currentData.length);
+                        //for(var i in dbCurrentList.currentData){
+                        for(var i=0 ; i < dbCurrentList.currentData.length ; i++){
+                            //log.info(i,'>', dbCurrentList.currentData[i].date, '|', dbCurrentList.currentData[i].time);
+                            var comparedDate = self.compareDate(
+                                {date:dbCurrentList.currentData[i].date, time:dbCurrentList.currentData[i].time},
+                                {date:newItem.date, time:newItem.time}
+                            );
+                            if(comparedDate === 0){
+                                //log.info('C> over write :', newItem);
+                                dbCurrentList.currentData[i].t1h = newItem.t1h;
+                                dbCurrentList.currentData[i].rn1 = newItem.rn1;
+                                dbCurrentList.currentData[i].sky = newItem.sky;
+                                dbCurrentList.currentData[i].uuu = newItem.uuu;
+                                dbCurrentList.currentData[i].vvv = newItem.vvv;
+                                dbCurrentList.currentData[i].reh = newItem.reh;
+                                dbCurrentList.currentData[i].pty = newItem.pty;
+                                dbCurrentList.currentData[i].lgt = newItem.lgt;
+                                dbCurrentList.currentData[i].vec = newItem.vec;
+                                dbCurrentList.currentData[i].wsd = newItem.wsd;
+                                isNew = 0;
+                                break;
+                            }
                         }
-                    }
 
-                    if(isNew){
-                        //log.info('C> push data :', newItem);
-                        dbCurrentList.currentData.push(newItem);
-                    }
-                });
+                        if(isNew){
+                            //log.info('C> push data :', newItem);
+                            dbCurrentList.currentData.push(newItem);
+                        }
+                    });
 
-                dbCurrentList.currentData.sort(function(a, b){
-                    if(a.date > b.date){
-                        return 1;
-                    }
-                    if(a.date < b.date){
-                        return -1;
-                    }
-                    if(a.date === b.date && a.time > b.time){
-                        return 1;
-                    }
-                    if(a.date === b.date && a.time < b.time){
-                        return -1;
-                    }
-                    return 0;
-                });
+                    dbCurrentList.currentData.sort(function(a, b){
+                        if(a.date > b.date){
+                            return 1;
+                        }
+                        if(a.date < b.date){
+                            return -1;
+                        }
+                        if(a.date === b.date && a.time > b.time){
+                            return 1;
+                        }
+                        if(a.date === b.date && a.time < b.time){
+                            return -1;
+                        }
+                        return 0;
+                    });
 
-                if(dbCurrentList.currentData.length > self.MAX_CURRENT_COUNT){
-                    dbCurrentList.currentData = dbCurrentList.currentData.slice((dbCurrentList.currentData.length - self.MAX_CURRENT_COUNT));
+                    if(dbCurrentList.currentData.length > self.MAX_CURRENT_COUNT){
+                        dbCurrentList.currentData = dbCurrentList.currentData.slice((dbCurrentList.currentData.length - self.MAX_CURRENT_COUNT));
+                    }
                 }
 
                 dbCurrentList.pubDate = pubDate;
@@ -1152,52 +1163,57 @@ Manager.prototype.saveShortest = function(newData, callback){
 
             list.forEach(function(dbShortestList){
                 //log.info('ST> coord :', dbShortestList.mCoord.mx, dbShortestList.mCoord.my);
-                newData.forEach(function(newItem){
-                    var isNew = 1;
-                    //log.info('ST> newItem : ', newItem);
-                    //log.info('ST> dbShortestList count : ', dbShortestList.shortestData.length);
-                    //for(var i in dbShortestList.shortestData){
-                    for(var i=0 ; i < dbShortestList.shortestData.length ; i++){
-                        //log.info(i,'>', dbShortestList.shortestData[i].date, '|', dbShortestList.shortestData[i].time);
-                        var comparedDate = self.compareDate(
-                            {date:dbShortestList.shortestData[i].date, time:dbShortestList.shortestData[i].time},
-                            {date:newItem.date, time:newItem.time}
-                        );
-                        if(comparedDate === 0){
-                            //log.info('ST> over write :', newItem);
-                            dbShortestList.shortestData[i].pty = newItem.pty;
-                            dbShortestList.shortestData[i].rn1 = newItem.rn1;
-                            dbShortestList.shortestData[i].sky = newItem.sky;
-                            dbShortestList.shortestData[i].lgt = newItem.lgt;
-                            isNew = 0;
-                            break;
+                if (self.saveOnlyLastOne) {
+                    dbShortestList.shortestData = newData;
+                }
+                else {
+                    newData.forEach(function(newItem){
+                        var isNew = 1;
+                        //log.info('ST> newItem : ', newItem);
+                        //log.info('ST> dbShortestList count : ', dbShortestList.shortestData.length);
+                        //for(var i in dbShortestList.shortestData){
+                        for(var i=0 ; i < dbShortestList.shortestData.length ; i++){
+                            //log.info(i,'>', dbShortestList.shortestData[i].date, '|', dbShortestList.shortestData[i].time);
+                            var comparedDate = self.compareDate(
+                                {date:dbShortestList.shortestData[i].date, time:dbShortestList.shortestData[i].time},
+                                {date:newItem.date, time:newItem.time}
+                            );
+                            if(comparedDate === 0){
+                                //log.info('ST> over write :', newItem);
+                                dbShortestList.shortestData[i].pty = newItem.pty;
+                                dbShortestList.shortestData[i].rn1 = newItem.rn1;
+                                dbShortestList.shortestData[i].sky = newItem.sky;
+                                dbShortestList.shortestData[i].lgt = newItem.lgt;
+                                isNew = 0;
+                                break;
+                            }
                         }
-                    }
 
-                    if(isNew){
-                        //log.info('ST> push data :', newItem);
-                        dbShortestList.shortestData.push(newItem);
-                    }
-                });
+                        if(isNew){
+                            //log.info('ST> push data :', newItem);
+                            dbShortestList.shortestData.push(newItem);
+                        }
+                    });
 
-                dbShortestList.shortestData.sort(function(a, b){
-                    if(a.date > b.date){
-                        return 1;
-                    }
-                    if(a.date < b.date){
-                        return -1;
-                    }
-                    if(a.date === b.date && a.time > b.time){
-                        return 1;
-                    }
-                    if(a.date === b.date && a.time < b.time){
-                        return -1;
-                    }
-                    return 0;
-                });
+                    dbShortestList.shortestData.sort(function(a, b){
+                        if(a.date > b.date){
+                            return 1;
+                        }
+                        if(a.date < b.date){
+                            return -1;
+                        }
+                        if(a.date === b.date && a.time > b.time){
+                            return 1;
+                        }
+                        if(a.date === b.date && a.time < b.time){
+                            return -1;
+                        }
+                        return 0;
+                    });
 
-                if(dbShortestList.shortestData.length > self.MAX_SHORTEST_COUNT){
-                    dbShortestList.shortestData = dbShortestList.shortestData.slice((dbShortestList.shortestData.length - self.MAX_SHORTEST_COUNT));
+                    if(dbShortestList.shortestData.length > self.MAX_SHORTEST_COUNT){
+                        dbShortestList.shortestData = dbShortestList.shortestData.slice((dbShortestList.shortestData.length - self.MAX_SHORTEST_COUNT));
+                    }
                 }
 
                 dbShortestList.pubDate = pubDate;
@@ -1321,47 +1337,53 @@ Manager.prototype.saveMid = function(db, newData, callback){
             }
 
             list.forEach(function(dbMidList){
-                var isNew = 1;
-                for(var i=0 ; i < dbMidList.data.length ; i++){
-                    var comparedDate = self.compareDate(
-                        {date:dbMidList.data[i].date, time:dbMidList.data[i].time},
-                        {date:newData.date, time:newData.time}
-                    );
+                if (self.saveOnlyLastOne) {
+                    dbMidList.data = [newData];
+                }
+                else {
+                    var isNew = 1;
+                    for(var i=0 ; i < dbMidList.data.length ; i++){
+                        var comparedDate = self.compareDate(
+                            {date:dbMidList.data[i].date, time:dbMidList.data[i].time},
+                            {date:newData.date, time:newData.time}
+                        );
 
-                    // If there is the same date in the DB, it would be replaced by new data.
-                    if(comparedDate === 0){
-                        // over write
-                        dbMidList.data[i] = self.dupMid(newData, dbMidList.data[i]);
-                        //log.info('overwrite :', newData);
-                        isNew = 0;
-                        break;
+                        // If there is the same date in the DB, it would be replaced by new data.
+                        if(comparedDate === 0){
+                            // over write
+                            dbMidList.data[i] = self.dupMid(newData, dbMidList.data[i]);
+                            //log.info('overwrite :', newData);
+                            isNew = 0;
+                            break;
+                        }
+                    }
+
+                    if(isNew){
+                        //log.info('M> push data :', newItem);
+                        dbMidList.data.push(newData);
+                    }
+
+                    dbMidList.data.sort(function(a, b){
+                        if(a.date > b.date){
+                            return 1;
+                        }
+                        if(a.date < b.date){
+                            return -1;
+                        }
+                        if(a.date === b.date && a.time > b.time){
+                            return 1;
+                        }
+                        if(a.date === b.date && a.time < b.time){
+                            return -1;
+                        }
+                        return 0;
+                    });
+
+                    if(dbMidList.data.length > self.MAX_MID_COUNT){
+                        dbMidList.data = dbMidList.data.slice((dbMidList.data.length - self.MAX_MID_COUNT));
                     }
                 }
 
-                if(isNew){
-                    //log.info('M> push data :', newItem);
-                    dbMidList.data.push(newData);
-                }
-
-                dbMidList.data.sort(function(a, b){
-                    if(a.date > b.date){
-                        return 1;
-                    }
-                    if(a.date < b.date){
-                        return -1;
-                    }
-                    if(a.date === b.date && a.time > b.time){
-                        return 1;
-                    }
-                    if(a.date === b.date && a.time < b.time){
-                        return -1;
-                    }
-                    return 0;
-                });
-
-                if(dbMidList.data.length > self.MAX_MID_COUNT){
-                    dbMidList.data = dbMidList.data.slice((dbMidList.data.length - self.MAX_MID_COUNT));
-                }
                 dbMidList.pubDate = pubDate;
                 dbMidList.save(function(err){
                     if(err){
@@ -2340,8 +2362,17 @@ Manager.prototype.startTownData = function(){
 
     self.getMidForecast(9, key);
     self.getMidSea(9, key);
-*/
-     //get shortest forecast once every hours.
+ */
+
+    self.getMidTemp(9, normal_key);
+    self.getMidLand(9, normal_key);
+    self.getTownCurrentData(9, server_key);
+    self.getTownShortData(9, server_key);
+    self.getTownShortestData(9, server_key);
+    self.getMidForecast(9, normal_key);
+    self.getMidSea(9, normal_key);
+
+    //get shortest forecast once every hours.
     self.loopTownShortestID = setInterval(function(){
         self.getTownShortestData(9, server_key);
     }, self.TIME_PERIOD.TOWN_SHORTEST);
@@ -2352,7 +2383,7 @@ Manager.prototype.startTownData = function(){
             function(callback){
                 self.getTownCurrentData(9, server_key, callback);
             },
-            function(callback){
+            function(data, callback){
                 if(timeToGetShort >= 2){
                     self.getTownShortData(9, server_key, callback);
                 }

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,7 @@
     "express": "~4.13.0",
     "jade": "~1.11.0",
     "jwt-simple": "^0.3.0",
-    "mongoose": "^4.1.8",
+    "mongoose": "^4.3.4",
     "morgan": "~1.6.1",
     "request": "^2.60.0",
     "serve-favicon": "~2.3.0",

--- a/server/routes/routeTownForecast.js
+++ b/server/routes/routeTownForecast.js
@@ -353,6 +353,12 @@ var getCoord = function(region, city, town, cb){
         });
     }catch(e){
         log.error(meta);
+        if (cb) {
+            cb(e);
+        }
+        else {
+            log.error(e);
+        }
     }
 
     return {}
@@ -454,6 +460,12 @@ var getTownDataFromDB = function(db, indicator, cb){
         });
     }catch(e){
         log.error(meta);
+        if (cb) {
+            cb(e);
+        }
+        else {
+            log.error(e);
+        }
     }
 
     return [];
@@ -526,6 +538,12 @@ var getMidDataFromDB = function(db, indicator, cb){
         });
     }catch(e){
         log.error(meta);
+        if (cb) {
+            cb(e);
+        }
+        else {
+            log.error(e);
+        }
     }
 
     return [];
@@ -567,6 +585,11 @@ var mergeShortWithCurrent = function(shortList, currentList, cb){
                             tmp = currentList[index + 1];
                         }else{
                             tmp = currentList[index - 1];
+                        }
+
+                        if (tmp === undefined || !tmp.hasOwnProperty('sky')) {
+                            log.warn(new Error('current is undefined or empty object'));
+                            return;
                         }
 
                         //log.info(tmp);
@@ -617,6 +640,12 @@ var mergeShortWithCurrent = function(shortList, currentList, cb){
     }
     catch(e){
         log.error(meta);
+        if (cb) {
+            cb(e)
+        }
+        else {
+            log.error(e);
+        }
         return [];
     }
 
@@ -701,6 +730,12 @@ var mergeShortWithRSS = function(shortList, rssList, cb){
     }
     catch(e) {
         log.error(meta);
+        if (cb) {
+            cb(e);
+        }
+        else {
+            log.error(e);
+        }
         return [];
     }
 
@@ -797,6 +832,12 @@ var mergeLandWithTemp = function(landList, tempList, cb){
     } catch(e){
         log.error('> something wrong');
         log.error(meta);
+        if (cb) {
+            cb(e);
+        }
+        else {
+            log.error(e);
+        }
         return [];
     }
 
@@ -823,6 +864,7 @@ var getShort = function(req, res, next){
             if (err) {
                 log.error('> getShort : failed to get data from DB');
                 log.error(meta);
+                log.error(err);
                 return;
             }
 
@@ -1042,6 +1084,10 @@ var getShort = function(req, res, next){
                     //shortList.forEach(function(item, index){
                     //    log.info('routeS>', item);
                     //});
+
+                    //req.short = shortList;
+                    //return next();
+
                     getTownDataFromDB(modelCurrent, coord, function(err, currentList){
                         if (err) {
                             log.error(err);
@@ -1092,6 +1138,7 @@ var getShort = function(req, res, next){
             });
         } catch(e){
             log.error('ERROE>>', meta);
+            log.error(e);
             next();
         }
     }
@@ -1175,6 +1222,7 @@ var getShortest = function(req, res, next){
             });
         } catch(e){
             log.error('ERROE>>', meta);
+            log.error(e);
             next();
         }
     }
@@ -1293,6 +1341,7 @@ var getCurrent = function(req, res, next){
             });
         } catch(e){
             log.error('ERROE>>', meta);
+            log.error(e);
             next();
         }
     }
@@ -1479,6 +1528,7 @@ var getMid = function(req, res, next){
             });
         }catch(e){
             log.error('ERROE>>', meta);
+            log.error(e);
             next();
         }
     }
@@ -1674,7 +1724,7 @@ router.get('/:region/:city', [getMid, getMidRss, getLifeIndexKma], function(req,
     res.json(result);
 });
 
-router.get('/:region/:city/:town', [getShort, getShortest, getCurrent, getMid, getMidRss, getLifeIndexKma, getKeco],
+router.get('/:region/:city/:town', [getShort, getShortest, getCurrent, getMid, getMidRss ],
             function(req, res) {
     var meta = {};
 
@@ -1727,7 +1777,7 @@ router.get('/:region/:city/:town/mid', [getMid, getMidRss], function (req, res) 
     res.json(result);
 });
 
-router.get('/:region/:city/:town/short', [getShort, getLifeIndexKma], function(req, res) {
+router.get('/:region/:city/:town/short', [getShort], function(req, res) {
     var meta = {};
 
     var result = {};
@@ -1753,7 +1803,7 @@ router.get('/:region/:city/:town/short', [getShort, getLifeIndexKma], function(r
     res.json(result);
 });
 
-router.get('/:region/:city/:town/shortest', getShortest, function(req, res) {
+router.get('/:region/:city/:town/shortest', [getShortest], function(req, res) {
     var meta = {};
 
     var result = {};
@@ -1779,7 +1829,7 @@ router.get('/:region/:city/:town/shortest', getShortest, function(req, res) {
     res.json(result);
 });
 
-router.get('/:region/:city/:town/current', [getCurrent, getKeco], function(req, res) {
+router.get('/:region/:city/:town/current', [getCurrent], function(req, res) {
     var meta = {};
 
     var result = {};

--- a/server/test/testCollectTownForecast.js
+++ b/server/test/testCollectTownForecast.js
@@ -61,24 +61,12 @@ describe('unit test - get town forecast in lib/collect class', function(){
     //    var collection = new collect();
     //    assert.doesNotThrow(function(){
     //        //collection.getTownData(listXY, collection.DATA_TYPE.TOWN_SHORT, keyString, '20150815', '0500', function(err, dataList){
-    //        collection.requestData(listXY, collection.DATA_TYPE.TOWN_SHORT, keydata.keyString.test_cert, '20151225', '0200', function(err, dataList){
+    //        collection.requestData(listXY, collection.DATA_TYPE.TOWN_SHORT, keydata.keyString.test_cert, '20151229', '1400', function(err, dataList){
+    //            if (err) {
+    //                log.error(err);
+    //                return;
+    //            }
     //            log.info('short data receive completed : %d\n', dataList.length);
-    //
-    //            dataList[0].data.sort(function(a, b){
-    //                if(a.date > b.date){
-    //                    return 1;
-    //                }
-    //                if(a.date < b.date){
-    //                    return -1;
-    //                }
-    //                if(a.date === b.date && a.time > b.time){
-    //                    return 1;
-    //                }
-    //                if(a.date === b.date && a.time < b.time){
-    //                    return -1;
-    //                }
-    //                return 0;
-    //            });
     //
     //            for(var i in dataList) {
     //                for (var j in dataList[i].data) {
@@ -89,12 +77,12 @@ describe('unit test - get town forecast in lib/collect class', function(){
     //            assert.equal(dataList.length, listXY.length, 'check receive count');
     //
     //            assert.notEqual(dataList[0].data[0].date, '', 'check date whether it is invalid');
-    //            assert.notEqual(dataList[1].data[0].date, '', 'check date whether it is invalid');
-    //            assert.notEqual(dataList[2].data[0].date, '', 'check date whether it is invalid');
+    //            //assert.notEqual(dataList[1].data[0].date, '', 'check date whether it is invalid');
+    //            //assert.notEqual(dataList[2].data[0].date, '', 'check date whether it is invalid');
     //
     //            assert.notEqual(dataList[0].data[0].time, '', 'check time whether it is invalid');
-    //            assert.notEqual(dataList[1].data[0].time, '', 'check time whether it is invalid');
-    //            assert.notEqual(dataList[2].data[0].time, '', 'check time whether it is invalid');
+    //            //assert.notEqual(dataList[1].data[0].time, '', 'check time whether it is invalid');
+    //            //assert.notEqual(dataList[2].data[0].time, '', 'check time whether it is invalid');
     //
     //            done();
     //        });
@@ -137,12 +125,12 @@ describe('unit test - get town forecast in lib/collect class', function(){
     //});
 
     //it('lib/collect : get towns CURRENT info by using XY list', function(done){
-    //    //var listXY = [{x:91, y:131}, {x:91, y:132}, {x:94, y:131}];
-    //    var listXY = listTown;
+    //    var listXY = [{mx:91, my:131}, {mx:91, my:132}, {mx:94, my:131}];
+    //    //var listXY = listTown;
     //
     //    var collection = new collect();
     //    assert.doesNotThrow(function(){
-    //        collection.requestData(listXY, collection.DATA_TYPE.TOWN_CURRENT, keydata.keyString.hyunsoo, '20150831', '0300', function(err, dataList){
+    //        collection.requestData(listXY, collection.DATA_TYPE.TOWN_CURRENT, keydata.keyString.test_cert, '20151229', '1600', function(err, dataList){
     //            log.info('current data receive completed : %d\n', dataList.length);
     //
     //            //log.info(dataList);


### PR DESCRIPTION
organizeXXXX 에서 데이터를 모으는 변수 생성을 변경하여 썪이거나 중복되는 문제 수정.

saveOnlyLastOne flag를 두어서 이 경우에는 각 model의 XXXdata를 덮어쓰기 하여 최신한개만 유지하게 한다.
COUNT는 각 DATA에 대한 갯수로 갯수가 가변인 경우를 고려하면  한번 들어오는 갯수의 최대값을 설정해서 해야 한다.  상세한 동작확인은 하지 않았음
waterfall 내에서 이전 function으로 부터 return 값을 받는 경우에 맞게 수정.
mongoose version update