### PR TITLE
#469 과거 실황 데이터 수집기 #471

### DIFF
--- a/server/lib/PastConditionGather.js
+++ b/server/lib/PastConditionGather.js
@@ -1,0 +1,105 @@
+/**
+ * Created by aleckim on 2015. 12. 29..
+ */
+
+var async = require('async');
+var req = require('request');
+
+var town = require('../models/town');
+var modelCurrent = require('../models/modelCurrent');
+var config = require('../config/config');
+
+function PastConditionGather() {
+    this.pubDateList; //{date: String, time: String}
+    this.updateList = []; //{mCoord: {mx,my}, baseTimeList: {date, time}}
+}
+
+PastConditionGather.prototype.makePubDateList = function (days) {
+    var pubDateList = [];
+    var counts = days*24;
+    var currentMins = (new Date()).getUTCMinutes();
+    var startOffset;
+    var currentDate;
+    var dateString;
+
+    if (currentMins > 40) {
+        startOffset = 9;
+    }
+    else {
+        startOffset = 8;
+    }
+    for (var i=0; i<counts; i++) {
+        currentDate = manager.getWorldTime(startOffset--);
+
+        dateString = {};
+        dateString.date = currentDate.slice(0, 8);
+        dateString.time = currentDate.slice(8,10) + '00';
+
+        pubDateList.push(dateString);
+    }
+    return pubDateList;
+};
+
+PastConditionGather.prototype._checkBaseTime = function (callback) {
+    var self = this;
+    var updateObject;
+    modelCurrent.find(null, {_id: 0}).lean().exec(function(err, modelList) {
+        if (err) {
+            return callback(err);
+        }
+        modelList.forEach(function (model) {
+            updateObject = {mCoord: model.mCoord, baseTimeList: []};
+            self.pubDateList.forEach(function (pubDate) {
+                for (var i=0; i<model.currentData.length; i++) {
+                    if (pubDate.date === model.currentData[i].date && pubDate.time === model.currentData[i].time) {
+                        log.debug('baseTime='+JSON.stringify(pubDate)+' is skipped');
+                        return;
+                    }
+                }
+                log.silly('baseTime='+JSON.stringify(pubDate)+' needs to get data');
+                updateObject.baseTimeList.push(pubDate);
+            });
+            if (updateObject.baseTimeList.length) {
+                self.updateList.push(updateObject);
+            }
+            else {
+                log.info('mCoord='+JSON.stringify(updateObject.mCoord)+' is already updated');
+            }
+        });
+        callback();
+    });
+};
+
+PastConditionGather.prototype.start = function (days, key, callback) {
+    var self = this;
+
+    async.waterfall([
+        function(callback) {
+            self.pubDateList = self.makePubDateList(days);
+            callback();
+        },
+        function (callback) {
+            self._checkBaseTime(function (err) {
+                callback(err);
+            });
+        },
+        function (callback) {
+            manager.requestDataByUpdateList(manager.DATA_TYPE.TOWN_CURRENT, key, self.updateList, 10, function (err, results) {
+                callback(err);
+            });
+        }
+    ], function(err, results) {
+        if (callback) {
+            return callback(err);
+        }
+        if (err) {
+            log.error(err);
+        }
+        log.silly(results);
+    });
+
+    return this;
+};
+
+module.exports = PastConditionGather;
+

--- a/server/test/testCollectTownForecast.js
+++ b/server/test/testCollectTownForecast.js
@@ -259,3 +259,28 @@ describe('unit test - test geocode ', function() {
     //    });
     //});
 });
+
+describe('unit test - test requestDataByBaseTimeList', function() {
+    //var col = new collect();
+    ////var listXY = [{mx:91, my:131}, {mx:91, my:132}, {mx:94, my:131}];
+    //var listXY = [{mx: 91, my: 131}];
+    //var baseTimeList = [{date: '20151231', time: '0500'}, {date: '20151231', time: '0600'}];
+    //
+    //it('requestDataByBaseTimeList', function (done) {
+    //    col.requestDataByBaseTimeList(listXY[0], col.DATA_TYPE.TOWN_CURRENT, keydata.keyString.test_cert, baseTimeList, function (err, dataList) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        log.info(dataList.length);
+    //        dataList.forEach(function (newData) {
+    //            log.info(newData.data.length);
+    //            newData.data.forEach(function (data) {
+    //                log.info(JSON.stringify(data));
+    //            });
+    //        });
+    //        done();
+    //    });
+    //});
+});
+
+

--- a/server/test/testControllerManager.js
+++ b/server/test/testControllerManager.js
@@ -121,6 +121,48 @@ describe('unit test - controller manager', function() {
         manager.stopManager();
     });
 
+    it('test get world time', function () {
+        var  dateStr = manager.getWorldTime(9);
+        log.info(dateStr);
+    });
+
+    //it('test recursive request data by base time list', function (done) {
+    //    this.timeout(1000*60); //1min
+    //    var updateObject = {mCoord:{mx:91, my:131}, baseTimeList:[]};
+    //    updateObject.baseTimeList = [{date: '20151231', time: '0500'}, {date: '20151231', time: '0600'}];
+    //
+    //    manager._recursiveRequestDataByBaseTimList(manager.DATA_TYPE.TOWN_CURRENT, config.keyString.test_cert,
+    //        updateObject.mCoord, updateObject.baseTimeList, 10, function(err, results) {
+    //            log.info('TOWN_CURRENT '+JSON.stringify(updateObject.mCoord)+' was updated counts='+updateObject.baseTimeList);
+    //            if (err) {
+    //                log.error(err);
+    //            }
+    //            log.info(results);
+    //            //unless previous item was failed, continues next item
+    //            done();
+    //        });
+    //});
+
+    //it('test requestDataByUpdateList', function (done) {
+    //    this.timeout(1000*60); //1min
+    //    var updateList = [];
+    //
+    //    var updateObject = {mCoord:{mx:91, my:131}, baseTimeList:[]};
+    //    updateObject.baseTimeList = [{date: '20151231', time: '0500'}, {date: '20151231', time: '0600'}];
+    //    updateList.push(updateObject);
+    //
+    //    var updateObject2 = {mCoord:{mx:62, my:125}, baseTimeList:[]};
+    //    updateObject2.baseTimeList = [{date: '20151231', time: '0500'}, {date: '20151231', time: '0600'}];
+    //    updateList.push(updateObject2);
+    //
+    //    manager.requestDataByUpdateList(manager.DATA_TYPE.TOWN_CURRENT, config.keyString.test_cert, updateList, 10, function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //
+    //});
 });
 
 

--- a/server/test/testPastConditionGather.js
+++ b/server/test/testPastConditionGather.js
@@ -1,0 +1,57 @@
+/**
+ * Created by aleckim on 2015. 12. 31..
+ */
+
+var Logger = require('../lib/log');
+global.log  = new Logger();
+
+var assert  = require('assert');
+var config = require('../config/config');
+var controllerManager = require('../controllers/controllerManager');
+var PastConditionGather = require('../lib/PastConditionGather');
+
+global.manager = new controllerManager();
+
+describe('unit test - past condition gather', function() {
+    //var mongoose = require('mongoose');
+    //mongoose.connect(config.db.path, function(err) {
+    //    if (err) {
+    //        log.error('Could not connect to MongoDB!');
+    //        console.log(err);
+    //        done();
+    //    }
+    //});
+    //
+    //mongoose.connection.on('error', function(err) {
+    //    log.error('MongoDB connection error: ' + err);
+    //    done();
+    //});
+
+    //it('test make pub date list', function() {
+    //    var pastGather = new PastConditionGather();
+    //    var pubDateList = pastGather.makePubDateList(7);
+    //    pubDateList.forEach(function (pubDate) {
+    //        log.info(JSON.stringify(pubDate));
+    //    });
+    //    log.info('pubDateCounts='+pubDateList.length);
+    //});
+
+    //it('test start past condition gather', function(done) {
+    //    this.timeout(1000*60*60*3);
+    //    var pastGather = new PastConditionGather();
+    //    pastGather.start(7, config.keyString.test_cert, function (err) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        else {
+    //            log.info('mCoords='+pastGather.updateList.length);
+    //            pastGather.updateList.forEach(function (updateObject) {
+    //                log.info('mCoord:'+JSON.stringify(updateObject.mCoord)+' baseTimes='+updateObject.baseTimeList.length);
+    //            });
+    //        }
+    //        done();
+    //    });
+    //});
+});
+
+


### PR DESCRIPTION
#469 - controller manager에서 task가 에러나도, 다음 task로 넘어가게 수정.
#471 - new PastConditionGather . 주의 : 신동네예보는 어제까지만, 구동네예보는 8일전까지 실황 가지고 올수 있음.
current는 currentData를 최대 240개까지 저장하게 수정.
saveCurrent에서 pubDate가 없는 경우에는 pubDate를 갱신하지 않음. - pastConditionGather위한 수정
기존에는 여러개의 mCoord list로 업데이트했으나 이번에 baseTime 기준으로 반복해서 받아, save하게 새로운 함수들 추가