### PR TITLE
API 미동작시에 대응할 crawler 제작. #594

### DIFF
--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1143,7 +1143,7 @@ Manager.prototype.getTownShortData = function(baseTime, key, callback){
                 log.info('S> srcList length=', srcList.length);
             }
 
-            self._recursiveRequestData(srcList, self.DATA_TYPE.TOWN_SHORT, key, dateString, 30, function (err, results) {
+            self._recursiveRequestData(srcList, self.DATA_TYPE.TOWN_SHORT, key, dateString, 10, function (err, results) {
                 log.info('S> save OK');
                 if (callback) {
                     return callback(err, results);
@@ -1219,7 +1219,7 @@ Manager.prototype.getTownShortestData = function(baseTime, key, callback){
             }
 
             //log.info('ST> +++ SHORTEST COORD LIST : ', listTownDb.length);
-            self._recursiveRequestData(srcList, self.DATA_TYPE.TOWN_SHORTEST, key, dateString, 30, function (err, results) {
+            self._recursiveRequestData(srcList, self.DATA_TYPE.TOWN_SHORTEST, key, dateString, 10, function (err, results) {
                 log.info('ST> save OK');
                 if (callback) {
                     return callback(err, results);
@@ -1289,7 +1289,7 @@ Manager.prototype.getTownCurrentData = function(gmt, key, callback){
                 log.info('C> srcList length=', srcList.length);
             }
 
-            self._recursiveRequestData(srcList, self.DATA_TYPE.TOWN_CURRENT, key, dateString, 30, function (err, results) {
+            self._recursiveRequestData(srcList, self.DATA_TYPE.TOWN_CURRENT, key, dateString, 10, function (err, results) {
                 log.info('C> save OK');
                 if (callback) {
                     return callback(err, results);
@@ -1858,7 +1858,7 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         });
     }
 
-    if (time === 41 || putAll) {
+    if (time === 35 || putAll) {
         log.info('push shortest');
         self.asyncTasks.push(function (callback) {
             self._requestApi("shortest", callback);


### PR DESCRIPTION
api 에러 발생시에 retry count를 30에서 10으로 변경.
current, shortest 업데이트 타임을 35분으로 변경. 30분부터 kma api를 모니터링하니, 값이 순차적으로 생기면서 32분정도에 모두 채워짐.
api total count가 0인 경우에 empty object를 추가하지 않고 에러로 처리함 - 추후 totalcount가 0인 경우에 crawler 동작 시킬껀데 좀 더 상셍한 시나리오 필요.
api 속도 문제로 한번에 400개까지 받는 제한 제거 (메모리를 더 많이 사용하게 됨). 추후 api 수신과 save가 분리되어 있는데 이것을 일련의 과정으로 묶어서 분산시키는 방법 고려