### PR TITLE
#568 cloudfront cache clear

### DIFF
--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1897,12 +1897,12 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         });
     }
 
-    if(time === 50 || putAll){
-        log.info('push invalidateCloudFront');
-        self.asyncTasks.push(function(callback){
-            self._requestApi("invalidateCloudFront/ALL", callback);
-        })
-    }
+    //if(time === 50 || putAll){
+    //    log.info('push invalidateCloudFront');
+    //    self.asyncTasks.push(function(callback){
+    //        self._requestApi("invalidateCloudFront/ALL", callback);
+    //    })
+    //}
 
     if (self.asyncTasks.length <= 12) {
         log.debug('wait '+self.asyncTasks.length+' tasks');


### PR DESCRIPTION
aws key가 없는 경우, request 종료하는데 2분정도 소요되어 임시로 막아둠.
데이터 갱신시에 clear해주도록 변경 필요함.