### PR TITLE
release version 0.7.4

### DIFF
--- a/client/config.xml
+++ b/client/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="net.wizardfactory.todayweather" version="0.7.3" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="net.wizardfactory.todayweather" version="0.7.4" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>TodayWeather</name>
     <description>
         Inform how warm or cold it's today than yesterday.

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TodayWeather",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "TodayWeather: Inform how warm or cold it is today than yesterday.",
   "repository": {
     "type": "git",

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -743,7 +743,7 @@ angular.module('starter.controllers', [])
     .controller('SettingCtrl', function($scope, $rootScope, $ionicPlatform, $ionicAnalytics, $http,
                                         $cordovaInAppBrowser) {
         //sync with config.xml
-        $scope.version  = "0.7.3";
+        $scope.version  = "0.7.4";
 
         //it doesn't work after ionic deploy
         //var deploy = new Ionic.Deploy();


### PR DESCRIPTION
backend - fsn(식중독), ultrv(자외선)지수 적용 3월부터 제공
backend - current, shortest 업데이트 타임을 35분으로 변경하고 한 번에 가지고 오는 데이터 수를 늘려 속도 개선.
frontend - disable FadeSplashScreen
frontend - 처음 일별 날씨 화면 짤리는 문제 해결
backend - To avoid calling convertGetcode again over again.
frontend - 도시 검색에서 시도, 시구명으로도 추가 가능하게 개선
frontend - 도시리스트에서 도시가 적어도 스크롤 생기는 문제 수정