### PR TITLE
fixed #632 cordova 6.0 호환성 문제

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
     "cordova-plugin-device",
     "cordova-plugin-console",
     "cordova-plugin-splashscreen",
-    "com.ionic.keyboard",
+    "ionic-plugin-keyboard",
     "cordova-plugin-geolocation",
     "cordova-plugin-apple-watch",
     "cordova-plugin-statusbar",
@@ -42,6 +42,11 @@
     },
     "ionic-plugin-deploy",
     "cordova-plugin-inappbrowser",
+    "cordova-plugin-googleplayservices",
+    {
+	    "locator": "https://github.com/floatinghotpot/google-admob-sdk.git",
+	    "id": "com.google.admobsdk"
+    },
     {
       "locator": "https://github.com/WizardFactory/cordova-plugin-admob.git",
       "id": "cordova-plugin-admob"


### PR DESCRIPTION
plugin name com.XXX로 시작 하는 부분들 대처된 이름이나, github에서 가지고 오도록 변경.