### PR TITLE
Fixed #557 Fixed #650 #168

### DIFF
--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -80,6 +80,10 @@ function ControllerTown() {
                             //log.info('found same date');
                             break;
                         }
+                        else if (shortList[i].date >= requestTime.date) {
+                            log.warn('Fail to find current time so start next day from request time');
+                            break;
+                        }
                     }
 
                     log.silly('route S> short remove count :', i);
@@ -190,9 +194,9 @@ function ControllerTown() {
                             req.short[j].sky = rssList[i].sky;
                             req.short[j].t3h = Math.round(rssList[i].temp);
                             if(req.short[j].time === '0600' && rssList[i].tmn != -999) {
-                                req.short[j].tmn = Math.round(rssList[i].tmn);
+                                req.short[j].tmn = rssList[i].tmn;
                             } else if(req.short[j].time === '1500' && rssList[i].tmn != -999) {
-                                req.short[j].tmx = Math.round(rssList[i].tmx);
+                                req.short[j].tmx = rssList[i].tmx;
                             }
                             break;
                         }
@@ -209,12 +213,12 @@ function ControllerTown() {
                         item.sky = rssList[i].sky;
                         item.t3h = Math.round(rssList[i].temp);
                         if(item.time === '0600' && rssList[i].tmn != -999){
-                            item.tmn = Math.round(rssList[i].tmn);
+                            item.tmn = rssList[i].tmn;
                         } else{
                             item.tmn = -50;
                         }
                         if(item.time === '1500' && rssList[i].tmx != -999){
-                            item.tmx = Math.round(rssList[i].tmx);
+                            item.tmx = rssList[i].tmx;
                         }else{
                             item.tmx = -50;
                         }
@@ -332,14 +336,13 @@ function ControllerTown() {
                     }
 
                     log.debug(shortestList.length);
+                    //log.info(listShortest);
 
                     var nowDate = self._getShortestTimeValue(+9);
-                    var resultItem = shortestList.filter(function (shortest) {
+                    req.shortest = shortestList.filter(function (shortest) {
                         return nowDate.date + nowDate.time <= shortest.date + shortest.time;
                     });
 
-                    //log.info(listShortest);
-                    req.shortest = resultItem;
                     next();
                 });
             });
@@ -404,6 +407,8 @@ function ControllerTown() {
                     resultItem.sensorytem = Math.round(self._getNewWCT(resultItem.t1h, resultItem.wsd));
                     resultItem.sensorytemStr = self._parseSensoryTem(resultItem.sensorytem);
                     //log.info(listCurrent);
+                    //지수 계산 이후에 반올림함.
+                    resultItem.t1h = Math.round(resultItem.t1h);
                     req.current = resultItem;
                     next();
                 });
@@ -477,10 +482,7 @@ function ControllerTown() {
 
         var regionName = req.params.region;
         var cityName = req.params.city;
-        var townName = '';
-        if(req.params.town != undefined){
-            townName = req.params.town;
-        }
+
         meta.method = 'getMid';
         meta.region = regionName;
         meta.city = cityName;
@@ -569,6 +571,13 @@ function ControllerTown() {
         return this;
     };
 
+    /**
+     *
+     * @param current
+     * @param short
+     * @param dailyData
+     * @private
+     */
     this._appendLifeIndexToCurrent = function (current, short, dailyData) {
         var i;
         //for (i=0;i<short.length;i++) {
@@ -738,7 +747,13 @@ function ControllerTown() {
                     }
 
                     try {
-                        req.pastData = currentList;
+                        var requestTime = self._getTimeValue(9-7*24); //지난주 동일 요일까지
+
+                        //log.info(parseInt(curItem.date), parseInt(requestTime.date));
+                        req.pastData = currentList.filter(function (current) {
+                            return parseInt(current.date) >= parseInt(requestTime.date);
+                        });
+
                         daySummaryList = self._getDaySummaryList(req.pastData);
                         self._mergeList(req.midData.dailyData, daySummaryList);
                     }
@@ -819,6 +834,9 @@ function ControllerTown() {
         var daySummaryList = [];
         req.short.forEach(function (short, index) {
             var daySummary = self._createOrGetDaySummaryList(daySummaryList, short.date);
+            daySummary.taMax = daySummary.taMax === undefined ? -50:daySummary.taMax;
+            daySummary.taMin = daySummary.taMin === undefined ? -50:daySummary.taMin;
+
             if (daySummary.taMax < short.t3h) {
                 daySummary.taMax = short.t3h;
             }
@@ -849,6 +867,8 @@ function ControllerTown() {
 
         req.short.forEach(function (short) {
             var daySum = self._createOrGetDaySummaryList(daySummaryList, short.date);
+            daySum.taMax = daySum.taMax === undefined ? -50:daySum.taMax;
+            daySum.taMin = daySum.taMin === undefined ? -50:daySum.taMin;
             if (daySum.taMax === -50 || daySum.taMin === -50) {
                 log.error("short date:"+short.date+" fail to get daySummary");
                 return;
@@ -944,16 +964,14 @@ ControllerTown.prototype._getShortestTimeValue = function(gmt) {
 ControllerTown.prototype._getCurrentTimeValue = function(gmt) {
     var timeFunction = manager;
     var currentDate = timeFunction.getWorldTime(gmt);
-    var dateString = {
+    return {
         date: currentDate.slice(0, 8),
         time: currentDate.slice(8, 10) + '00'
     };
-
-    return dateString;
 };
 
 /**
- *
+ * for short
  * @param gmt
  * @returns {{date: *, time: string}}
  */
@@ -999,7 +1017,7 @@ ControllerTown.prototype._getTimeValue = function(gmt) {
 };
 
 /**
- *
+ * for short
  * @returns {Array}
  */
 ControllerTown.prototype._getTimeTable = function () {
@@ -1039,7 +1057,7 @@ ControllerTown.prototype._getTimeTable = function () {
     }
     else{
         log.error('unknown TimeString');
-        return;
+        return listResult;
     }
 
     log.info('make time table');
@@ -1131,15 +1149,91 @@ ControllerTown.prototype._getShortFromDB = function(regionName, cityName, townNa
 /**
  *
  * @param list
+ * @param invalidValue
+ * @returns {*}
+ * @private
+ */
+ControllerTown.prototype._max = function(list, invalidValue) {
+    var ret;
+    var validList;
+
+    if (!Array.isArray(list)) {
+        return -1;
+    }
+
+    if (invalidValue != undefined) {
+        validList = list.filter(function (val) {
+            return val !== invalidValue;
+        });
+    }
+    else {
+        validList = list;
+    }
+
+    validList.forEach(function (data) {
+        if (data > ret || ret === undefined) {
+            ret = data;
+        }
+    });
+
+    if (ret === undefined) {
+        ret = invalidValue;
+    }
+    return ret;
+};
+
+ControllerTown.prototype._min = function(list, invalidValue) {
+    var ret;
+    var validList;
+
+    if (!Array.isArray(list)) {
+        return -1;
+    }
+
+    if (invalidValue != undefined) {
+        validList = list.filter(function (val) {
+            return val !== invalidValue;
+        });
+    }
+    else {
+        validList = list;
+    }
+
+    validList.forEach(function (data) {
+        if (data < ret || ret === undefined) {
+            ret = data;
+        }
+    });
+
+    if (ret === undefined) {
+        ret = invalidValue;
+    }
+    return ret;
+};
+
+/**
+ *
+ * @param list
+ * @param invalidValue
  * @returns {number}
  * @private
  */
-ControllerTown.prototype._sum = function(list) {
+ControllerTown.prototype._sum = function(list, invalidValue) {
     var total = 0;
     if (!Array.isArray(list)) {
         return -1;
     }
-    list.forEach(function (num) {
+    var validList;
+    if (invalidValue != undefined) {
+        validList = list.filter(function (val) {
+            return val !== invalidValue;
+        });
+    }
+    else {
+        validList = list;
+    }
+
+    validList.forEach(function (num) {
         total += num;
     });
     return total;
@@ -1148,16 +1242,28 @@ ControllerTown.prototype._sum = function(list) {
 /**
  *
  * @param list
+ * @param invalidValue
  * @returns {number}
  * @private
  */
-ControllerTown.prototype._average = function(list) {
+ControllerTown.prototype._average = function(list, invalidValue) {
     var self = this;
 
     if (!Array.isArray(list)) {
         return -1;
     }
-    return Math.round(self._sum(list)/list.length);
+
+    var validList;
+    if (invalidValue != undefined) {
+        validList = list.filter(function (val) {
+            return val !== invalidValue;
+        });
+    }
+    else {
+        validList = list;
+    }
+
+    return Math.round(self._sum(validList)/validList.length);
 };
 
 /**
@@ -1196,9 +1302,7 @@ ControllerTown.prototype._mergeList = function(dstList, srcList) {
             if (dstList[i].date === src.date) {
                 for (var key in src) {
                     //copy all the fields
-                    if (src[key] !== -50) {
-                        dstList[i][key] = src[key];
-                    }
+                    dstList[i][key] = src[key];
                 }
                 return;
             }
@@ -1520,55 +1624,6 @@ ControllerTown.prototype._getMidDataFromDB = function(db, indicator, cb){
 };
 
 /**
- *
- * @param list
- * @param invalidValue
- * @returns {*}
- * @private
- */
-ControllerTown.prototype._getMax = function(list, invalidValue) {
-    var ret;
-    list.forEach(function (data) {
-        if (data !== invalidValue && (data > ret || ret === undefined)) {
-            ret = data;
-        }
-    });
-
-    if (ret === undefined) {
-        ret = invalidValue;
-    }
-    return ret;
-};
-
-/**
- *
- * @param list
- * @param invalidValue
- * @returns {number}
- * @private
- */
-ControllerTown.prototype._getAverage = function(list, invalidValue) {
-    var ret=0;
-    var len=0;
-
-    list.forEach(function (data) {
-        if (data !== invalidValue) {
-            ret += data;
-            len++;
-        }
-    });
-
-    if (len > 0) {
-        ret = Math.round(ret/len);
-    }
-    else {
-        ret = invalidValue;
-    }
-
-    return ret;
-};
-
-/**
  * merge short data with current data
  * @param shortList
  * @param currentList
@@ -1597,6 +1652,9 @@ ControllerTown.prototype._mergeShortWithCurrent = function(shortList, currentLis
 
             var newItem = {};
             var daySummary = self._createOrGetDaySummaryList(daySummaryList, curItem.date);
+            daySummary.taMax = daySummary.taMax === undefined ? -50:daySummary.taMax;
+            daySummary.taMin = daySummary.taMin === undefined ? -50:daySummary.taMin;
+
             if (daySummary.taMax < curItem.t1h) {
                 daySummary.taMax = curItem.t1h;
             }
@@ -1610,7 +1668,8 @@ ControllerTown.prototype._mergeShortWithCurrent = function(shortList, currentLis
                 ((parseInt(curItem.date) === parseInt(requestTime.date)) &&
                 parseInt(curItem.time) <= parseInt(requestTime.time))){
                 // 시간이 0시 이거나 3의 배수인 시간일때 데이터를 구성한다
-                if(curItem.time === '0000' || (parseInt(curItem.time) % 3) === 0){
+                // 1시, 2시 같은 경우에는 마지막의 있는 1시, 2시 시간을 버린다.
+                if(curItem.time === '0000' || (parseInt(curItem.time) % 3) === 0) {
                     newItem.time = curItem.time;
                     newItem.date = curItem.date;
                     if(index === 0) {
@@ -1618,46 +1677,40 @@ ControllerTown.prototype._mergeShortWithCurrent = function(shortList, currentLis
                             newItem[string] = curItem[string];
                         });
                     }
-                    else if (index === 1) {
-                        var tmp = {};
-                        tmp = currentList[index - 1];
+                    else {
+                        var prv1;
+                        if (index === 1) {
+                            prv1 = {'t1h':-50, 'rn1':-1, 'sky':-1, 'uuu':-100, 'vvv':-100,
+                                'reh':-1, 'pty':-1, 'lgt':-1, 'vec':-1, 'wsd':-1};
+                        }
+                        else {
+                            prv1 = currentList[index-2];
+                        }
 
-                        if (tmp === undefined || !tmp.hasOwnProperty('sky')) {
+                        var prv2 = currentList[index-1];
+
+                        if (prv1 === undefined || !prv1.hasOwnProperty('sky') ||
+                            prv2 === undefined || !prv2.hasOwnProperty('sky'))
+                        {
                             log.warn(new Error('current is undefined or empty object'));
                             return;
                         }
 
-                        //log.info(tmp);
-                        curString.forEach(function(string){
+                        curString.forEach(function(string) {
                             if(string === 'sky' || string === 'pty' || string === 'lgt') {
-                                newItem[string] = self._getMax([tmp[string], curItem[string]], -1);
+                                newItem[string] = self._max([prv1[string], prv2[string], curItem[string]], -1);
                             }
                             else if(string === 'uuu' || string === 'vvv') {
-                                newItem[string] = self._getAverage([tmp[string], curItem[string]], -100);
+                                newItem[string] = self._average([prv1[string], prv2[string], curItem[string]], -100);
                             }
                             else if(string === 't1h') {
-                                newItem[string] = self._getAverage([tmp[string], curItem[string]], -50);
+                                newItem[string] = Math.round(curItem[string]);
+                            }
+                            else if(string === 'rn1') {
+                                newItem[string] = self._sum([prv1[string], prv2[string], curItem[string]], -1);
                             }
                             else{
-                                newItem[string] = self._getAverage([tmp[string], curItem[string]], -1);
-                            }
-                        });
-                    } else {
-                        var prv1 = currentList[index-2];
-                        var prv2 = currentList[index-1];
-                        //var next = currentList[index+1];
-                        curString.forEach(function(string){
-                            if(string === 'sky' || string === 'pty' || string === 'lgt') {
-                                newItem[string] = self._getMax([prv1[string], prv2[string], curItem[string]], -1);
-                            }
-                            else if(string === 'uuu' || string === 'vvv') {
-                                newItem[string] = self._getAverage([prv1[string], prv2[string], curItem[string]], -100);
-                            }
-                            else if(string === 't1h') {
-                                newItem[string] = self._getAverage([prv1[string], prv2[string], curItem[string]], -50);
-                            }
-                            else{
-                                newItem[string] = self._getAverage([prv1[string], prv2[string], curItem[string]], -1);
+                                newItem[string] = self._average([prv1[string], prv2[string], curItem[string]], -1);
                             }
                         });
                     }
@@ -1687,6 +1740,7 @@ ControllerTown.prototype._mergeShortWithCurrent = function(shortList, currentLis
 
             if (shortItem.time === '0600') {
                 currentTmn = (self._createOrGetDaySummaryList(daySummaryList, shortItem.date)).taMin;
+                currentTmn = currentTmn === undefined ? -50: currentTmn;
                 if (currentTmn !== -50) {
                     //당일은 측정된 값과, 예보중에 큰값으로 결정.
                     if (shortItem.date === requestTime.date && shortList[index].tmn !== -50) {
@@ -1700,6 +1754,7 @@ ControllerTown.prototype._mergeShortWithCurrent = function(shortList, currentLis
             }
             if (shortItem.time === '1500') {
                 currentTmx = (self._createOrGetDaySummaryList(daySummaryList, shortItem.date)).taMax;
+                currentTmx = currentTmx === undefined ? -50: currentTmx;
                 if (currentTmx !== -50) {
                     //당일은 측정된 값과, 예보중에 큰값으로 결정.
                     if (shortItem.date === requestTime.date && shortList[index].tmx !== -50) {
@@ -1963,7 +2018,12 @@ ControllerTown.prototype._mergeShortWithBasicList = function(shortList, basicLis
         basicList.forEach(function(basicItem) {
             if(shortItem.date === basicItem.date && shortItem.time === basicItem.time){
                 shortString.forEach(function(string){
-                    basicItem[string] = shortItem[string];
+                    if (string === 't3h') {
+                        basicItem[string] = Math.round(shortItem[string]);
+                    }
+                    else {
+                        basicItem[string] = shortItem[string];
+                    }
                 });
             }
         });
@@ -2054,51 +2114,76 @@ ControllerTown.prototype._createOrGetDaySummaryList = function(list, date) {
         }
     }
 
-    list.push({date:date, lgt:-1, pty:-1, reh:-1, rn1:-1, sky:-1, pop:-1, s06:-1, wfAm:'', wfPm:'', t1d:-50, wsd:-1, taMax:-50, taMin:-50});
+    list.push({date:date});
     return list[list.length-1];
 };
 
 /**
  * -1, 0, 1
  * @param list
+ * @param invalidValue
  * @returns {*}
  * @private
  */
-ControllerTown.prototype._summaryLgt = function(list) {
+ControllerTown.prototype._summaryLgt = function(list, invalidValue) {
     if (!Array.isArray(list)) {
         return -1;
     }
-    for (var i=0; i<list.length; i++) {
-        if (list[i] > 0) {
-            return list[i];
+
+    var validList;
+    if (invalidValue != undefined) {
+        validList = list.filter(function (val) {
+            return val !== invalidValue;
+        });
+    }
+    else {
+        validList = list;
+    }
+
+    for (var i=0; i<validList.length; i++) {
+        if (validList[i] > 0) {
+            return validList[i];
         }
     }
+
     return 0;
 };
 
 /**
  *  -1, 0, 1, 2, 3
  * @param list
+ * @param invalidValue
  * @returns {number}
  * @private
  */
-ControllerTown.prototype._summaryPty = function(list) {
+ControllerTown.prototype._summaryPty = function(list, invalidValue) {
     var pty = 0;
 
     if (!Array.isArray(list)) {
         return -1;
     }
-    for (var i=0; i<list.length; i++) {
-        if (list[i] === 2) {
+
+    var validList;
+    if (invalidValue != undefined) {
+        validList = list.filter(function (val) {
+            return val !== invalidValue;
+        });
+    }
+    else {
+        validList = list;
+    }
+
+    for (var i=0; i<validList.length; i++) {
+        if (validList[i] === 2) {
             return 2;
         }
-        else if (list[i] === 1) {
+        else if (validList[i] === 1) {
             if (pty === 3) {
                 return 2;
             }
             pty = 1;
         }
-        else if (list[i] === 3) {
+        else if (validList[i] === 3) {
             if (pty === 1) {
                 return  2;
             }
@@ -2128,8 +2213,9 @@ ControllerTown.prototype._convertSkyToKorStr = function(sky, pty) {
     }
     else {
         switch (sky) {
-            case 1: //str = '맑고 ';
+            case 1: str = '구름적고 ';
                 log.warn("It's special case");
+                break;
             case 2: str = '구름적고 ';
                 break;
             case 3: str = '구름많고 ';
@@ -2208,17 +2294,17 @@ ControllerTown.prototype._getDaySummaryListByShort = function(shortList) {
 
         var daySummary = self._createOrGetDaySummaryList(daySummaryList, dayCondition.date);
 
-        daySummary.pop = Math.max.apply(null, dayCondition.pop);
-        daySummary.pty = self._summaryPty(dayCondition.pty);
-        //daySummary.r06 = _sum(dayCondition.r06);
-        daySummary.reh = self._average(dayCondition.reh);
-        //daySummary.s06 = _sum(dayCondition.s06);
-        daySummary.sky = self._average(dayCondition.sky);
+        daySummary.pop = self._max(dayCondition.pop, -1);
+        daySummary.pty = self._summaryPty(dayCondition.pty, -1);
+        daySummary.r06 = self._sum(dayCondition.r06, -1);
+        daySummary.reh = self._average(dayCondition.reh, -1);
+        daySummary.s06 = self._sum(dayCondition.s06, -1);
+        daySummary.sky = self._average(dayCondition.sky, -1);
         daySummary.wfAm = self._convertSkyToKorStr(daySummary.sky, daySummary.pty);
         daySummary.wfPm = self._convertSkyToKorStr(daySummary.sky, daySummary.pty);
-        daySummary.t1d = self._average(dayCondition.t3h);
-        daySummary.taMax = dayCondition.tmx;
-        daySummary.taMin = dayCondition.tmn;
+        daySummary.t1d = self._average(dayCondition.t3h, -50);
+        daySummary.taMax = Math.round(dayCondition.tmx);
+        daySummary.taMin = Math.round(dayCondition.tmn);
     });
 
     return daySummaryList;
@@ -2275,17 +2361,17 @@ ControllerTown.prototype._getDaySummaryList = function(pastList) {
 
         var daySummary = self._createOrGetDaySummaryList(daySummaryList, dayCondition.date);
 
-        daySummary.lgt = self._summaryLgt(dayCondition.lgt);
-        daySummary.pty = self._summaryPty(dayCondition.pty);
-        daySummary.reh = self._average(dayCondition.reh);
-        daySummary.rn1 = self._sum(dayCondition.rn1);
-        daySummary.sky = self._average(dayCondition.sky);
+        daySummary.lgt = self._summaryLgt(dayCondition.lgt, -1);
+        daySummary.pty = self._summaryPty(dayCondition.pty, -1);
+        daySummary.reh = self._average(dayCondition.reh, -1);
+        daySummary.rn1 = self._sum(dayCondition.rn1, -1);
+        daySummary.sky = self._average(dayCondition.sky, -1);
         daySummary.wfAm = self._convertSkyToKorStr(daySummary.sky, daySummary.pty);
         daySummary.wfPm = self._convertSkyToKorStr(daySummary.sky, daySummary.pty);
-        daySummary.t1d = self._average(dayCondition.t1h);
-        daySummary.wsd = self._average(dayCondition.wsd);
-        daySummary.taMax = Math.max.apply(null, dayCondition.t1h);
-        daySummary.taMin = Math.min.apply(null, dayCondition.t1h);
+        daySummary.t1d = self._average(dayCondition.t1h, -50);
+        daySummary.wsd = self._average(dayCondition.wsd, -1);
+        daySummary.taMax = Math.round(self._max(dayCondition.t1h, -50));
+        daySummary.taMin = Math.round(self._min(dayCondition.t1h, -50));
     });
 
     return daySummaryList;

--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -53,6 +53,9 @@ function ControllerTown24h() {
             }
 
             var daySummary = self._createOrGetDaySummaryList(daySummaryList, short.date);
+            daySummary.taMax = daySummary.taMax === undefined ? -50:daySummary.taMax;
+            daySummary.taMin = daySummary.taMin === undefined ? -50:daySummary.taMin;
+
             if (daySummary.taMax < short.t3h) {
                 daySummary.taMax = short.t3h;
             }
@@ -85,6 +88,8 @@ function ControllerTown24h() {
         req.short.forEach(function (short, index) {
 
             var daySum = self._createOrGetDaySummaryList(daySummaryList, short.date);
+            daySum.taMax = daySum.taMax === undefined ? -50:daySum.taMax;
+            daySum.taMin = daySum.taMin === undefined ? -50:daySum.taMin;
             if (daySum.taMax === -50 || daySum.taMin === -50) {
                 log.error("short date:"+short.date+" fail to get daySummary");
                 return;

--- a/server/controllers/midRssKmaController.js
+++ b/server/controllers/midRssKmaController.js
@@ -58,8 +58,8 @@ midRssKmaController.overwriteData = function(reqMidData, regId, callback) {
 
             for (var i = 0; i < dailyData.length; i++) {
                 if (dailyData[i].date === midData.date) {
-                    dailyData[i].taMin = midData.taMin;
-                    dailyData[i].taMax = midData.taMax;
+                    dailyData[i].taMin = Math.round(midData.taMin);
+                    dailyData[i].taMax = Math.round(midData.taMax);
                     dailyData[i].wfAm = midData.wfAm;
                     dailyData[i].wfPm = midData.wfPm;
                     dailyData[i].reliability = midData.reliability;

--- a/server/lib/collectTownForecast.js
+++ b/server/lib/collectTownForecast.js
@@ -483,20 +483,20 @@ CollectData.prototype.organizeShortData = function(index, listData){
                 result.mx = parseInt(item.nx[0]);
                 result.my = parseInt(item.ny[0]);
 
-                if(item.category[0] === 'POP') {result.pop = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'PTY') {result.pty = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'R06') {result.r06 = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'REH') {result.reh = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'S06') {result.s06 = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'SKY') {result.sky = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'T3H') {result.t3h = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'TMN') {result.tmn = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'TMX') {result.tmx = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'UUU') {result.uuu = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'VVV') {result.vvv = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'WAV') {result.wav = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'VEC') {result.vec = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'WSD') {result.wsd = parseInt(item.fcstValue[0]);}
+                if(item.category[0] === 'POP') {result.pop = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'PTY') {result.pty = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'R06') {result.r06 = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'REH') {result.reh = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'S06') {result.s06 = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'SKY') {result.sky = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'T3H') {result.t3h = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'TMN') {result.tmn = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'TMX') {result.tmx = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'UUU') {result.uuu = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'VVV') {result.vvv = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'WAV') {result.wav = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'VEC') {result.vec = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'WSD') {result.wsd = parseFloat(item.fcstValue[0]);}
                 else{
                     log.error(new Error('Known property', item.category[0]));
                 }
@@ -562,10 +562,10 @@ CollectData.prototype.organizeShortestData = function(index, listData) {
                 result.mx = parseInt(item.nx[0]);
                 result.my = parseInt(item.ny[0]);
 
-                if(item.category[0] === 'PTY') {result.pty = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'RN1') {result.rn1 = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'SKY') {result.sky = parseInt(item.fcstValue[0]);}
-                else if(item.category[0] === 'LGT') {result.lgt = parseInt(item.fcstValue[0]);}
+                if(item.category[0] === 'PTY') {result.pty = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'RN1') {result.rn1 = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'SKY') {result.sky = parseFloat(item.fcstValue[0]);}
+                else if(item.category[0] === 'LGT') {result.lgt = parseFloat(item.fcstValue[0]);}
                 else{
                     log.error(new Error('Known property '+item.category[0]));
                 }
@@ -638,16 +638,16 @@ CollectData.prototype.organizeCurrentData = function(index, listData) {
                 result.mx = parseInt(item.nx[0]);
                 result.my = parseInt(item.ny[0]);
 
-                if(item.category[0] === 'T1H') {result.t1h = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'RN1') {result.rn1 = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'SKY') {result.sky = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'UUU') {result.uuu = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'VVV') {result.vvv = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'REH') {result.reh = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'PTY') {result.pty = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'LGT') {result.lgt = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'VEC') {result.vec = parseInt(item.obsrValue[0]);}
-                else if(item.category[0] === 'WSD') {result.wsd = parseInt(item.obsrValue[0]);}
+                if(item.category[0] === 'T1H') {result.t1h = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'RN1') {result.rn1 = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'SKY') {result.sky = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'UUU') {result.uuu = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'VVV') {result.vvv = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'REH') {result.reh = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'PTY') {result.pty = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'LGT') {result.lgt = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'VEC') {result.vec = parseFloat(item.obsrValue[0]);}
+                else if(item.category[0] === 'WSD') {result.wsd = parseFloat(item.obsrValue[0]);}
                 else{
                     log.error('organizeCurrentData : Known property', item.category[0]);
                 }
@@ -841,22 +841,22 @@ CollectData.prototype.organizeTempData = function(index, listData, options){
 
             result = template;
             result.regId = item.regId[0];
-            result.taMin3 = parseInt(item.taMin3[0]);
-            result.taMax3 = parseInt(item.taMax3[0]);
-            result.taMin4 = parseInt(item.taMin4[0]);
-            result.taMax4 = parseInt(item.taMax4[0]);
-            result.taMin5 = parseInt(item.taMin5[0]);
-            result.taMax5 = parseInt(item.taMax5[0]);
-            result.taMin6 = parseInt(item.taMin6[0]);
-            result.taMax6 = parseInt(item.taMax6[0]);
-            result.taMin7 = parseInt(item.taMin7[0]);
-            result.taMax7 = parseInt(item.taMax7[0]);
-            result.taMin8 = parseInt(item.taMin8[0]);
-            result.taMax8 = parseInt(item.taMax8[0]);
-            result.taMin9 = parseInt(item.taMin9[0]);
-            result.taMax9 = parseInt(item.taMax9[0]);
-            result.taMin10 = parseInt(item.taMin10[0]);
-            result.taMax10 = parseInt(item.taMax10[0]);
+            result.taMin3 = parseFloat(item.taMin3[0]);
+            result.taMax3 = parseFloat(item.taMax3[0]);
+            result.taMin4 = parseFloat(item.taMin4[0]);
+            result.taMax4 = parseFloat(item.taMax4[0]);
+            result.taMin5 = parseFloat(item.taMin5[0]);
+            result.taMax5 = parseFloat(item.taMax5[0]);
+            result.taMin6 = parseFloat(item.taMin6[0]);
+            result.taMax6 = parseFloat(item.taMax6[0]);
+            result.taMin7 = parseFloat(item.taMin7[0]);
+            result.taMax7 = parseFloat(item.taMax7[0]);
+            result.taMin8 = parseFloat(item.taMin8[0]);
+            result.taMax8 = parseFloat(item.taMax8[0]);
+            result.taMin9 = parseFloat(item.taMin9[0]);
+            result.taMax9 = parseFloat(item.taMax9[0]);
+            result.taMin10 = parseFloat(item.taMin10[0]);
+            result.taMax10 = parseFloat(item.taMax10[0]);
 
             var insertItem = JSON.parse(JSON.stringify(result));
             listResult.push(insertItem);
@@ -955,32 +955,32 @@ CollectData.prototype.organizeSeaData = function(index, listData, options){
             result.wf9 = item.wf9[0];
             result.wf10 = item.wf10[0];
 
-            result.wh3AAm = parseInt(item.wh3AAm[0]);
-            result.wh3APm = parseInt(item.wh3APm[0]);
-            result.wh3BAm = parseInt(item.wh3BAm[0]);
-            result.wh3BPm = parseInt(item.wh3BPm[0]);
-            result.wh4AAm = parseInt(item.wh3AAm[0]);
-            result.wh4APm = parseInt(item.wh3APm[0]);
-            result.wh4BAm = parseInt(item.wh3BAm[0]);
-            result.wh4BPm = parseInt(item.wh3BPm[0]);
-            result.wh5AAm = parseInt(item.wh3AAm[0]);
-            result.wh5APm = parseInt(item.wh3APm[0]);
-            result.wh5BAm = parseInt(item.wh3BAm[0]);
-            result.wh5BPm = parseInt(item.wh3BPm[0]);
-            result.wh6AAm = parseInt(item.wh3AAm[0]);
-            result.wh6APm = parseInt(item.wh3APm[0]);
-            result.wh6BAm = parseInt(item.wh3BAm[0]);
-            result.wh6BPm = parseInt(item.wh3BPm[0]);
-            result.wh7AAm = parseInt(item.wh3AAm[0]);
-            result.wh7APm = parseInt(item.wh3APm[0]);
-            result.wh7BAm = parseInt(item.wh3BAm[0]);
-            result.wh7BPm = parseInt(item.wh3BPm[0]);
-            result.wh8A = parseInt(item.wh8A[0]);
-            result.wh8B = parseInt(item.wh8B[0]);
-            result.wh9A = parseInt(item.wh9A[0]);
-            result.wh9B = parseInt(item.wh9B[0]);
-            result.wh10A = parseInt(item.wh10A[0]);
-            result.wh10B = parseInt(item.wh10B[0]);
+            result.wh3AAm = parseFloat(item.wh3AAm[0]);
+            result.wh3APm = parseFloat(item.wh3APm[0]);
+            result.wh3BAm = parseFloat(item.wh3BAm[0]);
+            result.wh3BPm = parseFloat(item.wh3BPm[0]);
+            result.wh4AAm = parseFloat(item.wh3AAm[0]);
+            result.wh4APm = parseFloat(item.wh3APm[0]);
+            result.wh4BAm = parseFloat(item.wh3BAm[0]);
+            result.wh4BPm = parseFloat(item.wh3BPm[0]);
+            result.wh5AAm = parseFloat(item.wh3AAm[0]);
+            result.wh5APm = parseFloat(item.wh3APm[0]);
+            result.wh5BAm = parseFloat(item.wh3BAm[0]);
+            result.wh5BPm = parseFloat(item.wh3BPm[0]);
+            result.wh6AAm = parseFloat(item.wh3AAm[0]);
+            result.wh6APm = parseFloat(item.wh3APm[0]);
+            result.wh6BAm = parseFloat(item.wh3BAm[0]);
+            result.wh6BPm = parseFloat(item.wh3BPm[0]);
+            result.wh7AAm = parseFloat(item.wh3AAm[0]);
+            result.wh7APm = parseFloat(item.wh3APm[0]);
+            result.wh7BAm = parseFloat(item.wh3BAm[0]);
+            result.wh7BPm = parseFloat(item.wh3BPm[0]);
+            result.wh8A = parseFloat(item.wh8A[0]);
+            result.wh8B = parseFloat(item.wh8B[0]);
+            result.wh9A = parseFloat(item.wh9A[0]);
+            result.wh9B = parseFloat(item.wh9B[0]);
+            result.wh10A = parseFloat(item.wh10A[0]);
+            result.wh10B = parseFloat(item.wh10B[0]);
 
             var insertItem = JSON.parse(JSON.stringify(result));
             listResult.push(insertItem);

--- a/server/test/testControllerTown.js
+++ b/server/test/testControllerTown.js
@@ -1,0 +1,63 @@
+/**
+ * Created by aleckim on 2016. 3. 16..
+ */
+
+var Logger = require('../lib/log');
+global.log  = new Logger(__dirname + "/debug.log");
+
+var assert  = require('assert');
+
+var ControllerTown = require('../controllers/controllerTown');
+var cTown = new ControllerTown();
+
+var ControllerTown24h = require('../controllers/controllerTown24h');
+var cTown24h = new ControllerTown24h();
+
+var controllerManager = require('../controllers/controllerManager');
+global.manager = new controllerManager();
+
+var kmaTimeLib = require('../lib/kmaTimeLib');
+
+describe('unit test - controller town', function() {
+
+    it('test _getShortestTimeValue ', function() {
+        var ret = cTown._getShortestTimeValue(9);
+        var today = kmaTimeLib.convertDateToYYYYMMDD(new Date());
+        assert.equal(ret.date, today, 'Fail get time value');
+    });
+
+    it('test _getCurrentTimeValue', function () {
+        var ret = cTown._getCurrentTimeValue(9);
+        var today = kmaTimeLib.convertDateToYYYYMMDD(new Date());
+        assert.equal(ret.date, today, 'Fail get time value');
+    });
+
+    it('test _min', function () {
+        var min = cTown._min([3,4,6,7], 3);
+        assert.equal(min, 4, 'Fail to get min') ;
+    });
+
+    it('test _max', function () {
+        var min = cTown._max([3,4,6,7], 7);
+        assert.equal(min, 6, 'Fail to get max') ;
+    });
+
+    it('test _sum', function () {
+        var sum = cTown._sum([3,7,10], 10);
+        assert.equal(sum, 10, 'Fail to sum');
+    });
+
+    it('test _average', function () {
+        var avg = cTown._average([10,10, 5], 5);
+        assert.equal(avg, 10, 'Fail to average');
+    });
+
+    it('test _mergeList', function () {
+        var list = [{date:'20160322', a:1, b:2}, {date:'20160808', c:3, d:4}];
+        cTown._mergeList(list, [{date:'20160808', e:5}, {date:'20160909', f:7}]);
+        assert(list, [ { date: '20160322', a: 1, b: 2 },
+                        { date: '20160808', c: 3, d: 4, e: 5 },
+                        { date: '20160909', f: 7 } ], 'Fail to merge list');
+    });
+});
+

--- a/server/test/testKmaTimeLib.js
+++ b/server/test/testKmaTimeLib.js
@@ -1,0 +1,36 @@
+/**
+ * Created by aleckim on 2016. 3. 16..
+ */
+
+var Logger = require('../lib/log');
+global.log  = new Logger(__dirname + "/debug.log");
+
+var assert  = require('assert');
+
+var kmaTimeLib = require('../lib/kmaTimeLib');
+
+
+describe('unit test - kma time lib', function() {
+    it('test convertStringToDate', function() {
+        var date = kmaTimeLib.convertStringToDate('20160316');
+        assert('2016', date.getFullYear(), 'Fail to convert string to date')
+    });
+
+    it('test convertDateToYYYYMMDD', function () {
+        var date = new Date();
+        var yyyymmdd = kmaTimeLib.convertDateToYYYYMMDD(date);
+        var target = ''+ date.getFullYear();
+        target += date.getMonth()+1 < 10 ? '0'+(date.getMonth()+1):date.getMonth()+1;
+        target += date.getDate()<10 ? '0' + date.getDate():date.getDate();
+        assert(yyyymmdd, target, 'Fail to convert date to yyyymmdd');
+    });
+
+    it('test convertDateToHHMM', function () {
+        var date = new Date();
+        var hhmm = kmaTimeLib.convertDateToHHMM(date);
+        var target = date.getHours() < 10 ? '0'+ date.getHours(): ''+date.getHours();
+        target += '00';
+        assert(hhmm, target, 'Fail to convert date to hhmm');
+    });
+});
+


### PR DESCRIPTION
#650 현재 날씨, 바람 소수점까지 표기하기.
provider로부터 데이터를 가지고 올때 정수가 아닌 실수 형태로 저장.
short 에 들어가는 tmn, tmx, t3h는 반올림함.
getCurrent에서 마지막에 t1h를 반올림함.

#557 과거 기입시에 currentList중에 8일이전꺼는 삭제
getPastMid에서 currentList를 필요한 날짜로 필터링 추가.

#168 current로 short생성시에 온도는 평균값이 아닌 해당시간 사용하도록 변경.

etc
shortList에서 현재 request day가 없는 경우에 대하여 예외처리.
과거 데이터 사용할때 overwrite 오류를 해결하기 위해 _createOrGetDaySummaryList 에서 기본값 없애고, taMax taMin는 사용전에 추가하도록 변경.
current, short, mid  merge시에 invalid data에 대하여 제외처리 강화.