### PR TITLE
Fixed #266 move making summary, making string info to backend

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -230,6 +230,7 @@ angular.module('starter', [
 
                 var chart = function () {
                     var data = scope.timeChart;
+                    var currentTime = parseInt(scope.currentWeather.time)/100;
 
                     x.domain(d3.range(data[0].values.length));
                     y.domain([
@@ -321,8 +322,6 @@ angular.module('starter', [
                         .remove();
 
                     // draw current point
-                    var currentTime = new Date();
-
                     var point = lineGroups.selectAll('.point')
                         .data(function(d) {
                             return [d];
@@ -331,8 +330,8 @@ angular.module('starter', [
                             var cx1, cx2;
                             for (var i = 0; i < d.values.length; i = i + 1) {
                                 if (d.values[i].value.day === "오늘") {
-                                    cx1 = i + Math.floor(currentTime.getHours() / 3) - 1;
-                                    cx2 = currentTime.getHours() % 3;
+                                    cx1 = i + Math.floor(currentTime / 3) - 1;
+                                    cx2 = currentTime % 3;
                                     break;
                                 }
                             }
@@ -350,8 +349,8 @@ angular.module('starter', [
                             var cx1, cx2;
                             for (var i = 0; i < d.values.length; i = i + 1) {
                                 if (d.values[i].value.day === "오늘") {
-                                    cx1 = i + Math.floor(currentTime.getHours() / 3) - 1;
-                                    cx2 = currentTime.getHours() % 3;
+                                    cx1 = i + Math.floor(currentTime / 3) - 1;
+                                    cx2 = currentTime % 3;
                                     break;
                                 }
                             }
@@ -365,8 +364,8 @@ angular.module('starter', [
                             var cx1, cx2;
                             for (var i = 0; i < d.values.length; i = i + 1) {
                                 if (d.values[i].value.day === "오늘") {
-                                    cx1 = i + Math.floor(currentTime.getHours() / 3) - 1;
-                                    cx2 = currentTime.getHours() % 3;
+                                    cx1 = i + Math.floor(currentTime / 3) - 1;
+                                    cx2 = currentTime % 3;
                                     break;
                                 }
                             }
@@ -376,8 +375,8 @@ angular.module('starter', [
                             var cx1, cx2;
                             for (var i = 0; i < d.values.length; i = i + 1) {
                                 if (d.values[i].value.day === "오늘") {
-                                    cx1 = i + Math.floor(currentTime.getHours() / 3) - 1;
-                                    cx2 = currentTime.getHours() % 3;
+                                    cx1 = i + Math.floor(currentTime / 3) - 1;
+                                    cx2 = currentTime % 3;
                                     break;
                                 }
                             }

--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -345,8 +345,8 @@ angular.module('starter.services', [])
          * @returns {*}
          */
         function getDayString(day) {
-            var dayString = ["그제", "어제", "오늘", "내일", "모레", "글피"];
-            if (-2 <= day && day <= 3) {
+            var dayString = ["엊그제", "그제", "어제", "오늘", "내일", "모레", "글피"];
+            if (-3 <= day && day <= 3) {
                 return dayString[day + 2];
             }
             console.error("Fail to get day string day=" + day);
@@ -480,87 +480,6 @@ angular.module('starter.services', [])
         }
 
         /**
-         * 어제오늘, 미세먼지(보통이하 일반 단 나쁨이면 높음), 초미세먼지(미세먼지랑 같이 나오지 않음), 강수량/적설량, 자외선, 체감온도
-         * @param {Object} current
-         * @param {Object} yesterday
-         * @returns {String}
-         */
-        function makeSummary(current, yesterday) {
-            var str = "";
-            var stringList = [];
-
-            if (current.t1h !== undefined && yesterday && yesterday.t3h !== undefined) {
-                var diffTemp = current.t1h - yesterday.t3h;
-
-                str = "어제";
-                if (diffTemp == 0) {
-                    str += "와 동일";
-                }
-                else {
-                    str += "보다 " + Math.abs(diffTemp);
-                    if (diffTemp < 0) {
-                        str += "도 낮음";
-                    }
-                    else if (diffTemp > 0) {
-                        str += "도 높음";
-                    }
-                }
-                stringList.push(str);
-            }
-
-            //current.arpltn = {};
-            //current.arpltn.pm10Value = 82;
-            //current.arpltn.pm10Str = "나쁨";
-            //current.arpltn.pm25Value = 82;
-            //current.arpltn.pm25Str = "나쁨";
-            if (current.arpltn && current.arpltn.pm10Value && current.arpltn.pm10Str &&
-                        (current.arpltn.pm10Value > 80 || current.arpltn.pm10Grade > 2)) {
-                stringList.push("미세먼지 " + current.arpltn.pm10Str);
-            }
-            else if (current.arpltn && current.arpltn.pm25Value &&
-                        (current.arpltn.pm25Value > 50 || current.arpltn.pm25Grade > 2)) {
-                stringList.push("초미세먼지 " + current.arpltn.pm25Str);
-            }
-
-            //current.ptyStr = '강수량'
-            //current.rn1Str = '1mm 미만'
-            if (current.rn1Str) {
-                stringList.push(current.ptyStr + " " + current.rn1Str);
-            }
-
-            //current.ultrv = 6;
-            //current.ultrvStr = "높음";
-            if (current.ultrv && current.ultrv >= 6) {
-                stringList.push("자외선 " + current.ultrvStr);
-            }
-
-            //current.sensorytem = -10;
-            //current.sensorytemStr = "관심";
-            //current.wsd = 10;
-            //current.wsdStr = convertKmaWsdToStr(current.wsd);
-            if (current.sensorytem && current.sensorytem <= -10 && current.sensorytem !== current.t1h) {
-                stringList.push("체감온도 " + current.sensorytem +"˚");
-            }
-            else if (current.wsd && current.wsd > 9) {
-                stringList.push("바람이 " + current.wsdStr);
-            }
-
-            if (stringList.length === 1) {
-                //특정 이벤트가 없다면, 미세먼지가 기본으로 추가.
-                if (current.arpltn && current.arpltn.pm10Str && current.arpltn.pm10Value >= 0)  {
-                    stringList.push("미세먼지 " + current.arpltn.pm10Str);
-                }
-            }
-
-            if (stringList.length >= 3) {
-                return stringList[1]+", "+stringList[2];
-            }
-            else {
-               return stringList.toString();
-            }
-        }
-
-        /**
          * It's supporting only korean lang
          * @param {Object[]} results
          * @returns {string}
@@ -629,71 +548,6 @@ angular.module('starter.services', [])
 
             return deferred.promise;
         }
-
-        function convertKmaPtyToStr(pty) {
-           if (pty === 1 || pty ===2) {
-               return "강수량";
-           }
-            else if (pty === 3) {
-               return "적설량";
-           }
-        }
-
-        /**
-         *
-         * @param pty
-         * @param rXX
-         * @returns {*}
-         */
-        function convertKmaRxxToStr(pty, rXX) {
-            if (pty === 1 || pty === 2) {
-                switch(rXX) {
-                    case 0: return "0mm";
-                    case 1: return "1mm 미만";
-                    case 5: return "1~4mm";
-                    case 10: return "5~9mm";
-                    case 20: return "10~19mm";
-                    case 40: return "20~39mm";
-                    case 70: return "40~69mm";
-                    case 100: return "70mm 이상";
-                    default : console.log('unknown data='+rXX);
-                }
-                /* spec에 없지만 2로 오는 경우가 있었음 related to #347 */
-                if (0 < rXX || rXX < 100) {
-                    return rXX+"mm 미만";
-                }
-            }
-            else if (pty === 3) {
-                switch (rXX) {
-                    case 0: return "0cm";
-                    case 1: return "1cm 미만";
-                    case 5: return "1~4cm";
-                    case 10: return "5~9cm";
-                    case 20: return "10~19cm";
-                    case 100: return "20cm 이상";
-                    default : console.log('unknown data='+rXX);
-                }
-                /* spec에 없지만 2로 오는 경우가 있었음 */
-                if (0 < rXX || rXX < 100) {
-                    return rXX+"cm 미만";
-                }
-            }
-        }
-
-        function convertKmaWsdToStr(wsd) {
-            if (wsd < 4) {
-                return '약함';
-            }
-            else if(wsd < 9) {
-                return '약간강함';
-            }
-            else if(wsd < 14) {
-                return '강함';
-            }
-            else {
-                return '매우강함';
-            }
-        }
         //endregion
 
         //region APIs
@@ -705,10 +559,9 @@ angular.module('starter.services', [])
          *          sky: Number, t1h: Number, time: String, uuu: Number, vec: Number, vvv: Number,
          *          wsd: Number}
          * @param {Object} currentTownWeather
-         * @param shortList
          * @returns {{}}
          */
-        obj.parseCurrentTownWeather = function (currentTownWeather, shortList) {
+        obj.parseCurrentTownWeather = function (currentTownWeather) {
             var currentForecast = {};
             var time;
             var isNight;
@@ -721,29 +574,6 @@ angular.module('starter.services', [])
             currentForecast.time = time;
             currentForecast = currentTownWeather;
 
-            //related to #379
-            if (currentForecast.t1h === -50) {
-                //set near data of short
-                for(var i = 0; i < shortList.length; i++) {
-                    var short = shortList[i];
-                    if (short.date === currentForecast.date) {
-                        if (short.time === currentForecast.time) {
-                            currentForecast.t1h = short.t3h;
-                            console.log('set t1h to ' + short.t3h + ' of short t3h');
-                            break;
-                        }
-                        if (short.time > currentForecast.time) {
-                            currentForecast.t1h = shortList[i-1].t3h;
-                            console.log('set t1h to ' + shortList[i-1].t3h + ' of short time='+ shortList[i-1].time);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            currentForecast.wsdStr = convertKmaWsdToStr(currentForecast.wsd);
-            currentForecast.ptyStr = convertKmaPtyToStr(currentForecast.pty);
-            currentForecast.rn1Str = convertKmaRxxToStr(currentForecast.pty, currentForecast.rn1);
             currentForecast.skyIcon = parseSkyState(currentTownWeather.sky, currentTownWeather.pty,
                 currentTownWeather.lgt, isNight);
 
@@ -751,71 +581,21 @@ angular.module('starter.services', [])
         };
 
         /**
-         *
-         * @param shortForecastList
-         * @param currentTime
-         * @returns {Array}
-         */
-        obj.parsePreShortTownWeather = function (shortForecastList, currentTime) {
-            // {date: String, sky: String, tmx: Number, tmn: Number, reh: Number}
-            var dailyTemp = [];
-            if (!shortForecastList || !Array.isArray(shortForecastList)) {
-               return dailyTemp;
-            }
-
-            shortForecastList.forEach(function (shortForecast) {
-                var dayInfo = getDayInfo(dailyTemp, shortForecast.date);
-                if (!dayInfo) {
-                    var data = {date: shortForecast.date, skyIcon: "Sun", tmx: null, tmn: null, pop: 0, reh: 0};
-                    dailyTemp.push(data);
-                    dayInfo = dailyTemp[dailyTemp.length - 1];
-                    dayInfo.skyIcon = parseSkyState(shortForecast.sky, shortForecast.pty, shortForecast.lgt, false);
-                }
-
-                var diffDays = getDiffDays(convertStringToDate(dayInfo.date), currentTime);
-                if (diffDays == 0) {
-                    dayInfo.week = "오늘";
-                }
-                else {
-                    dayInfo.week = dayToString(convertStringToDate(dayInfo.date).getDay());
-                }
-
-                if (shortForecast.tmx !== -50) {
-                    dayInfo.tmx = shortForecast.tmx;
-                }
-                if (shortForecast.tmn !== -50) {
-                    dayInfo.tmn = shortForecast.tmn;
-                }
-
-                if (shortForecast.pty > 0) {
-                    dayInfo.skyIcon = parseSkyState(shortForecast.sky, shortForecast.pty, shortForecast.lgt, false);
-                }
-                dayInfo.pop = shortForecast.pop > dayInfo.pop ? shortForecast.pop : dayInfo.pop;
-                dayInfo.reh = shortForecast.reh > dayInfo.reh ? shortForecast.reh : dayInfo.reh;
-            });
-
-            console.log(dailyTemp);
-            return dailyTemp;
-        };
-
-        /**
-         * r06 6시간 강수량, s06 6시간 신적설, Sensorytem 체감온도, 부패, 동상가능, 열, 불쾌, 동파가능, 대기확산
          * @param {Object[]} shortForecastList
          * @param {Date} currentForecast
          * @param {Date} current
-         * @param {Object[]} dailyInfoList
+         * @param {Object[]} midData.dailyData
          * @returns {{timeTable: Array, timeChart: Array}}
          */
         obj.parseShortTownWeather = function (shortForecastList, currentForecast, current, dailyInfoList) {
             var data = [];
-            var prevT3H;
 
             if (!shortForecastList || !Array.isArray(shortForecastList)) {
                 return {timeTable: [], timeChart: []};
             }
 
             shortForecastList.every(function (shortForecast, index) {
-                var tempObject = {};
+                var tempObject;
                 var time = parseInt(shortForecast.time.slice(0, -2));
                 var diffDays = getDiffDays(convertStringToDate(shortForecast.date), current);
                 var day = "";
@@ -826,68 +606,13 @@ angular.module('starter.services', [])
                 var dayInfo = getDayInfo(dailyInfoList, shortForecast.date);
                 if (!dayInfo) {
                     console.log("Fail to find dayInfo date=" + shortForecast.date);
-                    dayInfo = {date: shortForecast.date, tmx: 100, tmn: -49};
+                    dayInfo = {date: shortForecast.date, taMax: 100, taMin: -49};
                 }
 
-                //It means invalid data
-                if (!shortForecast.pop && !shortForecast.sky && !shortForecast.pty && !shortForecast.reh && !shortForecast.t3h) {
-                    tempObject.pop = undefined;
-                    tempObject.pty = undefined;
-                    tempObject.r06 = undefined;
-                    tempObject.reh = undefined;
-                    tempObject.s06 = undefined;
-                    tempObject.sky = undefined;
-                    tempObject.t3h = undefined;
-                    tempObject.tmx = undefined;
-                    tempObject.tmn = undefined;
-                    tempObject.uuu = undefined;
-                    tempObject.vvv = undefined;
-                    tempObject.wav = undefined;
-                    tempObject.vec = undefined;
-                    tempObject.wsd = undefined;
-                    tempObject.skyIcon = "Sun";
-                    tempObject.tempIcon = "Temp-01";
-                    //past condition from current
-                    tempObject.rn1 = undefined;
-                    tempObject.lgt = undefined;
-                    tempObject.wsd = undefined;
-                    tempObject.vec = undefined;
+                tempObject = shortForecast;
 
-                    //related to #402
-                    if (prevT3H) {
-                        tempObject.t3h = prevT3H;
-                    }
-                }
-                else {
-                    tempObject = shortForecast;
-
-                    //related to #379
-                    if (tempObject.t3h === -50) {
-                        console.log('t3h is invalid');
-                        tempObject.t3h = prevT3H;
-                    }
-                    else {
-                        prevT3H = tempObject.t3h;
-                    }
-
-                    if (tempObject.pty === 1 || tempObject.pty === 2) {
-
-                        tempObject.ptyStr = convertKmaPtyToStr(shortForecast.pty);
-                        tempObject.rnsStr = convertKmaRxxToStr(shortForecast.pty, shortForecast.r06);
-                    }
-                    else if (tempObject.pty === 3) {
-                        tempObject.ptyStr = convertKmaPtyToStr(shortForecast.pty);
-                        tempObject.rnsStr = convertKmaRxxToStr(shortForecast.pty, shortForecast.s06);
-                    }
-                    else {
-                        tempObject.rnsStr = undefined;
-                    }
-
-                    tempObject.wsdStr = convertKmaWsdToStr(shortForecast.wsd);
-
-                    tempObject.skyIcon = parseSkyState(shortForecast.sky, shortForecast.pty, shortForecast.lgt, isNight);
-                    tempObject.tempIcon = decideTempIcon(shortForecast.t3h, dayInfo.tmx, dayInfo.tmn);
-                }
+                tempObject.skyIcon = parseSkyState(shortForecast.sky, shortForecast.pty, shortForecast.lgt, isNight);
+                tempObject.tempIcon = decideTempIcon(shortForecast.t3h, dayInfo.taMax, dayInfo.taMin);
 
                 tempObject.day = day;
                 tempObject.time = time + "시";
@@ -918,25 +643,21 @@ angular.module('starter.services', [])
         /**
          * 식중독, ultra 자외선,
          * @param midData
-         * @param dailyInfoList
          * @param currentTime
-         * @param currentWeather
          * @returns {Array}
          */
-        obj.parseMidTownWeather = function (midData, dailyInfoList, currentTime, currentWeather) {
+        obj.parseMidTownWeather = function (midData, currentTime) {
             var tmpDayTable = [];
 
             if (!midData || !midData.hasOwnProperty('dailyData') || !Array.isArray(midData.dailyData)) {
                 return tmpDayTable;
             }
             midData.dailyData.forEach(function (dayInfo) {
-                var data = {};
-                data.date = dayInfo.date;
+                var data;
+                data = dayInfo;
 
                 var diffDays = getDiffDays(convertStringToDate(data.date), currentTime);
-                if (diffDays < -7 || diffDays > 10) {
-                    return;
-                }
+
                 if (diffDays == 0) {
                     data.week = "오늘";
                 }
@@ -947,34 +668,15 @@ angular.module('starter.services', [])
                 var skyAm = convertMidSkyString(dayInfo.wfAm);
                 var skyPm = convertMidSkyString(dayInfo.wfPm);
                 data.skyIcon = getHighPrioritySky(skyAm, skyPm);
-                if (diffDays === 0) {
-                    data.tmx = currentWeather.t1h>dayInfo.taMax?currentWeather.t1h:dayInfo.taMax;
-                    data.tmn = currentWeather.t1h<dayInfo.taMin?currentWeather.t1h:dayInfo.taMin;
-                }
-                else {
-                    data.tmx = dayInfo.taMax;
-                    data.tmn = dayInfo.taMin;
-                }
 
-                if (dayInfo.reh !== undefined) {
-                    data.reh = dayInfo.reh;
-                }
-                if (dayInfo.pop !== undefined && dayInfo.pop !== -1) {
-                   data.pop = dayInfo.pop;
-                }
+                data.tmx = dayInfo.taMax;
+                data.tmn = dayInfo.taMin;
 
                 if (data.reh !== undefined) {
                     data.humidityIcon = decideHumidityIcon(data.reh);
                 }
                 else {
                     data.humidityIcon = "Humidity-00";
-                }
-
-                if (dayInfo.rn1 !== undefined && dayInfo.rn1 !== -1) {
-                    data.rn1 = dayInfo.rn1;
-                }
-                if (dayInfo.pty !== undefined && dayInfo.pty !== -1) {
-                    data.pty = dayInfo.pty;
                 }
 
                 tmpDayTable.push(data);
@@ -1352,26 +1054,19 @@ angular.module('starter.services', [])
                 }
             });
 
-            var currentForecast = that.parseCurrentTownWeather(weatherData.current, weatherData.short);
-            var dailyInfoArray = that.parsePreShortTownWeather(weatherData.short, currentTime);
+            var currentForecast = that.parseCurrentTownWeather(weatherData.current);
 
             /**
-             * parseShortWeather에서 currentForcast에 체감온도를 추가 함, scope에 적용전에 parseShortTownWeather를 해야 함
              * @type {{name, value}|{timeTable, timeChart}|{timeTable: Array, timeChart: Array}}
              */
-            var shortTownWeather = that.parseShortTownWeather(weatherData.short, currentForecast, currentTime, dailyInfoArray);
+            var shortTownWeather = that.parseShortTownWeather(weatherData.short, currentForecast, currentTime, weatherData.midData.dailyData);
             console.log(shortTownWeather);
 
             /**
-             * parseMidTownWeather에서 currentForecast에 자외선지수를 추가 함
              * @type {Array}
              */
-            var midTownWeather = that.parseMidTownWeather(weatherData.midData, dailyInfoArray, currentTime, currentForecast);
+            var midTownWeather = that.parseMidTownWeather(weatherData.midData, currentTime);
             console.log(midTownWeather);
-
-            //0~3시 사이를 위해 그저께 24시(index 8)부터 비교함.
-            var yesterdayIndex = parseInt(parseInt(currentForecast.time)/100/3) + 8;
-            currentForecast.summary = makeSummary(currentForecast, weatherData.short[yesterdayIndex]);
 
             data.currentWeather = currentForecast;
             data.timeTable = shortTownWeather.timeTable;

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -563,10 +563,11 @@ Manager.prototype.saveShortest = function(newData, callback){
 
             list.forEach(function(dbShortestList){
                 //log.info('ST> coord :', dbShortestList.mCoord.mx, dbShortestList.mCoord.my);
-                if (self.saveOnlyLastOne) {
-                    dbShortestList.shortestData = newData;
-                }
-                else {
+                //if (self.saveOnlyLastOne) {
+                //    dbShortestList.shortestData = newData;
+                //}
+                //else
+                {
                     newData.forEach(function(newItem){
                         var isNew = 1;
                         //log.info('ST> newItem : ', newItem);
@@ -1831,23 +1832,16 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
     log.verbose('check time and request task');
 
     if (time === 1 || putAll) {
-        log.info('push short rss');
+        log.info('push past');
         self.asyncTasks.push(function (callback) {
-            self._requestApi("shortrss", callback);
-        });
-
-        log.info('push mid rss');
-        self.asyncTasks.push(function (callback) {
-            self._requestApi("midrss", callback);
+            self._requestApi("past", callback);
         });
 
         log.info('push life index');
         self.asyncTasks.push(function (callback) {
             self._requestApi("lifeindex", callback);
         });
-    }
 
-    if (time === 2 || putAll) {
         log.info('push mid temp');
         self.asyncTasks.push(function (callback) {
             self._requestApi("midtemp", callback);
@@ -1864,12 +1858,15 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         self.asyncTasks.push(function (callback) {
             self._requestApi("midsea", callback);
         });
-    }
 
-    if (time === 10 || putAll) {
-        log.info('push past');
+        log.info('push mid rss');
         self.asyncTasks.push(function (callback) {
-            self._requestApi("past", callback);
+            self._requestApi("midrss", callback);
+        });
+
+        log.info('push short rss');
+        self.asyncTasks.push(function (callback) {
+            self._requestApi("shortrss", callback);
         });
     }
 
@@ -1881,21 +1878,20 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         });
     }
 
-    if (time === 31 || putAll) {
-        log.info('push short');
-        self.asyncTasks.push(function (callback) {
-            self._requestApi("short", callback);
-        });
-    }
-
     if (time === 35 || putAll) {
         log.info('push shortest');
         self.asyncTasks.push(function (callback) {
             self._requestApi("shortest", callback);
         });
+
         log.info('push current');
         self.asyncTasks.push(function (callback) {
             self._requestApi("current", callback);
+        });
+
+        log.info('push short');
+        self.asyncTasks.push(function (callback) {
+            self._requestApi("short", callback);
         });
     }
 

--- a/server/controllers/kecoController.js
+++ b/server/controllers/kecoController.js
@@ -104,8 +104,6 @@ arpltnController._mregeData = function(current, arpltnDataList, callback){
         log.silly(JSON.stringify(arpltnData));
 
         current.arpltn = arpltnData.arpltn;
-        current.arpltn.pm10Str = self.parsePm10Info(arpltnData.arpltn.pm10Value, arpltnData.arpltn.pm10Grade);
-        current.arpltn.pm25Str = self.parsePm25Info(arpltnData.arpltn.pm25Value, arpltnData.arpltn.pm25Grade);
         return callback(err, arpltnData);
     }
     catch(e) {
@@ -256,8 +254,6 @@ arpltnController._appendFromKeco = function(town, current, callback) {
         //never mind about save
         var tempTown = { "first" : town.first, "second" : town.second, "third" : town.third};
         var mCoord = {mx: town.mCoord.mx, my:town.mCoord.my};
-        arpltn.pm10Str = self.parsePm10Info(arpltn.pm10Value, arpltn.pm10Grade);
-        arpltn.pm25Str = self.parsePm25Info(arpltn.pm25Value, arpltn.pm25Grade);
 
         keco.saveArpltnTown({town: tempTown, mCoord: mCoord}, arpltn, function (err) {
             if (err) {

--- a/server/controllers/lifeIndexKmaController.js
+++ b/server/controllers/lifeIndexKmaController.js
@@ -10,7 +10,7 @@ function LifeIndexKmaController() {
 
 }
 
-LifeIndexKmaController._fsnStr = function (grade) {
+LifeIndexKmaController.fsnStr = function (grade) {
     switch(grade) {
         case 0: return "관심";
         case 1: return "주의";
@@ -35,7 +35,7 @@ LifeIndexKmaController._fsnGrade = function (value) {
     }
 };
 
-LifeIndexKmaController._ultrvStr = function (grade) {
+LifeIndexKmaController.ultrvStr = function (grade) {
     switch(grade) {
         case 0: return "낮음";
         case 1: return "보통";
@@ -103,11 +103,9 @@ LifeIndexKmaController._addIndexDataToList = function(destList, srcList, indexNa
             //add grade
             if (indexName === 'fsn') {
                 (destList[j])['fsnGrade'] = this._fsnGrade(srcList[i].value);
-                (destList[j])['fsnStr'] = this._fsnStr((destList[j])['fsnGrade']);
             }
             else if (indexName === 'ultrv') {
                 (destList[j])['ultrvGrade'] = this._ultrvGrade(srcList[i].value);
-                (destList[j])['ultrvStr'] = this._ultrvStr((destList[j])['ultrvGrade']);
             }
         }
         return true;

--- a/server/routes/v000705/routeTownForecast.js
+++ b/server/routes/v000705/routeTownForecast.js
@@ -43,25 +43,34 @@ router.get('/', [cTown.getSummary], function(req, res) {
 router.get('/:region', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
                         cTown.getCurrent, cTown.adjustShort, cTown.getKeco, cTown.getMid,
                         cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
-                        cTown.mergeByShortest, cTown.sendResult]);
+                        cTown.mergeByShortest,  cTown.getLifeIndexKma, cTown.insertStrForData,
+                            cTown.getSummary, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
                                 cTown.getCurrent, cTown.adjustShort, cTown.getKeco, cTown.getMid,
                                 cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
-                                cTown.mergeByShortest, cTown.sendResult]);
+                                cTown.mergeByShortest, cTown.getLifeIndexKma, cTown.insertStrForData,
+                                cTown.getSummary, cTown.sendResult]);
 
+/**
+ * getCurrent가는 getShortest, getShort보다 앞에 올 수 없음.
+ * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
+ */
 router.get('/:region/:city/:town', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
                                     cTown.getCurrent, cTown.adjustShort, cTown.getKeco, cTown.getMid,
                                     cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
-                                    cTown.mergeByShortest, cTown.getLifeIndexKma, cTown.sendResult]);
+                                    cTown.mergeByShortest, cTown.getLifeIndexKma, cTown.insertStrForData,
+                                        cTown.getSummary, cTown.sendResult]);
 
 router.get('/:region/:city/:town/mid', [cTown.getMid, cTown.getMidRss, cTown.getPastMid,
-                                    cTown.mergeMidWithShort, cTown.sendResult]);
+                                            cTown.mergeMidWithShort, cTown.insertStrForData, cTown.sendResult]);
 
-router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTown.adjustShort, cTown.sendResult]);
+router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTown.adjustShort,
+                                            cTown.insertStrForData, cTown.sendResult]);
 
-router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.sendResult]);
+router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.insertStrForData, cTown.sendResult]);
 
-router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKeco, cTown.sendResult]);
+router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKeco, cTown.insertStrForData,
+                                                cTown.getSummary, cTown.sendResult]);
 
 module.exports = router;


### PR DESCRIPTION
frontend
chart에서 현재 포인트 시간을 currentWeather에서 가지고 오게 수정.
엊그제 추가 - 에러 방지용.
makeSummary(), convertKmaPtyToStr(), convertKmaRxxToStr(), convertKmaWsdToStr() 서버로 이동.
parseCurrent, parseShort, parseMid에서 보정하던 code 제거.
parsePreShort 제거.
backend
controllerTown.getSummary, controllerTown.insertStrForData 추가. -> client 부분 넘어옴.
shortest 3일치 저장하게 수정. -> current  데이터 없는 경우 보정용.
short내의 tmx,tmn을 소수점 1자리로 제한.
gathering time 단일화. 1, 20, 35

related issue #379