### PR TITLE
widget을 위해서, midData에 기본 property 추가

### DIFF
--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -1230,6 +1230,21 @@ function ControllerTown() {
         if (req.midData.pubDate == undefined) {
             req.midData.pubDate = req.midData.tempPubDate;
         }
+        if (req.midData.province == undefined) {
+           req.midData.province = '';
+        }
+        if (req.midData.city == undefined) {
+            req.midData.city = '';
+        }
+        if (req.midData.stnId == undefined) {
+            req.midData.stnId = '';
+        }
+        if (req.midData.regId == undefined) {
+            req.midData.regId = '';
+        }
+        if (req.midData.pubDate == undefined) {
+            req.midData.pubDate = '';
+        }
 
         res.json(result);
 

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -1227,11 +1227,14 @@ function ControllerTown() {
         if(req.midData){
             result.midData = req.midData;
         }
+        if (req.midData.pubDate == undefined) {
+            req.midData.pubDate = req.midData.tempPubDate;
+        }
 
         res.json(result);
 
         return this;
-    }
+    };
 }
 
 /**

--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -228,6 +228,54 @@ function ControllerTown24h() {
         return this;
     };
 
+    this.sendResult = function (req, res) {
+        var meta = {};
+
+        var result = {};
+        var regionName = req.params.region;
+        var cityName = req.params.city;
+        var townName = req.params.town;
+
+        meta.method = '/:region/:city/:town';
+        meta.region = regionName;
+        meta.city = cityName;
+        meta.town = townName;
+
+        log.info('##', decodeURI(req.originalUrl));
+
+        result.regionName = regionName;
+        result.cityName = cityName;
+        result.townName = townName;
+
+        if(req.shortPubDate) {
+            result.shortPubDate = req.shortPubDate;
+        }
+        if(req.shortRssPubDate) {
+            result.shortRssPubDate = req.shortRssPubDate;
+        }
+        if(req.short){
+            result.short = req.short;
+        }
+        if (req.shortestPubDate) {
+            result.shortestPubDate = req.shortestPubDate;
+        }
+        if(req.shortest){
+            result.shortest = req.shortest;
+        }
+        if(req.currentPubDate) {
+            result.currentPubDate = req.currentPubDate;
+        }
+        if(req.current){
+            result.current = req.current;
+        }
+        if(req.midData){
+            result.midData = req.midData;
+        }
+
+        res.json(result);
+
+        return this;
+    };
 }
 
 // subclass extends superclass


### PR DESCRIPTION
#741
sendResult를 overriding하고 v000001에서는 midData.pubDate를 생성해주어 기존 버전 호환성유지.

#575
weather info가 필요한 만큼 넘어가도, 그외에 체크하는 데이터들은 모두 보내주어야 한다.
