### PR TITLE
gather aws data at 5mins

### DIFF
--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1883,14 +1883,10 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         self.asyncTasks.push(function (callback) {
             self._requestApi("shortrss", callback);
         });
-
-        log.info('push kma stn hourly');
-        self.asyncTasks.push(function (callback) {
-            self._requestApi('kmaStnHourly', callback);
-        });
     }
 
     if (time === 5) {
+        //related issue #754 aws is not updated at correct time
         log.info('push kma stn hourly');
         self.asyncTasks.push(function (callback) {
             self._requestApi('kmaStnHourly', callback);


### PR DESCRIPTION
#754
정각이 지나면 데이터 갱신 없이 기상실황표 시간만 변경됨.
aws update는 5분에 함.