### PR TITLE
#619 즐겨찾기된 도시로 바로 이동가능한 url path 설정

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -188,6 +188,8 @@ angular.module('starter', [
         $ionicConfigProvider.tabs.style('standard');
         $ionicConfigProvider.tabs.position('bottom');
 
+        $ionicConfigProvider.views.transition("android");
+
         // Enable Native Scrolling on Android
         $ionicConfigProvider.platform.android.scrolling.jsScrolling(false);
     })


### PR DESCRIPTION
#619 즐겨찾기된 도시로 바로 이동가능한 url path 설정
* ios(chrome의 iphone)에서 "tab/forecast?fav=0"로 페이지 이동 시 배경이 검은색으로 표시되는 문제 수정
 - ionic.css에 nav-view-transition이 ios이고 nav-view-direction가 forward/back인 경우에 background를 검은색으로 처리하는 부분이 있음
 - view transition 시 animation style을 android로 항상 처리되도록 함