### PR TITLE
kma stn hourly data 한개만 저장하는 것에 대한 에러 수정.

### DIFF
--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -95,18 +95,21 @@ controllerKmaStnWeather._getStnHourlyList = function (stnList, dateTime, callbac
                log.warn('It does not have any data stnName=', stnInfo.stnName);
                return mCallback();
            }
-           if ((new Date(stnWeatherList[0].pubDate)).getTime() < (new Date(dateTime)).getTime()) {
-               log.warn('It was not updated yet pubDate=',stnWeatherList[0].pubDate,' stnName=', stnInfo.stnName);
-               return mCallback();
-           }
 
-           var hourlyData;
-           for (var i=stnWeatherList[0].hourlyData.length-1; i>=0; i--) {
-               if (stnWeatherList[0].hourlyData[i].date === dateTime) {
-                   hourlyData = stnWeatherList[0].hourlyData[i];
-                   break;
-               }
-           }
+           //if ((new Date(stnWeatherList[0].pubDate)).getTime() < (new Date(dateTime)).getTime()) {
+           //    log.warn('It was not updated yet pubDate=',stnWeatherList[0].pubDate,' stnName=', stnInfo.stnName);
+           //    return mCallback();
+           //}
+
+           var hourlyData = stnWeatherList[0].hourlyData[0];
+
+           //for (var i=stnWeatherList[0].hourlyData.length-1; i>=0; i--) {
+           //    if (stnWeatherList[0].hourlyData[i].date === dateTime) {
+           //        hourlyData = stnWeatherList[0].hourlyData[i];
+           //        break;
+           //    }
+           //}
+
            if (hourlyData == undefined) {
                log.error('It does not have data pubDate=', dateTime, ' stnName=', stnInfo.stnName);
                return mCallback();

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1885,7 +1885,7 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         });
     }
 
-    if (time === 6 || time === 10 || putAll) {
+    if (time === 3 || time === 6 || time === 9 || putAll) {
         //related issue #754 aws is not updated at correct time
         //overwrite
         log.info('push kma stn hourly');

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -838,7 +838,6 @@ function ControllerTown() {
                 }
 
                 var now = new Date();
-                now.setMinutes(now.getMinutes()-5);
                 now = kmaTimeLib.toTimeZone(9, now);
 
                 var date = kmaTimeLib.convertDateToYYYYMMDD(now);


### PR DESCRIPTION
#754 #796

routing시에 시간 비교하는 부분 code out
routing시에 매시간 5분이전에는 한시간 전시간 데이터로 가지고 오는 부분 codeout
3,6,9분에 kmaStnHourly data가져옴.