### PR TITLE
set overlay web view of status bar to true

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -51,7 +51,6 @@ angular.module('starter', [
 
             }
             if (window.StatusBar) {
-                StatusBar.overlaysWebView(false);
                 StatusBar.backgroundColorByHexString('#0288D1');
             }
         });


### PR DESCRIPTION
#857
광고가 있는 경우와 없는 경우 margin동작 오류로 일단 true로 변경함.
이 변경으로 ios에서 날씨와 설정 탭에서 상태바 컬러가 나오지 않음. - 추후 계선 예정.