### PR TITLE
aws 데이터의 오류 체크

### DIFF
--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -96,10 +96,10 @@ controllerKmaStnWeather._getStnHourlyList = function (stnList, dateTime, callbac
                return mCallback();
            }
 
-           //if ((new Date(stnWeatherList[0].pubDate)).getTime() < (new Date(dateTime)).getTime()) {
-           //    log.warn('It was not updated yet pubDate=',stnWeatherList[0].pubDate,' stnName=', stnInfo.stnName);
-           //    return mCallback();
-           //}
+           if ((new Date(stnWeatherList[0].pubDate)).getTime()+3600000 < (new Date(dateTime)).getTime()) {
+               log.warn('It was not updated yet pubDate=',stnWeatherList[0].pubDate,' stnName=', stnInfo.stnName);
+               return mCallback();
+           }
 
            var hourlyData = stnWeatherList[0].hourlyData[0];
 
@@ -181,7 +181,7 @@ controllerKmaStnWeather.getStnHourly = function (townInfo, dateTime, callback) {
             return cb(new Error('Fail to make stn Weather info town='+JSON.stringify(townInfo)));
         }
         else {
-            mergedStnWeather.stnDateTime = stnDateTime;
+            mergedStnWeather.stnDateTime = stnHourWeatherList[0].date;
         }
         cb(undefined, mergedStnWeather);
     }], function (err, result) {

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -887,12 +887,20 @@ function ControllerTown() {
                     }
 
                     var stnHourlyFirst = true;
-                    if (req.current.time === time) {
-                        log.verbose('use api first, just append new data of stn hourly weather info');
+                    var stnWeatherInfoTime = stnWeatherInfo.stnDateTime.substr(11,2);
+                    var currentTime = req.current.time.substr(0,2);
+
+                    if (Number(currentTime) >= Number(stnWeatherInfoTime)) {
+                        log.info('use api first, just append new data of stn hourly weather info');
                         stnHourlyFirst = false;
                     }
                     else {
-                        log.verbose('overwrite all data');
+                        log.info('overwrite all data');
+                    }
+
+                    if (stnWeatherInfo.t1h === 0 && stnWeatherInfo.vec === 0 && stnWeatherInfo.wsd === 0) {
+                        log.error('stnWeatherInfo is invalid!');
+                        stnHourlyFirst = false;
                     }
 
                     for (var key in stnWeatherInfo) {


### PR DESCRIPTION
#872
t1h, vec, wsd, vec1 모두가 0이면 오류로 보고 저장안함.
getCityWeather에서 stnId 생성하도록 개선.
aws와 city weather를 merge할때, stnId로 비교하게 수정.
aws에 city weather가 없는 경우 추가해도록 개선.
저장된 aws weather info는 한 시간 전까지 사용하도록 변경.