### PR TITLE
#798 daum api가 에러나서, google에 geolocation을 요청하면 무조건 에러가 발생

### DIFF
--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -999,6 +999,7 @@ angular.module('starter.services', [])
                     var address = findDongAddressFromGoogleGeoCodeResults(data.results);
                     if (!address || address.length === 0) {
                         deferred.reject(new Error("Fail to find dong address from " + data.results[0].formatted_address));
+                        return;
                     }
                     console.log(address);
                     deferred.resolve(address);


### PR DESCRIPTION
#798 daum api가 에러나서, google에 geolocation을 요청하면 무조건 에러가 발생
* 재현되지 않아 코드 상 오류만 수정
* promise reject 후에 return 문 추가하여 resolve 처리되지 않도록 함