### PR TITLE
오동작 수정.

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -201,21 +201,21 @@ $font-family-base: "Bareun Dotum Pro", sans-serif !default;
   fill: #ffffff;
 }
 
-.detail-image {
-  height: 100%;
-  display: table;
-}
+//.detail-image {
+//  height: 100%;
+//  display: table;
+//}
 
-.detail-image div {
-  display: table-cell;
-  vertical-align: middle;
-}
+//.detail-image div {
+//  display: table-cell;
+//  vertical-align: middle;
+//}
 
-.detail-image div img {
-  width: 40px;
-  margin: 0 auto;
-  display: block;
-}
+//.detail-image div img {
+//  width: 40px;
+//  margin: 0 auto;
+//  display: block;
+//}
 
 //.detail-text {
 //  display: table;
@@ -233,14 +233,20 @@ $font-family-base: "Bareun Dotum Pro", sans-serif !default;
 //  margin: 0;
 //}
 
-.detail-item {
-  background-color: transparent;
-  color: inherit;
-  margin-left: 0;
-  margin-right: 0;
-  padding: 0;
-  height: 80px;
+//.detail-item {
+//  background-color: transparent;
+//  color: inherit;
+//  margin-left: 0;
+//  margin-right: 0;
+//  padding: 0;
+//  height: 80px;
+//}
+
+.detail-item-p {
+  margin: auto 0 auto 8px;
+  width: 200px
 }
+
 
 .main-content {
   width: 100%;

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -95,6 +95,7 @@ angular.module('starter.controllers', [])
 
             var padding = 1;
             var smallPadding = 1;
+            console.log("UA:"+ionic.Platform.ua);
             console.log("Height:" + window.innerHeight + ", Width:" + window.innerWidth + ", PixelRatio:" + window.devicePixelRatio);
             console.log("OuterHeight:" + window.outerHeight + ", OuterWidth:" + window.outerWidth);
 
@@ -181,7 +182,7 @@ angular.module('starter.controllers', [])
             }
             str += shortenAddress+'</p>';
             str += '<div class="row row-no-padding"> <div id="weatherInfo" style="margin: auto"> <div class="row row-no-padding">';
-            str +=      '<p id="pBigDigit" style="font-size: '+bigDigitSize+'px; margin: 0; font-weight:300">'+cityData.currentWeather.t1h;
+            str +=      '<p id="pBigDigit" style="font-size: '+bigDigitSize+'px; margin: 0; font-weight:300">'+Math.round(cityData.currentWeather.t1h);
             str +=      '<span style="font-size: '+bigDigitSize/2+'px;vertical-align: super;">˚</span></p>';
             str +=      '<div style="text-align: left; margin: auto">';
             //str +=          '<img id="imgBigTempPointSize" style="height: '+bigTempPointSize+'px; width: '+bigTempPointSize+'px" src="img/reddot.png">';
@@ -211,14 +212,14 @@ angular.module('starter.controllers', [])
             var rsf = 0;
 
             if (r06 != undefined && r06 > 0) {
-                frcst = r06;
+                frcst = r06>=10?Math.round(r06):r06;
             }
             else if (r06 != undefined && s06 > 0) {
-                frcst = s06;
+                frcst = s06>=10?Math.round(s06):s06;
             }
 
             if (rn1 != undefined && rn1 > 0) {
-                rsf = rn1;
+                rsf = rn1>=10?Math.round(rn1):rn1;
             }
 
             if (rn1 != undefined && rn1 > 0) {
@@ -360,7 +361,6 @@ angular.module('starter.controllers', [])
             var i;
             var value;
             var str = '';
-            var currentIndex = -1;
 
             str += '<div class="row row-no-padding"> <div style="width: '+colWidth/2+'px;"></div>';
             for (i=0; i<cityData.dayTable.length; i++) {
@@ -376,15 +376,6 @@ angular.module('starter.controllers', [])
 
             str += '<div class="row row-no-padding" style="border-bottom : 1px solid rgba(254,254,254,0.5);">';
             for (i=0; i<cityData.timeTable.length; i++) {
-                if (cityData.currentWeather.date == cityData.timeTable[i].date && cityData.currentWeather.time >= cityData.timeTable[i].time) {
-                    if (i == cityData.timeTable.length-1) {
-                        currentIndex = i+1;
-                    }
-                    else if (cityData.currentWeather.time < cityData.timeTable[i+1].time) {
-                        currentIndex = i+1;
-                    }
-                }
-
                 value = cityData.timeTable[i];
                 str += '<div class="col table-items" style="text-align: center;">';
                 if (value.time == 24) {
@@ -401,11 +392,11 @@ angular.module('starter.controllers', [])
             str += '<div style="width: '+colWidth/2+'px;"></div>';
             for (i=1; i<cityData.timeTable.length; i++) {
                 value = cityData.timeTable[i];
-                if (i == currentIndex) {
-                    str += '<div class="col table-items table-border" style="background-color: #039BE5;">';
+                if (value.currentIndex) {
+                    str += '<div class="col table-items table-border" style="background-color: #039BE5; width:auto;">';
                 }
                 else {
-                    str += '<div class="col table-items table-border">';
+                    str += '<div class="col table-items table-border" style="width:auto;">';
                 }
                 str += '<img width='+smallImageSize+'px height='+smallImageSize+'px style="margin: auto" src="'+Util.imgPath+'/'+ value.skyIcon+'.png">';
                 str += '</div>';
@@ -417,11 +408,11 @@ angular.module('starter.controllers', [])
             str += '<div style="width: '+colWidth/2+'px;"></div>';
             for (i=1; i<cityData.timeTable.length; i++) {
                 value = cityData.timeTable[i];
-                if (i == currentIndex) {
-                    str += '<div class="col table-items table-border" style="background-color: #039BE5;">';
+                if (value.currentIndex) {
+                    str += '<div class="col table-items table-border" style="background-color: #039BE5; width: auto">';
                 }
                 else {
-                    str += '<div class="col table-items table-border">';
+                    str += '<div class="col table-items table-border" style="width: auto">';
                 }
                 if (value.pop) {
                     str += '<p class="subheading" style="letter-spacing:0; margin: auto">'+
@@ -517,9 +508,11 @@ angular.module('starter.controllers', [])
                         Util.imgPath+'/'+value.skyPm+'.png">';
                 }
 
-                if (value.pop != undefined && value.pop > 0) {
-                    tmpStr = value.pop == undefined?'-':value.pop+'<small>%</small>';
-                    str += '<p class="body1" style="margin: auto">'+tmpStr+'</p>';
+                if (value.fromToday >= 0) {
+                    if (value.pop != undefined && value.pop > 0) {
+                        tmpStr = value.pop == undefined?'-':value.pop+'<small>%</small>';
+                        str += '<p class="body1" style="margin: auto">'+tmpStr+'</p>';
+                    }
                 }
 
                 str += '<p class="caption" style="margin: auto; letter-spacing: 0;">';

--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -691,7 +691,7 @@ angular.module('starter.services', [])
 
         /**
          * @param {Object[]} shortForecastList
-         * @param {Date} currentForecast
+         * @param {Object} currentForecast
          * @param {Date} current
          * @param {Object[]} dailyInfoList midData.dailyData
          * @returns {{timeTable: Array, timeChart: Array}}
@@ -702,6 +702,8 @@ angular.module('starter.services', [])
             if (!shortForecastList || !Array.isArray(shortForecastList)) {
                 return {timeTable: [], timeChart: []};
             }
+
+            var currentIndex = -1;
 
             shortForecastList.every(function (shortForecast, index) {
                 var tempObject;
@@ -726,6 +728,24 @@ angular.module('starter.services', [])
                 tempObject.day = day;
                 tempObject.time = time;
                 tempObject.timeStr = time + "시";
+
+                if (currentForecast.date == tempObject.date && currentForecast.time >= tempObject.time) {
+                    if (index == shortForecastList.length-1) {
+                        currentIndex = index;
+                        tempObject.currentIndex = true;
+                    }
+                    else {
+                        var nextTime = parseInt(shortForecastList[index+1].time.slice(0, -2));
+                        if (currentForecast.time < nextTime) {
+                            currentIndex = index;
+                            /**
+                             * chart는 기준 index부터 뒤로 rect를 그리고, table은 기준값 기준으로 앞으로 데이터를 선정하기 때문에 선택된 index에 한칸으로 가야 함
+                             */
+                            shortForecastList[index+1].currentIndex = true;
+                        }
+                    }
+                }
+
                 data.push(tempObject);
 
                 return true;
@@ -743,7 +763,8 @@ angular.module('starter.services', [])
                     name: "today",
                     values: data.slice(8).map(function (d) {
                         return {name: "today", value: d};
-                    })
+                    }),
+                    currentIndex: currentIndex - 8
                 }
             ];
 

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -69,7 +69,7 @@
                            <div class="row" style="margin: auto;">
                                <div style="margin: 0 auto; min-width: 120px" ng-if="$index == 6 || $index == 7 || $index == 8" ng-repeat="day in dayChart[0].values">
                                    <div class="row" style="margin: 0">
-                                       <a class="icon ion-calendar" style="color: white; margin: 0 12px"> {{convertMMDD(day.date)}} {{day.fromTodayStr}}</a>
+                                       <a class="icon ion-calendar" style="color: white; margin: 0 12px; min-width: 90px"> {{convertMMDD(day.date)}} {{day.fromTodayStr}}</a>
                                    </div>
                                    <div class="row" style="margin: 0" ng-if="day.reh">
                                        <img ng-src="img/Humidity-{{day.reh?day.reh - day.reh%10:'00'}}.png" style="height: 24px; margin: auto 0;">

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -59,43 +59,43 @@
                     <hr style="margin: 0; border: 0; border-top:1px solid rgba(255,255,255,0.6);">
                     <p class="caption" style="margin: 5px 5px 0 5px; letter-spacing: 5px">상세날씨</p>
                     <div class="row row-no-padding">
-                        <div style="margin: 0 auto">
+                        <div style="margin: 0 auto;">
                             <div class="row subheading">
                                 <img src="img/Temp-05.png" style="height: 24px;">
-                                <p style="margin: auto 8px;">{{diffTodayYesterday()}}</p>
+                                <p class="detail-item-p">{{diffTodayYesterday()}}</p>
                             </div>
                             <div class="row subheading">
                                 <img ng-src="img/Humidity-{{currentWeather.reh?currentWeather.reh - currentWeather.reh%10:'00'}}.png"
                                      style="height: 24px;">
-                                <p style="margin: auto 8px;">습도 {{currentWeather.reh}}<small>%</small></p>
+                                <p class="detail-item-p">습도 {{currentWeather.reh}}<small>%</small></p>
                             </div>
                             <div class="row subheading">
                                 <img src="img/wind-and-cloud.svg" style="height: 20px; margin: 0 2px">
-                                <p style="margin: auto 8px">바람 {{currentWeather.wdd}} {{currentWeather.wsd}}<small>m/s</small></p>
+                                <p class="detail-item-p">바람 {{currentWeather.wdd}} {{currentWeather.wsd}}<small>m/s</small></p>
                             </div>
                             <div class="row subheading">
                                 <img src="img/ic_visibility_white_24px.svg" style="height: 24px">
-                                <p style="margin: auto 8px">가시거리 {{currentWeather.visibility}}<small>km</small></p>
+                                <p class="detail-item-p">가시거리 {{currentWeather.visibility}}<small>km</small></p>
                             </div>
                             <div class="row subheading">
                                 <img src="img/ic_vertical_align_bottom_white_24px.svg" style="height: 24px">
-                                <p style="margin: auto 8px">기압 {{currentWeather.hPa}}<small>hPa</small></p>
+                                <p class="detail-item-p">기압 {{currentWeather.hPa}}<small>hPa</small></p>
                             </div>
                             <div class="row subheading" ng-if="currentWeather.dspls && currentWeather.dspls > 60">
                                 <img src="img/angry.svg" style="height: 20px; margin: 0 2px">
-                                <p style="margin: auto 8px">불쾌지수 {{currentWeather.dsplsStr}}<span class="caption">({{currentWeather.dspls}})</span></p>
+                                <p class="detail-item-p">불쾌지수 {{currentWeather.dsplsStr}}<span class="caption">({{currentWeather.dspls}})</span></p>
                             </div>
                             <div class="row subheading" ng-if="currentWeather.sensorytem">
                                 <img src="img/ic_person_outline_white_24px.svg" style="height: 24px">
-                                <p style="margin: auto 8px">체감온도 {{currentWeather.sensorytem}}˚</p>
+                                <p class="detail-item-p">체감온도 {{currentWeather.sensorytem}}˚</p>
                             </div>
                             <div class="row subheading" ng-if="currentWeather.weather">
                                 <img ng-src="{{::imgPath}}/{{currentWeather.skyIcon}}.png" style="height: 24px">
-                                <p style="margin: auto 8px">날씨 {{currentWeather.weather}}</p>
+                                <p class="detail-item-p">날씨 {{currentWeather.weather}}</p>
                             </div>
                             <div class="row subheading" ng-if="currentWeather.rn1">
                                 <img src="img/glass-with-water.svg" style="height: 20px; margin: 0 2px">
-                                <p style="margin: auto 8px">강수량 {{currentWeather.rn1}}<small>mm</small></p>
+                                <p class="detail-item-p">강수량 {{currentWeather.rn1}}<small>mm</small></p>
                             </div>
                         </div>
                     </div>
@@ -104,7 +104,7 @@
                     <div style="width: 100%">
                         <p class="caption" style="margin: 5px 5px 0 5px; letter-spacing: 5px">상세대기정보</p>
                         <div class="row" style="padding-top: 0">
-                            <div style="margin: auto">
+                            <div style="margin: auto; min-width: 220px">
                                 <div class="subheading" ng-class="getGradeColor(currentWeather.arpltn.khaiGrade)" style="padding: 2px">
                                     CAI <img ng-src="img/{{getSentimentIcon(currentWeather.arpltn.khaiGrade)}}" style="height: 24px; vertical-align: middle">
                                     {{currentWeather.arpltn.khaiStr}}<span class="caption" style="letter-spacing: 0"


### PR DESCRIPTION
#786
android 4.4.x에서 상세날씨의 레이아웃 맞지 않는 문제 수정.
currentIndex나 currentTime 변경시에 현재위치 배경 박스와 현재시간 아이콘, 온도 색깔 업데이트 안되는 문제 수정.
들어오는 데이터 중에 정수로 표시해야 할 내용들 정수로 변경.
search cache is disabled (cache on시에 도시 추가가 갱신 안됨)
iphone4, iphone5 등 좁은 width를 위해 강수량 10이상일 경우 정수로 변경.
일별날씨에서 오늘부터 미래만 강수확률 표시로 변경.