### PR TITLE
getKmaStnHourlyWeather에 의해 받은 온도를 short에 잘 못 overwrite되는 문제.

### DIFF
--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -1009,11 +1009,11 @@ function ControllerTown() {
                                         req.short[i].tmn = req.current.t1h;
                                         log.info('stn hourly weather update tmn to ', req.current.t1h);
                                     }
-                                }
-                                if (req.short[i].time === req.current.time) {
-                                    req.short[i].t3h = req.current.t1h;
-                                }
 
+                                    if (req.short[i].time === req.current.time) {
+                                        req.short[i].t3h = req.current.t1h;
+                                    }
+                                }
                                 if (req.short[i].date > req.current.date) {
                                     break;
                                 }


### PR DESCRIPTION
#949
시간 체크 코드가 날짜 체크 코드 밖에 있어서 발생한 문제로 안으로 넣음.