### PR TITLE
AWS 온도가 너무 차이나는 케이스

### DIFF
--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -700,7 +700,7 @@ function ControllerTown() {
                 var date = kmaTimeLib.convertDateToYYYYMMDD(now);
                 var time = kmaTimeLib.convertDateToHHMM(now);
                 log.info(date+time);
-                controllerKmaStnWeather.getStnHourly(townInfo, date+time, function (err, stnWeatherInfo) {
+                controllerKmaStnWeather.getStnHourly(townInfo, date+time, req.current.t1h, function (err, stnWeatherInfo) {
                     if (err) {
                         log.error(err);
                         next();


### PR DESCRIPTION
#977
산간에 있는 측정소 등이 근접하면 발생하는 문제.
다음 측정소보다 온도차가 더 크면 사용하지 않음
단 도시별날씨의 측정소의 경우 조건없이 적용.