### PR TITLE
#982 앱 시작시에 도시목록의 데이터를 모두 받아야 로딩이 끝나는 방법 개선. 

### DIFF
--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -4,8 +4,7 @@ angular.module('starter.services', [])
         var cities = [];
         var cityIndex = -1;
         var obj = {
-            towns: [],
-            isLoadComplete: false
+            towns: []
         };
 
         var createCity = function (item) {
@@ -285,30 +284,6 @@ angular.module('starter.services', [])
         obj.saveCities = function() {
             localStorage.setItem("cities", JSON.stringify(cities));
             this._saveCitiesPreference(cities);
-        };
-
-        obj.updateCities = function(index) {
-            var that = this;
-            var city = cities[index];
-
-            if (city === undefined) {
-                $ionicPlatform.ready(function() {
-                    that.isLoadComplete = true;
-                    $rootScope.$broadcast('loadCompleteEvent');
-                });
-                return;
-            }
-
-            if (that.canLoadCity(index) && !city.currentPosition) {
-                WeatherUtil.getWeatherInfo(city.address, that.towns).then(function (weatherDatas) {
-                    var city = WeatherUtil.convertWeatherData(weatherDatas);
-                    that.updateCity(index, city);
-                }).finally(function () {
-                    that.updateCities(index + 1);
-                });
-            } else {
-                that.updateCities(index + 1);
-            }
         };
 
         obj.loadTowns = function() {
@@ -1350,5 +1325,4 @@ angular.module('starter.services', [])
     .run(function(WeatherInfo) {
         WeatherInfo.loadCities();
         WeatherInfo.loadTowns();
-        WeatherInfo.updateCities(0);
     });


### PR DESCRIPTION
#982 앱 시작시에 도시목록의 데이터를 모두 받아야 로딩이 끝나는 방법 개선.
* 앱 시작 시에 도시 목록의 데이터를 모두 업데이트 하는 코드 제거
 - WeatherInfo의 run 시에 updateCities 호출하지 않음
 - 사용되지 않는 updateCities, isLoadComplete, loadCompleteEvent 제거
* ForecastCtrl 실행 시에 현재 도시에 대한 데이터를 요청하여 업데이트됨
* SearchCtrl 실행 시에 도시 목록을 모두 업데이트 요청함
 - 검색 화면인 경우에는 도시 목록의 날씨 정보 업데이트 처리
 - 업데이트 중에 도시 목록이 변경될 수 있으므로 현재 도시 목록에서 도시를 찾아서 업데이트함