### PR TITLE
#926 설정에 가이드 가는 경우, 현재위치 선택창 제거.

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -733,6 +733,7 @@ angular.module('starter', [
         $stateProvider
             .state('guide', {
                 url: '/guide',
+                cache: false,
                 templateUrl: 'templates/guide.html',
                 controller: 'GuideCtrl'
             })


### PR DESCRIPTION
#926 설정에 가이드 가는 경우, 현재위치 선택창 제거.
* 재현 경로 : 처음 설치 시에 guide 페이지 show(guideVersion = null) -> close(localStorage에 저장) -> 설정에서 다시 guide 페이지 show 하면 cache되어 있어 init 함수가 호출되지 않음(guideVersion = null)
* guide 페이지는 cache 하지 않도록 설정 변경