### PR TITLE
3,6,9에서 현재위치를 뒤 영역으로 표시되게 수정.

### DIFF
--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -684,7 +684,7 @@ angular.module('starter.services', [])
                 tempObject.timeStr = time + "시";
 
                 if (currentForecast.date == tempObject.date && currentForecast.time == tempObject.time) {
-                    currentIndex = index-1;
+                    currentIndex = index;
                     shortForecastList[index].currentIndex = true;
                 }
                 else if (currentForecast.date == tempObject.date && currentForecast.time > tempObject.time) {


### PR DESCRIPTION
#786 #957
#957 에서 데이터 자체가 과거이므로 앞영역으로 변경하였으나.
데이터는 데이터이고 사용자가 생각하는 시간적 흐름상 뒤에게 맞고,
측정소를 활용한 실시간 날씨 정도의 경우, 정각 이후에는 넘어가야 하므로, 뒤로 보냄.