### PR TITLE
release version 0.9.4

### DIFF
--- a/client/config.xml
+++ b/client/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="net.wizardfactory.todayweather" version="0.9.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="net.wizardfactory.todayweather" version="0.9.4" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>TodayWeather</name>
     <description>
         Inform how warm or cold it is today than yesterday.

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TodayWeather",
-  "version": "0.9.1",
+  "version": "0.9.4",
   "description": "TodayWeather: Inform how warm or cold it is today than yesterday.",
   "repository": {
     "type": "git",

--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -1322,7 +1322,7 @@ angular.module('starter.services', [])
         //endregion
 
         obj.imgPath = 'img/weatherIcon2-color';
-        obj.version = '0.9.1'; // sync with config.xml
+        obj.version = '0.9.4'; // sync with config.xml
         obj.guideVersion = 1.0;
         obj.admobIOSBannerAdUnit = '';
         obj.admobIOSInterstitialAdUnit = '';


### PR DESCRIPTION
0.9.4
자정부터 3시까지 발생하는 차트 오류 수정.
0.9.3
일부폰에서 미세먼지 정보를 스크롤하지 않고 볼 수 있게 개선.
앱실행시에 날씨정보 갱신 안되는 문제 수정.
습도 100% 오류 수정.
설정에 가이드 가는 경우 간헐적으로 선택창뜨는 문제 수정.
도시가 하나밖에 없는 경우 좌우 버튼 나오지 않게 개선.
즐겨찾기된 도시가 많은 경우 앱 실행시 오래 걸리는 문제 개선.
도시 검색하여 시간별날씨로 넘어올때 날씨 정보 다시 받는 문제 수정.
초미세먼지 정보가 없는 경우 -1로 나오는 문제 수정.
일별날씨는 이틀전부터 표시되게 수정.
일부 안드로이드 폰에서 현재위치 정보 못 가지고 오는 문제 개선.
시간별,일별날씨정보 차트 일체화 시켜 UI개선 - iphone4에서 차트랑 날씨정보 칸 안맞는 문제 수정.