### PR TITLE
653 997 kma aws minute

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -419,7 +419,11 @@ angular.module('starter', [
                             })
                             .attr('cx', function (d) {
                                 var cx = getCx(currentTime, d.values);
-                                return x.rangeBand() * (cx.cx1 + cx.cx2 / 3) + x.rangeBand() / 2;
+                                var x1 = cx.cx1 + cx.cx2 / 3;
+                                if (scope.currentWeather.liveTime && currentTime+'00' != scope.currentWeather.liveTime) {
+                                    x1 += 1 / 6;
+                                }
+                                return x.rangeBand() * x1 + x.rangeBand() / 2;
                             })
                             .attr('cy', height);
 
@@ -433,26 +437,39 @@ angular.module('starter', [
                             })
                             .attr('cx', function (d) {
                                 var cx = getCx(currentTime, d.values);
-                                return x.rangeBand() * (cx.cx1 + cx.cx2 / 3) + x.rangeBand() / 2;
+                                var x1 = cx.cx1 + cx.cx2 / 3;
+                                if (scope.currentWeather.liveTime && currentTime+'00' != scope.currentWeather.liveTime) {
+                                    x1 += 1 / 6;
+                                }
+                                return x.rangeBand() * x1 + x.rangeBand() / 2;
                             })
                             .attr('cy', height);
 
                         point.attr('cx', function (d) {
                             var cx = getCx(currentTime, d.values);
-                            return x.rangeBand() * (cx.cx1 + cx.cx2 / 3) + x.rangeBand() / 2;
+                            var x1 = cx.cx1 + cx.cx2 / 3;
+                            if (scope.currentWeather.liveTime && currentTime+'00' != scope.currentWeather.liveTime) {
+                                x1 += 1 / 6;
+                            }
+                            return x.rangeBand() * x1 + x.rangeBand() / 2;
                         })
                             .attr('cy', function (d) {
                                 var cx = getCx(currentTime, d.values);
                                 var cy1 = d.values[cx.cx1].value.t3h;
                                 var cy2 = d.values[cx.cx1+1].value.t3h;
 
+                                var y1;
                                 if (cx.cx2 === 1) {
-                                    return y(cy1 + (cy2 - cy1) / 3);
+                                    y1 = cy1 + (cy2 - cy1) / 3;
                                 }
                                 else if (cx.cx2 === 2) {
-                                    return y(cy1 + (cy2 - cy1) / 3 * 2);
+                                    y1 = cy1 + (cy2 - cy1) / 3 * 2;
                                 }
-                                return y(cy1);
+
+                                if (scope.currentWeather.liveTime && currentTime+'00' != scope.currentWeather.liveTime) {
+                                    y1 += (cy2-cy1)/6;
+                                }
+                                return y(y1);
                             });
 
                         point.exit()

--- a/server/app.js
+++ b/server/app.js
@@ -85,10 +85,12 @@ global.townRss = new controllerShortRss();
 if (config.mode === 'gather' || config.mode === 'local') {
     manager.startManager();
 
-    var ControllerPush = require('./controllers/controllerPush');
-    var co = new ControllerPush();
-    co.start();
-    co.apnFeedback();
+    if (config.mode === 'gather') {
+        var ControllerPush = require('./controllers/controllerPush');
+        var co = new ControllerPush();
+        co.start();
+        co.apnFeedback();
+    }
 }
 
 // catch 404 and forward to error handler

--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -187,13 +187,12 @@ controllerKmaStnWeather.getStnHourly = function (townInfo, dateTime, t1h, callba
         var coords = [townInfo.gCoord.lon, townInfo.gCoord.lat];
         async.parallel([function (pCallback) {
             //#997 이슈로 방안 마련까지, 도시날씨만 사용한다.
-            //KmaStnInfo.find({geo: {$near:coords, $maxDistance: 0.3}}).limit(5).lean().exec(function (err, kmaStnList) {
-            //    if (err) {
-            //        return pCallback(err);
-            //    }
-            //    return pCallback(err, kmaStnList);
-            //});
-            return pCallback(undefined, []);
+            KmaStnInfo.find({geo: {$near:coords, $maxDistance: 0.3}}).limit(5).lean().exec(function (err, kmaStnList) {
+                if (err) {
+                    return pCallback(err);
+                }
+                return pCallback(err, kmaStnList);
+            });
         }, function (pCallback) {
             KmaStnInfo.find({geo: {$near:coords, $maxDistance: 0.3}, isCityWeather: true}).limit(1).lean().exec(function (err, kmaStnList) {
                 if (err) {

--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -283,7 +283,6 @@ controllerKmaStnWeather.getStnHourly = function (townInfo, dateTime, t1h, callba
     async.waterfall([function (cb) {
         var coords = [townInfo.gCoord.lon, townInfo.gCoord.lat];
         async.parallel([function (pCallback) {
-            //#997 이슈로 방안 마련까지, 도시날씨만 사용한다.
             KmaStnInfo.find({geo: {$near:coords, $maxDistance: 0.3}}).limit(5).lean().exec(function (err, kmaStnList) {
                 if (err) {
                     return pCallback(err);
@@ -329,6 +328,14 @@ controllerKmaStnWeather.getStnHourly = function (townInfo, dateTime, t1h, callba
     return this;
 };
 
+/**
+ * 매분 날씨 정보를 가지고 옴.
+ * @param townInfo
+ * @param dateTime
+ * @param t1h
+ * @param callback
+ * @returns {controllerKmaStnWeather}
+ */
 controllerKmaStnWeather.getStnMinute = function (townInfo, dateTime, t1h, callback) {
     var self = this;
 

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1998,6 +1998,13 @@ Manager.prototype.startManager = function(){
         setInterval(function() {
             self.checkTimeAndRequestTask(false) ;
         }, 1000*60);
+
+        setInterval(function () {
+            log.info('request kma stn minute');
+            self._requestApi('kmaStnMinute', function () {
+                log.info('response kma stn minute');
+            });
+        }, 1000*60);
     });
 
     return this;

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -21,7 +21,7 @@ var modelMidSea = require('../models/modelMidSea');
 var modelMidTemp = require('../models/modelMidTemp');
 
 var midRssKmaRequester = new (require('../lib/midRssKmaRequester'))();
-var PastConditionGather = require('../lib/PastConditionGather');
+//var PastConditionGather = require('../lib/PastConditionGather');
 var keco = new (require('../lib/kecoRequester.js'))();
 var taskKmaIndexService = new (require('../lib/lifeIndexKmaRequester'))();
 
@@ -1919,6 +1919,13 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         });
     }
 
+    if(time === 50) {
+        log.info('push short');
+        self.asyncTasks.push(function (callback) {
+            self._requestApi("updateStnRnsHitRate", callback);
+        });
+    }
+
     //if(time === 50 || putAll){
     //    log.info('push invalidateCloudFront');
     //    self.asyncTasks.push(function(callback){
@@ -1926,7 +1933,7 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
     //    })
     //}
 
-    if (self.asyncTasks.length <= 16) {
+    if (self.asyncTasks.length <= 17) {
         log.debug('wait '+self.asyncTasks.length+' tasks');
     }
     else {
@@ -2004,7 +2011,7 @@ Manager.prototype.startManager = function(){
             self._requestApi('kmaStnMinute', function () {
                 log.info('response kma stn minute');
             });
-        }, 1000*60);
+        }, 1000*30);
     });
 
     return this;

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -775,7 +775,7 @@ function ControllerTown() {
                 now = kmaTimeLib.toTimeZone(9, now);
 
                 var date = kmaTimeLib.convertDateToYYYYMMDD(now);
-                var time = kmaTimeLib.convertDateToHHMM(now);
+                var time = kmaTimeLib.convertDateToHHZZ(now);
                 log.info(date+time);
                 controllerKmaStnWeather.getStnHourly(townInfo, date+time, req.current.t1h, function (err, stnWeatherInfo) {
                     if (err) {

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -840,7 +840,8 @@ function ControllerTown() {
     };
 
     /**
-     * req.current에만 적용하고 currentlist에서 적용안함.
+     * req.current에만 적용하고 currentlist에는 적용안함.
+     * req.current에 liveTime이라고 새로운 시간 정보를 추가함.
      * @param req
      * @param res
      * @param next
@@ -891,6 +892,7 @@ function ControllerTown() {
                         req.current[key] = stnWeatherInfo[key];
                     }
 
+                    //24시 01분부터 1시까지 날짜 맞지 않음.
                     //req.current.date = date;
                     req.current.liveTime = stnWeatherInfo.stnDateTime.substr(11, 5).replace(":","");
 

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -812,40 +812,6 @@ function ControllerTown() {
 
                     if (stnHourlyFirst) {
                         req.current.overwrite = true;
-                        if (req.current.rns === true) {
-                            if (req.current.pty === 0) {
-                                log.info('change pty to rain or snow by get Kma Stn Hourly Weather town=' +
-                                    req.params.region + req.params.city + req.params.town);
-
-                                //대충 잡은 값임. 추후 최적화 필요함.
-                                if (req.current.t1h > 2) {
-                                    req.current.pty = 1;
-                                }
-                                else if (req.current.t1h > -1) {
-                                    req.current.pty = 2;
-                                }
-                                else {
-                                    req.current.pty = 3;
-                                }
-                                if (req.current.sky === 1) {
-                                    req.current.sky = 2;
-                                }
-                            }
-                            req.current.rn1 = req.current.rs1h;
-                            if (req.current.rn1 > 10) {
-                                req.current.rn1 = Math.round(req.current.rn1);
-                            }
-                            else {
-                                req.current.rn1 = +(req.current.rn1).toFixed(1);
-                            }
-                        }
-                        else {
-                            if (req.current.pty != 0) {
-                                log.info('change pty to zero by get Kma Stn Hourly Weather town=' +
-                                    req.params.region + req.params.city + req.params.town);
-                                req.current.pty = 0;
-                            }
-                        }
                     }
 
                     //update currentList of req.
@@ -855,7 +821,7 @@ function ControllerTown() {
                             req.currentList[req.currentList.length-1] = req.current;
                         }
                         else {
-                            req.currentList.push(Object.create(req.current));
+                            req.currentList.push(JSON.parse(JSON.stringify(req.current)));
                         }
                     }
 
@@ -873,6 +839,110 @@ function ControllerTown() {
 
     };
 
+    /**
+     * req.current에만 적용하고 currentlist에서 적용안함.
+     * @param req
+     * @param res
+     * @param next
+     */
+    this.getKmaStnMinuteWeather = function (req, res, next) {
+        var meta = {};
+        meta.method = 'getKmaStnMinuteWeather';
+        meta.region = req.params.region;
+        meta.city = req.params.city;
+        meta.town = req.params.town;
+        log.info('>', meta);
+
+        if (!req.current)  {
+            req.current={};
+            var nowDate = self._getCurrentTimeValue(+9);
+            req.current.time = nowDate.time;
+            req.current.date = nowDate.date;
+        }
+
+        try {
+            self._getTownInfo(req.params.region, req.params.city, req.params.town, function (err, townInfo) {
+                if (err) {
+                    log.error(err);
+                    next();
+                    return;
+                }
+
+                var now = new Date();
+                now = kmaTimeLib.toTimeZone(9, now);
+
+                var date = kmaTimeLib.convertDateToYYYYMMDD(now);
+                var time = kmaTimeLib.convertDateToHHMM(now);
+                log.info(date+time);
+                controllerKmaStnWeather.getStnMinute(townInfo, date+time, req.current.t1h, function (err, stnWeatherInfo) {
+                    if (err) {
+                        log.error(err);
+                        next();
+                        return;
+                    }
+
+                    if (stnWeatherInfo.t1h === 0 && stnWeatherInfo.vec === 0 && stnWeatherInfo.wsd === 0) {
+                        log.error('stnWeatherInfo is invalid!');
+                        next();
+                        return;
+                    }
+
+                    for (var key in stnWeatherInfo) {
+                        req.current[key] = stnWeatherInfo[key];
+                    }
+
+                    //req.current.date = date;
+                    req.current.liveTime = stnWeatherInfo.stnDateTime.substr(11, 5).replace(":","");
+
+                    req.current.overwrite = true;
+                    if (req.current.rns === true) {
+                        if (req.current.pty === 0) {
+                            log.info('change pty to rain or snow by get Kma Stn Hourly Weather town=' +
+                                req.params.region + req.params.city + req.params.town);
+
+                            //온도에 따라 눈/비 구분.. 대충 잡은 값임. 추후 최적화 필요함.
+                            if (req.current.t1h > 2) {
+                                req.current.pty = 1;
+                            }
+                            else if (req.current.t1h > -1) {
+                                req.current.pty = 2;
+                            }
+                            else {
+                                req.current.pty = 3;
+                            }
+                            if (req.current.sky === 1) {
+                                req.current.sky = 2;
+                            }
+                        }
+                        req.current.rn1 = req.current.rs1h;
+                        if (req.current.rn1 > 10) {
+                            req.current.rn1 = Math.round(req.current.rn1);
+                        }
+                        else {
+                            req.current.rn1 = +(req.current.rn1).toFixed(1);
+                        }
+                    }
+                    else if (req.current.rns === false) {
+                        if (req.current.pty != 0) {
+                            log.info('change pty to zero by get Kma Stn Hourly Weather town=' +
+                                req.params.region + req.params.city + req.params.town);
+                            req.current.pty = 0;
+                        }
+                    }
+                    else {
+                        log.debug('we did not get rns info');
+                    }
+                    next();
+                });
+            });
+        }
+        catch(e) {
+            if (e) {
+                log.warn(e);
+            }
+            next();
+        }
+    };
     /**
      *
      * @param req
@@ -2103,7 +2173,7 @@ ControllerTown.prototype._getShortestTimeValue = function(gmt) {
 /**
  *
  * @param gmt
- * @returns {{date: *, time: string}}
+ * @returns {{date: string, time: string}}
  */
 ControllerTown.prototype._getCurrentTimeValue = function(gmt) {
     var timeFunction = manager;
@@ -2111,6 +2181,21 @@ ControllerTown.prototype._getCurrentTimeValue = function(gmt) {
     return {
         date: currentDate.slice(0, 8),
         time: currentDate.slice(8, 10) + '00'
+    };
+};
+
+/**
+ * 분까지 전달.
+ * @param gmt
+ * @returns {{date: *, time: *}}
+ * @private
+ */
+ControllerTown.prototype._getCurrentTimeMinuteValue = function(gmt) {
+    var timeFunction = manager;
+    var currentDate = timeFunction.getWorldTime(gmt);
+    return {
+        date: currentDate.slice(0, 8),
+        time: currentDate.slice(8, 12)
     };
 };
 

--- a/server/lib/kmaScraper.js
+++ b/server/lib/kmaScraper.js
@@ -16,7 +16,11 @@ var KmaStnHourly = require('../models/modelKmaStnHourly');
 var KmaStnMinute = require('../models/modelKmaStnMinute');
 var KmaStnInfo = require('../models/modelKmaStnInfo');
 
+var Current = require('../models/modelCurrent');
+var Town = require('../models/town');
+
 var convertGeocode = require('../utils/convertGeocode');
+var convert = require('../utils/coordinate2xy');
 
 /**
  *
@@ -557,12 +561,22 @@ KmaScraper.prototype._saveStnMinute = function (stnWeatherInfo, pubDate, callbac
         }
         else {
             kmaStnMinute = stnMinuteList[0];
+            /**
+             * 가끔씩 이전 시간의 데이터가 들어옴. 38mins->39mins->38mins
+             */
+            if ((new Date(kmaStnMinute.pubDate)).getTime() >= (new Date(pubDate)).getTime()) {
+                //log.info('already latest data');
+                return callback(err, {stnId:stnWeatherInfo.stnId, pubDate: pubDate});
+            }
+
             kmaStnMinute.pubDate = pubDate;
         }
 
         kmaStnMinute.minuteData.push(self._makeDailyData(pubDate, stnWeatherInfo));
-        if (kmaStnMinute.minuteData.length > 60) {
-            kmaStnMinute.minuteData.shift();
+        //2h 저장함. current data로 hitRate계산시 필요함.
+        if (kmaStnMinute.minuteData.length > 120) {
+            var index = kmaStnMinute.minuteData.length - 120;
+            kmaStnMinute.minuteData = kmaStnMinute.minuteData.slice(index, kmaStnMinute.minuteData.length);
         }
 
         kmaStnMinute.save(function () {
@@ -734,6 +748,10 @@ KmaScraper.prototype._mergeAWSandCity = function(awsList, cityList) {
     return awsList;
 };
 
+/**
+ *
+ * @param callback
+ */
 KmaScraper.prototype.getStnMinuteWeather = function (callback) {
     var self = this;
     log.info('get stn every minute weather');
@@ -825,7 +843,318 @@ KmaScraper.prototype.getStnHourlyWeather = function (callback) {
         }
         callback(err, results);
     });
+};
 
+/**
+ * 임시책이고, modelCurrents를 towns로 업데이트 하는 것이 아니라, 자체 list를 가지고 하도록 해야 할듯함.
+ * @param mOriCoord
+ * @param callback
+ * @private
+ */
+KmaScraper.prototype._findCurrent = function(mOriCoord, callback) {
+   var mCoordList = [];
+
+    mCoordList.push(mOriCoord);
+    //mCoordList.push({mx:mOriCoord.mx+1, my:mOriCoord.my});
+    //mCoordList.push({mx:mOriCoord.mx-1, my:mOriCoord.my});
+    //mCoordList.push({mx:mOriCoord.mx, my:mOriCoord.my+1});
+    //mCoordList.push({mx:mOriCoord.mx, my:mOriCoord.my-1});
+    //mCoordList.push({mx:mOriCoord.mx+1, my:mOriCoord.my+1});
+    //mCoordList.push({mx:mOriCoord.mx-1, my:mOriCoord.my-1});
+
+    async.mapSeries(mCoordList, function (mCoord, aCallback) {
+        Current.find({"mCoord.mx": mCoord.mx, "mCoord.my":mCoord.my}).lean().exec(function (err, currentList) {
+            if (err) {
+                return aCallback();
+            }
+            if (currentList.length == 0) {
+                return aCallback();
+            }
+            var current = currentList[0];
+            return aCallback(true, current);
+        });
+    }, function (isFind, results) {
+        if (isFind == true) {
+            return callback(undefined, results[results.length-1]);
+        }
+
+        callback(new Error("Fail to get current info"));
+    });
+};
+
+KmaScraper.prototype._updateRnsHitRate = function(stnInfo, callback) {
+    var self = this;
+    var geocode = {lon:stnInfo.geo[0], lat:stnInfo.geo[1]};
+    var conv = new convert(geocode, {}).toLocation();
+    var mCoord = {};
+    mCoord.mx = conv.getLocation().x;
+    mCoord.my = conv.getLocation().y;
+
+    async.waterfall([
+            function (aCallback) {
+                self._findCurrent(mCoord, function (err, currentList) {
+                    if (err) {
+                        return aCallback(new Error("Fail to get current info stnId="+stnInfo.stnId+" mCoord="+JSON.stringify(mCoord))+" address="+stnInfo.addr);
+                    }
+
+                    var current = currentList.currentData[currentList.currentData.length-1];
+
+                    if (current.pty > 0 || current.rn1 > 0) {
+                        log.info("stnId="+stnInfo.stnId+" it is raining");
+                        return aCallback(undefined, current);
+                    }
+
+                    aCallback("stnId="+stnInfo.stnId+" It was not raining");
+                });
+            },
+            function (current, aCallback) {
+                KmaStnMinute.find({"stnId": stnInfo.stnId}).lean().exec(function (err, stnWeatherList) {
+                    if (err) {
+                        return aCallback(err);
+                    }
+                    if (stnWeatherList.length == 0) {
+                       return aCallback(new Error("Fail to get weather info stnId="+stnInfo.stnId)) ;
+                    }
+                    var endTime = kmaTimeLib.convertStringToDate(current.date+current.time).getTime();
+                    var startTime = endTime - 3600000;
+                    var minuteList = stnWeatherList[0].minuteData.filter(function (data) {
+                        var dataTime = (new Date(data.date)).getTime();
+                        if ( startTime < dataTime && dataTime <= endTime) {
+                            return true;
+                        }
+                        return false;
+                    });
+
+                    if (minuteList.length < 40)  {
+                        return aCallback(new Error("Need more minute weather"));
+                    }
+                    var rnsCount = 0;
+                    var rns = false;
+                    if (stnInfo.stnId == "839") {
+                        log.info(JSON.stringify(minuteList));
+                    }
+                    for (var i=0; i<minuteList.length; i++) {
+                        if (minuteList[i].rns == undefined) {
+
+                        }
+                        else if (minuteList[i].rns == true) {
+                            rnsCount++;
+                            rns = true;
+                        }
+                        else if (minuteList[i].rns == false) {
+                            rnsCount++;
+                        }
+                    }
+                    if (rnsCount > 0) {
+                        return aCallback(undefined, rns);
+                    }
+                    aCallback("no rns information stnId="+stnInfo.stnId);
+                });
+            },
+            function (isHit, aCallback) {
+                if (stnInfo.rnsHit == undefined) {
+                    stnInfo.rnsHit = 0;
+                }
+                if (stnInfo.rnsCount == undefined) {
+                    stnInfo.rnsCount = 0;
+                }
+
+                if (isHit) {
+                    stnInfo.rnsHit = stnInfo.rnsHit + 1;
+                }
+                stnInfo.rnsCount = stnInfo.rnsCount + 1;
+
+                log.info('Update stnId='+stnInfo.stnId+" rnsHit="+stnInfo.rnsHit+" rnsCount="+stnInfo.rnsCount);
+                stnInfo.save(function (err) {
+                    if (err) {
+                        log.error (err);
+                    }
+                });
+
+                aCallback(undefined, stnInfo.rnsHit/stnInfo.rnsCount);
+            }
+        ],
+        function (err, result) {
+            if (err)  {
+                log.verbose(err);
+            }
+
+            callback(undefined, result);
+        });
+};
+
+/**
+ * current에서 비가 온 경우 aws에서 1시간 이내에 비가 온 적이 있다면, hit.
+ */
+KmaScraper.prototype.updateRnsHitRates = function (callback) {
+    var self = this;
+    KmaStnInfo.find().exec(function (err, kmaStnList) {
+        if (err) {
+            return callback(err);
+        }
+
+        async.mapSeries(kmaStnList,
+            function (stnInfo, mCallback) {
+                self._updateRnsHitRate(stnInfo, function (err, result) {
+                    if (err) {
+                        return mCallback(err);
+                    }
+                    mCallback(err, result);
+                });
+            },
+            function (err, results) {
+                if (err) {
+                    return callback(err);
+                }
+                callback(err, results);
+            }
+        );
+    });
+};
+
+/**
+ * rns(강수)가 동작하지는 않는 측정소 리스트.
+ * @param stnId
+ * @returns {boolean}
+ * @private
+ */
+KmaScraper.prototype._checkRnsWork = function (stnId) {
+    var noWorkRns = ["364", "365", "366", "368", "409", "458", "459", "460", "461", "476", "488", "492", "548", "556"];
+    for (var i=0; i<noWorkRns.length; i++) {
+        if (stnId == noWorkRns[i]) {
+            return false;
+        }
+    }
+    return true;
+};
+
+/**
+ * rns 확률값을 초기화 한다.
+ * @param callback
+ */
+KmaScraper.prototype.resetRnsHitRates = function (callback) {
+    var self = this;
+    KmaStnInfo.find().exec(function (err, kmaStnList) {
+        if (err) {
+            return callback(err);
+        }
+        async.map(kmaStnList, function(stn, aCallback) {
+                if (self._checkRnsWork(stn.stnId)) {
+                    stn.rnsHit = 1;
+                    stn.rnsCount = 1;
+                }
+                else {
+                    stn.rnsHit = 0;
+                    stn.rnsCount = 1;
+                }
+                stn.save(function(err) {
+                    aCallback(err);
+                });
+            },
+            function(err, results) {
+               callback(err, results) ;
+            });
+    });
+};
+
+/**
+ * 측정소의 address가 글자들이 붙어 있어 분리해야 함.
+ * @param addr
+ * @returns {{first: *, second: *, third: *}}
+ * @private
+ */
+KmaScraper.prototype._parseStnAddress = function (addr) {
+    var address = addr.replace(" ", "").replace("(산간)", "");
+    var sido = ["광역시", "도", "시"];
+    var sigungu = ["시흥시", "양구군", "완주군", "파주시", "공주시", "완도군", "고흥군", "신안군", "의성군", "군위군", "김천시",
+        "영덕군", "제주시", "거제시", "구미시", "구례군", "구리시", "구로구", "구", "시", "군"];
+    var i;
+    var index;
+    //log.info("addr="+addr+"!");
+    //log.info("address="+address+"!");
+    for (i=0; i<sido.length; i++) {
+        index = address.indexOf(sido[i]);
+        if (0< index && index < 7) {
+            if (sido[i] == "광역시") {
+                index+=2;
+            }
+            break;
+        }
+    }
+    var first = address.slice(0, index+1);
+    var rest = address.slice(index+1, address.length);
+
+    for (i=0; i<sigungu.length; i++) {
+        index = rest.indexOf(sigungu[i]);
+        //log.info(sigungu[i]+"="+index);
+        if (index >= 0) {
+            if (sigungu[i].length == 3) {
+                index+=2;
+            }
+            break;
+        }
+    }
+
+    var second = rest.slice(0, index+1);
+    var third = rest.slice(index+1, rest.length);
+
+    //log.info(first+"\t\t"+second+"\t\t"+third);
+    return {first: first, second: second, third: third};
+};
+
+/**
+ * 측정소가 있는 위치의 날씨 정보를 저장하기 위해서, towns에 측정소 위치를 저장한다.
+ * 동네예보를 제공하지 않는 지역들이 있음.섬지역임.
+ * @param callback
+ */
+KmaScraper.prototype.addStnAddressToTown = function (callback) {
+    var self = this;
+    var noWorkCoord = [{mx: 66, my:54}, {mx:60, my:49}, {mx:51, my:94}, {mx:30, my:58}, {mx:44, my:107}, {mx:60, my:49}];
+
+    KmaStnInfo.find().lean().exec(function (err, kmaStnList) {
+        if (err) {
+            return callback(err);
+        }
+
+        async.map(kmaStnList,
+            function (kmaStn, aCallback) {
+                kmaStn.town = self._parseStnAddress(kmaStn.addr);
+                kmaStn.geocode = {lat:kmaStn.geo[1], lon:kmaStn.geo[0]};
+                var conv = new convert(kmaStn.geocode, {}).toLocation();
+                kmaStn.mCoord = {};
+                kmaStn.mCoord.mx = conv.getLocation().x;
+                kmaStn.mCoord.my = conv.getLocation().y;
+                for (var i=0; i<noWorkCoord.length; i++) {
+                    if (kmaStn.mCoord.mx == noWorkCoord[i].mx && kmaStn.mCoord.my == noWorkCoord[i].my) {
+                        log.info("stnId="+kmaStn.stnId+" this area is not supported");
+                        return aCallback(err, kmaStn.addr);
+                    }
+                }
+
+                Town.find({"mCoord.mx": kmaStn.mCoord.mx, "mCoord.my": kmaStn.mCoord.my}).lean().exec(function (err, result) {
+                    if (err) {
+                        return log.error(err);
+                    }
+                    if (result.length == 0) {
+                        var town = new Town();
+                        town.town = kmaStn.town;
+                        town.gCoord = kmaStn.geocode;
+                        town.mCoord = kmaStn.mCoord;
+                        log.info('save town='+JSON.stringify(kmaStn.town));
+                        town.save(function (err) {
+                            aCallback(err, kmaStn.addr);
+                        });
+                    }
+                    else {
+                        log.info('already saved town='+JSON.stringify(kmaStn.town));
+                        aCallback(err, kmaStn.addr);
+                    }
+                });
+            },
+            function (err, results) {
+                return callback(err, results);
+            });
+    });
 };
 
 module.exports = KmaScraper;

--- a/server/lib/kmaScraper.js
+++ b/server/lib/kmaScraper.js
@@ -846,7 +846,7 @@ KmaScraper.prototype.getStnHourlyWeather = function (callback) {
 };
 
 /**
- * 임시책이고, modelCurrents를 towns로 업데이트 하는 것이 아니라, 자체 list를 가지고 하도록 해야 할듯함.
+ * towns에 측정소 주소를 추가하였음. 일부 섬지역은 current를 제공하지 않음.
  * @param mOriCoord
  * @param callback
  * @private
@@ -1013,7 +1013,7 @@ KmaScraper.prototype.updateRnsHitRates = function (callback) {
 };
 
 /**
- * rns(강수)가 동작하지는 않는 측정소 리스트.
+ * rns(강수)가 동작하지는 않는 측정소 리스트. resetRnsHitRates를 실행하면 아래 리스트 0/1이 되고, 나머지 측정소는 1/1로 설정됨.
  * @param stnId
  * @returns {boolean}
  * @private
@@ -1105,6 +1105,7 @@ KmaScraper.prototype._parseStnAddress = function (addr) {
 /**
  * 측정소가 있는 위치의 날씨 정보를 저장하기 위해서, towns에 측정소 위치를 저장한다.
  * 동네예보를 제공하지 않는 지역들이 있음.섬지역임.
+ * areaNo를 추가하지 않기 때문에 생활지수,보건지수를 구하지 못함.
  * @param callback
  */
 KmaScraper.prototype.addStnAddressToTown = function (callback) {

--- a/server/lib/kmaScraper.js
+++ b/server/lib/kmaScraper.js
@@ -39,8 +39,9 @@ KmaScraper.prototype._parseStnMinInfo = function(pubDate, $, callback) {
 
     var strAr = $('.ehead').text().split(" ");
 
+    stnWeatherList.pubDate = strAr[strAr.length-1];
+
     if (pubDate) {
-        stnWeatherList.pubDate = strAr[strAr.length-1];
         if ((new Date(stnWeatherList.pubDate)).getTime() < (new Date(pubDate)).getTime()) {
             var err =  new Error('Stn Minute info is not updated yet = '+ stnWeatherList.pubDate);
             return callback(err);
@@ -191,6 +192,7 @@ KmaScraper.prototype.getAWSWeather = function (type, dateTime, callback) {
                    if (err) {
                        return callback(err);
                    }
+                   log.info(results.stnList.length);
                    callback(err, results);
                });
             }
@@ -540,7 +542,7 @@ KmaScraper.prototype._saveStnMinute = function (stnWeatherInfo, pubDate, callbac
         if (err) {
             return callback(err);
         }
-        if (stnHourlyList.length > 1) {
+        if (stnMinuteList.length > 1) {
             log.error('stnHourlyInfo is duplicated stnId=', stnWeatherInfo.stnId);
         }
 
@@ -554,10 +556,11 @@ KmaScraper.prototype._saveStnMinute = function (stnWeatherInfo, pubDate, callbac
             });
         }
         else {
-           kmaStnMinute = stnMinuteList[0];
+            kmaStnMinute = stnMinuteList[0];
+            kmaStnMinute.pubDate = pubDate;
         }
 
-        kmaStnMinute.minuteData.push(self._makeDailyData(pushDate, stnWeatherInfo));
+        kmaStnMinute.minuteData.push(self._makeDailyData(pubDate, stnWeatherInfo));
         if (kmaStnMinute.minuteData.length > 60) {
             kmaStnMinute.minuteData.shift();
         }
@@ -741,7 +744,7 @@ KmaScraper.prototype.getStnMinuteWeather = function (callback) {
                 if (err) {
                     return cb(err);
                 }
-                return cb(err, {pubDate: weatherList.pubDate, stnList: weatherList});
+                return cb(err, {pubDate: weatherList.pubDate, stnList: weatherList.stnList});
             });
         },
         function (weatherList, cb) {

--- a/server/lib/kmaTimeLib.js
+++ b/server/lib/kmaTimeLib.js
@@ -47,13 +47,25 @@ kmaTimeLib.convertDateToYYYYMMDD = function(date) {
     return year+month+day;
 };
 
-kmaTimeLib.convertDateToHHMM = function(date) {
+kmaTimeLib.convertDateToHHZZ = function(date) {
     //I don't know why one more create Date object by aleckim
     var d = new Date(date);
     var hh = '' + (d.getHours());
     if (hh.length < 2)  {hh = '0'+hh; }
 
     return hh+'00';
+};
+
+kmaTimeLib.convertDateToHHMM = function(date) {
+    //I don't know why one more create Date object by aleckim
+    var d = new Date(date);
+    var hh = '' + (d.getHours());
+    if (hh.length < 2)  {hh = '0'+hh; }
+
+    var mm = '' + (d.getMinutes());
+    if (mm.length < 2)  {mm = '0'+mm; }
+
+    return hh+mm;
 };
 
 kmaTimeLib.toTimeZone = function (zone, time) {
@@ -90,10 +102,10 @@ kmaTimeLib.convertYYYY_MM_DDtoYYYYMMDD = function (dateStr) {
     return dateStr.substr(0,4)+dateStr.substr(5,2)+dateStr.substr(8,2);
 };
 
-kmaTimeLib.convertYYYYMMDDHHMMtoYYYYoMMoDDoMMoZZ = function(dateStr) {
+kmaTimeLib.convertYYYYMMDDHHMMtoYYYYoMMoDDoHHoMM = function(dateStr) {
     var str = dateStr.substr(0,4)+'.'+dateStr.substr(4,2)+'.'+dateStr.substr(6,2);
     if (dateStr.length > 8) {
-        str += '.' + dateStr.substr(8,2) + ':00';
+        str += '.' + dateStr.substr(8,2) + ':' + dateStr.substr(10,2);
     }
     return str;
 };

--- a/server/lib/lifeIndexKmaRequester.js
+++ b/server/lib/lifeIndexKmaRequester.js
@@ -334,7 +334,7 @@ KmaIndexService.prototype._parseHourlyLifeIndex = function (parsedData, indexMod
         }
 
         var data = {date: kmaTimeLib.convertDateToYYYYMMDD(startTime),
-                    time: kmaTimeLib.convertDateToHHMM(startTime),
+                    time: kmaTimeLib.convertDateToHHZZ(startTime),
                     value: indexModel[propertyName]};
 
         log.silly(data);

--- a/server/lib/lifeIndexKmaRequester.js
+++ b/server/lib/lifeIndexKmaRequester.js
@@ -760,6 +760,7 @@ KmaIndexService.prototype.getLifeIndexByTown = function(townInfo, callback) {
 
 /**
  * towns db로부터 areaNo정보를 life index kma에 추가함.
+ * kma aws의 정보가 towns에 들어올때, areaNo가 없는 경우가 있음. 그것에 대해서는 추가하지 않음.
  * @param callback
  */
 KmaIndexService.prototype.updateLifeIndexDbFromTowns = function (callback) {

--- a/server/lib/lifeIndexKmaRequester.js
+++ b/server/lib/lifeIndexKmaRequester.js
@@ -767,10 +767,16 @@ KmaIndexService.prototype.updateLifeIndexDbFromTowns = function (callback) {
     Town.find({},{_id:0}).lean().exec(function (err, townList) {
         if (err) {
             log.error(err);
-            return;
+            return callback();
         }
+
         async.map(townList,
             function (town, cb) {
+                if(town.areaNo === undefined) {
+                    log.warn("skip town="+JSON.stringify(town));
+                    return cb(undefined, town.areaNo);
+                }
+
                 LifeIndexKma.find({"areaNo": town.areaNo}, function (err, lifeIndexList) {
                     if (err) {
                         return cb(err);

--- a/server/models/modelKmaStnInfo.js
+++ b/server/models/modelKmaStnInfo.js
@@ -13,7 +13,8 @@ var ksiSchema = new mongoose.Schema({
         type: [Number],     // [<longitude(dmY)>, <latitude(dmX)>]
         index: '2d'         // create the geospatial index
     },
-    rnsHitRate: Number,
+    rnsHit: Number,
+    rnsCount: Number,
 });
 
 ksiSchema.index({stnName:'text'}, {default_language: 'none'});

--- a/server/models/modelKmaStnInfo.js
+++ b/server/models/modelKmaStnInfo.js
@@ -12,7 +12,8 @@ var ksiSchema = new mongoose.Schema({
     geo: {
         type: [Number],     // [<longitude(dmY)>, <latitude(dmX)>]
         index: '2d'         // create the geospatial index
-    }
+    },
+    rnsHitRate: Number,
 });
 
 ksiSchema.index({stnName:'text'}, {default_language: 'none'});

--- a/server/models/modelKmaStnMinute.js
+++ b/server/models/modelKmaStnMinute.js
@@ -1,0 +1,36 @@
+/**
+ * Created by aleckim on 2016. 7. 1..
+ * Hourly와 동일한 구조를 가지고, 데이터는 매분 저장된다.
+ */
+
+var mongoose = require("mongoose");
+var ksmwSchema = new mongoose.Schema({
+    stnId: String,
+    stnName: String, //unique
+    pubDate: String, //YYYY.MM.DD.HH.ZZ
+    minuteData: [{
+        date: String, //YYYY.MM.DD.HH.ZZ
+        weather: String,
+        visibility: Number, //km
+        cloud: Number, //1/10
+        heavyCloud: Number,
+        t1h: Number,
+        dpt: Number,
+        sensoryTem: Number, //체감온도
+        dspls: Number, //불쾌지수
+        r1d: Number,
+        s1d: Number,
+        reh: Number,
+        wdd: String, //ESE, SW, ..
+        vec: Number, //143.7
+        wsd: Number,
+        hPa: Number,
+        rs1h: Number, //rain or snow or rain/snow from AWS
+        rs1d: Number,
+        rns: Boolean, //rain,snow or not pty와 비슷하지만, on/off만 있음. property가 없으면, 동작하지 않거나, 정보 없음.
+    }]
+});
+
+ksmwSchema.index({stnId: 'text'});
+
+module.exports = mongoose.model('KmaStnMinute', ksmwSchema);

--- a/server/routes/v000001/routeGather.js
+++ b/server/routes/v000001/routeGather.js
@@ -169,6 +169,19 @@ router.get('/kmaStnMinute', function (req, res) {
     });
 });
 
+router.get('/updateStnRnsHitRate', function (req, res) {
+    var scrape = new Scrape();
+    scrape.updateRnsHitRates(function (err, results) {
+        if (err) {
+            log.error(err);
+        }
+        else {
+            log.silly(results);
+        }
+        res.send();
+    });
+});
+
 router.get('/invalidateCloudFront/:items', function(req, res){
     var keydata  = require('../../config/config').keyString;
     var awsData = require('../../config/config').aws;

--- a/server/routes/v000001/routeGather.js
+++ b/server/routes/v000001/routeGather.js
@@ -151,6 +151,24 @@ router.get('/kmaStnHourly', function (req, res) {
     });
 });
 
+router.get('/kmaStnMinute', function (req, res) {
+    var scrape = new Scrape();
+    scrape.getStnMinuteWeather(function (err, results) {
+        if (err) {
+            if (err === 'skip') {
+                log.info('stn minute weather info is already updated');
+            }
+            else {
+                log.error(err);
+            }
+        }
+        else {
+            log.silly(results);
+        }
+        res.send();
+    });
+});
+
 router.get('/invalidateCloudFront/:items', function(req, res){
     var keydata  = require('../../config/config').keyString;
     var awsData = require('../../config/config').aws;

--- a/server/routes/v000705/routeTownForecast.js
+++ b/server/routes/v000705/routeTownForecast.js
@@ -41,8 +41,8 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                    cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -50,8 +50,8 @@ router.get('/:region', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
                                     cTown.getSummary, cTown.dataToFixed, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                    cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -80,15 +80,15 @@ router.get('/:region/:city/:town/mid', [cTown.getMid, cTown.getMidRss, cTown.get
                                     cTown.insertStrForData, cTown.dataToFixed, cTown.sendResult]);
 
 router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                            cTown.convert0Hto24H, cTown.mergeShortWithCurrentList, cTown.adjustShort,
-                                            cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
-                                            cTown.insertStrForData, cTown.dataToFixed, cTown.sendResult]);
+                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList, cTown.adjustShort,
+                                    cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
+                                    cTown.insertStrForData, cTown.dataToFixed, cTown.sendResult]);
 
 router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.convert0Hto24H, cTown.insertIndex,
-                                            cTown.insertStrForData, cTown.dataToFixed, cTown.sendResult]);
+                                    cTown.insertStrForData, cTown.dataToFixed, cTown.sendResult]);
 
-router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                            cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
-                                            cTown.insertStrForData, cTown.getSummary, cTown.dataToFixed, cTown.sendResult]);
+router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
+                                    cTown.insertStrForData, cTown.getSummary, cTown.dataToFixed, cTown.sendResult]);
 
 module.exports = router;

--- a/server/routes/v000705/routeTownForecast.js
+++ b/server/routes/v000705/routeTownForecast.js
@@ -63,8 +63,8 @@ router.get('/:region/:city', [cTown.getShort, cTown.getShortRss, cTown.getShorte
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                    cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,

--- a/server/routes/v000803/routeTownForecast.js
+++ b/server/routes/v000803/routeTownForecast.js
@@ -41,8 +41,8 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                    cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -50,8 +50,8 @@ router.get('/:region', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
                                     cTown.getSummary, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                    cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -63,8 +63,8 @@ router.get('/:region/:city', [cTown.getShort, cTown.getShortRss, cTown.getShorte
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                    cTown.mergeCurrentByShortest,  cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest,  cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -87,8 +87,8 @@ router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTo
 router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.convert0Hto24H, cTown.insertIndex,
                                             cTown.insertStrForData, cTown.sendResult]);
 
-router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.convert0Hto24H,
-                                            cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
+router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                            cTown.convert0Hto24H, cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
                                             cTown.insertStrForData, cTown.getSummary, cTown.sendResult]);
 
 module.exports = router;

--- a/server/test/testControllerKmaStnWeather.js
+++ b/server/test/testControllerKmaStnWeather.js
@@ -118,5 +118,66 @@ describe('unit test - controller kma stn weather', function() {
     //        });
     //    });
     //});
+
+    //it('test get all hourly stn weather', function(done) {
+    //    this.timeout(1000*1000);
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //    });
+    //
+    //    var fs = require('fs');
+    //    var targetName = './utils/data/base.csv';
+    //    var lineList = fs.readFileSync(targetName).toString().split('\n');
+    //    // header remove
+    //    lineList.shift();
+    //    //remove last blank line
+    //    lineList = lineList.slice(0, lineList.length-1);
+    //
+    //    var date = kmaTimeLib.convertDateToYYYYMMDD(new Date());
+    //    var time = kmaTimeLib.convertDateToHHMM(new Date());
+    //    log.info('pubDate='+date+time);
+    //
+    //    var callCount = 0;
+    //    lineList.forEach(function (line) {
+    //        var tia = line.split(",");
+    //        var townInfo={first:tia[0],second:tia[1], third:tia[2], gCoord:{'lat':tia[3],'lon':tia[4]}};
+    //        //log.info(JSON.stringify(townInfo));
+    //        callCount++;
+    //        controllerKmaStnWeather.getStnMinute(townInfo, date+time, undefined, function (err, result) {
+    //            if (err) {
+    //                log.error(err);
+    //            }
+    //            else {
+    //                if (result.t1h === 0 && result.vec === 0 && result.wsd === 0) {
+    //                    log.error('result is invalid!');
+    //                    next();
+    //                    return;
+    //                }
+    //
+    //                if (result.rns) {
+    //                    log.info(JSON.stringify(townInfo)+'--'+JSON.stringify(result));
+    //                }
+    //
+    //                //if (result.t1h == undefined) {
+    //                //    log.error(JSON.stringify(townInfo)+'--'+JSON.stringify(result));
+    //                //}
+    //                //else {
+    //                //    log.info(JSON.stringify(townInfo)+'--'+JSON.stringify(result));
+    //                //}
+    //            }
+    //            callCount--;
+    //            if (callCount == 0) {
+    //                done();
+    //            }
+    //        });
+    //    });
+    //});
 });
 

--- a/server/test/testControllerKmaStnWeather.js
+++ b/server/test/testControllerKmaStnWeather.js
@@ -27,9 +27,37 @@ describe('unit test - controller kma stn weather', function() {
     //    var townInfo={first:'서울특별시',second:'송파구', third:'잠실본동', gCoord:{'lat':37.5033556,'lon':127.0864194}};
     //
     //    var date = kmaTimeLib.convertDateToYYYYMMDD(new Date());
-    //    var time = kmaTimeLib.convertDateToHHMM(new Date());
+    //    var time = kmaTimeLib.convertDateToHHZZ(new Date());
     //    console.log('pubDate='+date+time);
     //    controllerKmaStnWeather.getStnHourly(townInfo, date+time, function (err, result) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        else {
+    //            log.info(JSON.stringify(result));
+    //        }
+    //        done();
+    //    });
+    //});
+
+    //it('test get minute stn weather', function(done) {
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //    });
+    //
+    //    var townInfo={first:'서울특별시',second:'송파구', third:'잠실본동', gCoord:{'lat':37.5033556,'lon':127.0864194}};
+    //
+    //    var date = kmaTimeLib.convertDateToYYYYMMDD(new Date());
+    //    var time = kmaTimeLib.convertDateToHHMM(new Date());
+    //    console.log('pubDate='+date+time);
+    //    controllerKmaStnWeather.getStnMinute(townInfo, date+time, undefined, function (err, result) {
     //        if (err) {
     //            log.error(err);
     //        }
@@ -62,7 +90,7 @@ describe('unit test - controller kma stn weather', function() {
     //    lineList = lineList.slice(0, lineList.length-1);
     //
     //    var date = kmaTimeLib.convertDateToYYYYMMDD(new Date());
-    //    var time = kmaTimeLib.convertDateToHHMM(new Date());
+    //    var time = kmaTimeLib.convertDateToHHZZ(new Date());
     //    log.info('pubDate='+date+time);
     //
     //    var callCount = 0;

--- a/server/test/testKmaScraper.js
+++ b/server/test/testKmaScraper.js
@@ -93,31 +93,109 @@ describe('unit test - kma city weather scraping', function() {
     //    });
     //});
 
-    it('test get kma stn weather info', function (done) {
-        this.timeout( 30*1000);
+    //it('test get kma stn weather info', function (done) {
+    //    this.timeout( 30*1000);
+    //
+    //    var controllerManager = require('../controllers/controllerManager');
+    //    global.manager = new controllerManager();
+    //
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //    });
+    //
+    //    var scrape = new Scrape();
+    //    scrape.getStnMinuteWeather(function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        log.info(results);
+    //        done();
+    //    });
+    //});
 
-        var controllerManager = require('../controllers/controllerManager');
-        global.manager = new controllerManager();
+    //it('test update rns hit rate', function (done) {
+    //    this.timeout( 30*1000);
+    //
+    //    var controllerManager = require('../controllers/controllerManager');
+    //    global.manager = new controllerManager();
+    //
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //    });
+    //
+    //    var scrape = new Scrape();
+    //    scrape.updateRnsHitRates(function (err) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
 
-        var mongoose = require('mongoose');
-        mongoose.connect('localhost/todayweather', function(err) {
-            if (err) {
-                console.error('Could not connect to MongoDB!');
-                console.log(err);
-            }
-        });
-        mongoose.connection.on('error', function(err) {
-            console.error('MongoDB connection error: ' + err);
-        });
+    //it('test reset rns hit rate', function (done) {
+    //    this.timeout( 30*1000);
+    //
+    //    var controllerManager = require('../controllers/controllerManager');
+    //    global.manager = new controllerManager();
+    //
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //    });
+    //
+    //    var scrape = new Scrape();
+    //    scrape.resetRnsHitRates(function (err) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
 
-        var scrape = new Scrape();
-        scrape.getStnMinuteWeather(function (err, results) {
-            if (err) {
-                log.error(err);
-            }
-            log.info(results);
-            done();
-        });
-    });
+    //it('test add stn address to towns', function (done) {
+    //    this.timeout( 100*1000);
+    //
+    //    var controllerManager = require('../controllers/controllerManager');
+    //    global.manager = new controllerManager();
+    //
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather2', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //    });
+    //
+    //    var scrape = new Scrape();
+    //    scrape.addStnAddressToTown(function(err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
 });
 

--- a/server/test/testKmaScraper.js
+++ b/server/test/testKmaScraper.js
@@ -92,5 +92,32 @@ describe('unit test - kma city weather scraping', function() {
     //        done();
     //    });
     //});
+
+    it('test get kma stn weather info', function (done) {
+        this.timeout( 30*1000);
+
+        var controllerManager = require('../controllers/controllerManager');
+        global.manager = new controllerManager();
+
+        var mongoose = require('mongoose');
+        mongoose.connect('localhost/todayweather', function(err) {
+            if (err) {
+                console.error('Could not connect to MongoDB!');
+                console.log(err);
+            }
+        });
+        mongoose.connection.on('error', function(err) {
+            console.error('MongoDB connection error: ' + err);
+        });
+
+        var scrape = new Scrape();
+        scrape.getStnMinuteWeather(function (err, results) {
+            if (err) {
+                log.error(err);
+            }
+            log.info(results);
+            done();
+        });
+    });
 });
 

--- a/server/test/testKmaTimeLib.js
+++ b/server/test/testKmaTimeLib.js
@@ -25,9 +25,9 @@ describe('unit test - kma time lib', function() {
         assert(yyyymmdd, target, 'Fail to convert date to yyyymmdd');
     });
 
-    it('test convertDateToHHMM', function () {
+    it('test convertDateToHHZZ', function () {
         var date = new Date();
-        var hhmm = kmaTimeLib.convertDateToHHMM(date);
+        var hhmm = kmaTimeLib.convertDateToHHZZ(date);
         var target = date.getHours() < 10 ? '0'+ date.getHours(): ''+date.getHours();
         target += '00';
         assert(hhmm, target, 'Fail to convert date to hhmm');

--- a/server/test/testLifeIndexKmaRequester.js
+++ b/server/test/testLifeIndexKmaRequester.js
@@ -276,5 +276,29 @@ describe('unit test - requester of kma index service class', function() {
     //        console.log(townList);
     //    });
     //});
+
+    //it('test update lifeindex db from towns', function (done) {
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //        process.exit(-1);
+    //    });
+    //
+    //    reqLifeIndex = new LifeIndexKmaRequester();
+    //    reqLifeIndex.updateLifeIndexDbFromTowns(function (err, results) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        log.info('Finish updating life index db from towns');
+    //        log.info(results);
+    //        done();
+    //    });
+    //});
 });
 


### PR DESCRIPTION
#653 #997
**frontend**
pubdate에 분단위 정보가 들어오면, 실시간 날씨로 구분하고, 6단계로 구분한다.

**backend**
new getStnMinute, getKmaStnMinuteWeather
분단위 데이터는 가지고와서 적용한다. 
강수의 경우 측정소에서 대략 20분내에 강수로 표시가 한번이라도 발생하면 비옴으로 간주한다.
측정소에 대하여 강수 신뢰도를 두고 50프로 이상인 경우에만 사용한다.

new updateRnsHitRates
새로운 current가 들어오면 측정소의 주소로 current정보를 가지고 와서 측정소의 강수 신뢰도를 계산한다.

new getStnMinuteWeather
30초마다 측정소의 기상정보를 가지고 오는데, 시간이 뒤집어 들어오는 경우도 있고, 건너 뛰는 경우도 있음.

new addStnAddressToTown
stnInfo에 있는 addr에 따라 towns에 새로운 정보를 추가함.

new resetRnsHitRates
측정소의 강수 신뢰도는 초기화하는데 사전 조사에서 강수가 표시 되지 않는 지역 정보에 따라 rate를 0으로 만듬.

