### PR TITLE
실시간 날씨 반영 및 운영 방법 수정.

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -415,7 +415,12 @@ angular.module('starter', [
                                 return [d];
                             })
                             .attr('r', function () {
-                                return currentTime % 3 == 0 ? 11:5;
+                                if (scope.currentWeather.liveTime && currentTime+'00' != scope.currentWeather.liveTime) {
+                                    return 5;
+                                }
+                                else {
+                                    return currentTime % 3 == 0 ? 11:5;
+                                }
                             })
                             .attr('cx', function (d) {
                                 var cx = getCx(currentTime, d.values);
@@ -458,7 +463,7 @@ angular.module('starter', [
                                 var cy1 = d.values[cx.cx1].value.t3h;
                                 var cy2 = d.values[cx.cx1+1].value.t3h;
 
-                                var y1;
+                                var y1 = cy1;
                                 if (cx.cx2 === 1) {
                                     y1 = cy1 + (cy2 - cy1) / 3;
                                 }
@@ -492,7 +497,12 @@ angular.module('starter', [
                             .style("fill", function (d) {
                                 if (d.name == "today") {
                                     if (d.value.time  === currentTime && d.value.date === scope.currentWeather.date) {
-                                       return '#fefefe';
+                                        if (scope.currentWeather.liveTime && currentTime+'00' != scope.currentWeather.liveTime) {
+                                            return '#0288D1';
+                                        }
+                                        else {
+                                            return '#fefefe';
+                                        }
                                     }
                                 }
                                 return '#0288D1';
@@ -510,7 +520,12 @@ angular.module('starter', [
                             .style("fill", function (d) {
                                 if (d.name == "today") {
                                     if (d.value.time === currentTime && d.value.date === scope.currentWeather.date) {
-                                       return '#fefefe';
+                                        if (scope.currentWeather.liveTime && currentTime+'00' != scope.currentWeather.liveTime) {
+                                            return '#0288D1';
+                                        }
+                                        else {
+                                            return '#fefefe';
+                                        }
                                     }
                                 }
                                 return '#0288D1';

--- a/server/app.js
+++ b/server/app.js
@@ -93,6 +93,10 @@ if (config.mode === 'gather' || config.mode === 'local') {
     }
 }
 
+if (config.mode === 'scrape' || config.mode === 'local') {
+    manager.startScrape();
+}
+
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
   var err = new Error('Not Found url='+req.originalUrl);

--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -158,7 +158,7 @@ controllerKmaStnWeather._getStnMinuteList = function (stnList, dateTime, callbac
                 }
 
                 //log.info("minuteList length="+minuteList.length);
-                if (minuteData.rns != undefined && minuteList.length >= 10) {
+                if (minuteData.rns != undefined && minuteList.length >= 5) {
                     //15분안에 rain이 하나라도 true이면 rain임.
                     for (var i=0; i < minuteList.length; i++) {
                         if (minuteList[i].rns) {

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1816,7 +1816,7 @@ Manager.prototype._requestApi = function (apiName, callback) {
     var timeout = 1000*60*60*24;
     var url = "http://"+config.ipAddress+":"+config.port+"/gather/";
 
-    log.info('Start '+apiName);
+    log.info('Start url='+url+apiName);
     req(url+apiName, {timeout: timeout}, function(err, response) {
         log.info('Finished '+apiName+' '+new Date());
         if (err) {
@@ -1876,15 +1876,6 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         });
     }
 
-    if (time === 3 || time === 6 || time === 9 || putAll) {
-        //related issue #754 aws is not updated at correct time
-        //overwrite
-        log.info('push kma stn hourly');
-        self.asyncTasks.push(function (callback) {
-            self._requestApi('kmaStnHourly', callback);
-        });
-    }
-
     if (time === 3 || time === 13 || time === 23 || time === 33 || time === 43 || time === 53 || putAll) {
         log.info('push keco');
         self.asyncTasks.push(function (callback) {
@@ -1916,13 +1907,6 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         log.info('push short');
         self.asyncTasks.push(function (callback) {
             self._requestApi("short", callback);
-        });
-    }
-
-    if(time === 50) {
-        log.info('push short');
-        self.asyncTasks.push(function (callback) {
-            self._requestApi("updateStnRnsHitRate", callback);
         });
     }
 
@@ -2005,13 +1989,6 @@ Manager.prototype.startManager = function(){
         setInterval(function() {
             self.checkTimeAndRequestTask(false) ;
         }, 1000*60);
-
-        setInterval(function () {
-            log.info('request kma stn minute');
-            self._requestApi('kmaStnMinute', function () {
-                log.info('response kma stn minute');
-            });
-        }, 1000*30);
     });
 
     return this;
@@ -2020,6 +1997,52 @@ Manager.prototype.startManager = function(){
 Manager.prototype.stopManager = function(){
     //var self = this;
     //self.stopTownData();
+};
+
+Manager.prototype.startScrape = function () {
+    var self = this;
+    var Scrape = require('../lib/kmaScraper');
+    var scrape = new Scrape();
+
+    setInterval(function () {
+        var time = (new Date()).getUTCMinutes();
+
+        //if (time === 3 || time === 6 || time === 9) {
+        //    //related issue #754 aws is not updated at correct time
+        //    //overwrite
+        //    log.info('request kma stn hourly');
+        //    self._requestApi('kmaStnHourly', function () {
+        //        log.info('kma stn hourly done');
+        //    });
+        //}
+        //
+        //if(time === 50) {
+        //    log.info('update stn rns hit rate');
+        //    self._requestApi('updateStnRnsHitRate', function () {
+        //        log.info('update stn rns hit rate done');
+        //    });
+        //}
+
+        if(time % 5 == 0) {
+            log.info('request kma stn minute');
+            scrape.getStnMinuteWeather(function (err, results) {
+                if (err) {
+                    if (err === 'skip') {
+                        log.info('stn minute weather info is already updated');
+                    }
+                    else {
+                        log.error(err);
+                    }
+                }
+                else {
+                    log.silly(results);
+                    log.info('kma stn minute done');
+                }
+            });
+        }
+
+        //gc(true);
+    }, 1000*60);
 };
 
 module.exports = Manager;

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1876,6 +1876,15 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         });
     }
 
+    if (time === 3 || time === 6 || time === 9 || time === 15 || putAll) {
+        //related issue #754 aws is not updated at correct time
+        //overwrite
+        log.info('request kma stn hourly');
+        self._requestApi('kmaStnHourly', function () {
+            log.info('kma stn hourly done');
+        });
+    }
+
     if (time === 3 || time === 13 || time === 23 || time === 33 || time === 43 || time === 53 || putAll) {
         log.info('push keco');
         self.asyncTasks.push(function (callback) {
@@ -1907,6 +1916,13 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
         log.info('push short');
         self.asyncTasks.push(function (callback) {
             self._requestApi("short", callback);
+        });
+    }
+
+    if(time === 50) {
+        log.info('update stn rns hit rate');
+        self._requestApi('updateStnRnsHitRate', function () {
+            log.info('update stn rns hit rate done');
         });
     }
 
@@ -2000,31 +2016,13 @@ Manager.prototype.stopManager = function(){
 };
 
 Manager.prototype.startScrape = function () {
-    var self = this;
     var Scrape = require('../lib/kmaScraper');
     var scrape = new Scrape();
 
     setInterval(function () {
         var time = (new Date()).getUTCMinutes();
-
-        //if (time === 3 || time === 6 || time === 9) {
-        //    //related issue #754 aws is not updated at correct time
-        //    //overwrite
-        //    log.info('request kma stn hourly');
-        //    self._requestApi('kmaStnHourly', function () {
-        //        log.info('kma stn hourly done');
-        //    });
-        //}
-        //
-        //if(time === 50) {
-        //    log.info('update stn rns hit rate');
-        //    self._requestApi('updateStnRnsHitRate', function () {
-        //        log.info('update stn rns hit rate done');
-        //    });
-        //}
-
-        if(time % 5 == 0) {
-            log.info('request kma stn minute');
+        if(time % 2 == 0) {
+            log.info('request kma stn minute time='+(new Date()));
             scrape.getStnMinuteWeather(function (err, results) {
                 if (err) {
                     if (err === 'skip') {
@@ -2036,7 +2034,7 @@ Manager.prototype.startScrape = function () {
                 }
                 else {
                     log.silly(results);
-                    log.info('kma stn minute done');
+                    log.info('kma stn minute done time='+(new Date()));
                 }
             });
         }

--- a/server/lib/kmaScraper.js
+++ b/server/lib/kmaScraper.js
@@ -925,14 +925,11 @@ KmaScraper.prototype._updateRnsHitRate = function(stnInfo, callback) {
                         return false;
                     });
 
-                    if (minuteList.length < 40)  {
+                    if (minuteList.length < 15)  {
                         return aCallback(new Error("Need more minute weather"));
                     }
                     var rnsCount = 0;
                     var rns = false;
-                    if (stnInfo.stnId == "839") {
-                        log.info(JSON.stringify(minuteList));
-                    }
                     for (var i=0; i<minuteList.length; i++) {
                         if (minuteList[i].rns == undefined) {
 

--- a/server/lib/kmaScraper.js
+++ b/server/lib/kmaScraper.js
@@ -1155,6 +1155,49 @@ KmaScraper.prototype.addStnAddressToTown = function (callback) {
     });
 };
 
+/**
+ * 고도 필드의 배경이 rgb(255, 255, 187), stnName에 (레)가 들어간 경우, 주변 지역보다 많이 높은 경우.
+ * 부산(레), 가야산, 북악산, 팔공산, 백운산, 토함산, 매곡
+ * @param stnId
+ * @private
+ */
+KmaScraper.prototype._checkMountain = function (stnId) {
+    var mountainList = ["100", "116", "160", "175", "216", "311", "314", "315", "316", "318",
+                        "320", "422", "497", "498", "554", "579", "659", "674", "682", "694",
+                        "695", "753", "782", "831", "853", "856", "859", "867", "868", "869",
+                        "870", "871", "872", "873", "875", "878", "879", "943"];
+    for (var i=0; i<mountainList.length; i++) {
+        if (stnId == mountainList[i]) {
+            return true;
+        }
+    }
+    return false;
+};
+
+/**
+ * db에 isMountain에 대한 값을 설정한다.
+ * 고도 필드의 배경색이 rgb(255, 255, 187); 인것과 일부 주변지역에 비해 고도가 높은 지역을 mountain으로 설정하여
+ * 관측정보에서 제외한다.
+ * @param callback
+ */
+KmaScraper.prototype.resetMoutainInfo = function(callback) {
+    var self = this;
+    KmaStnInfo.find().exec(function (err, kmaStnList) {
+        if (err) {
+            return callback(err);
+        }
+        async.map(kmaStnList, function(stn, aCallback) {
+                stn.isMountain = self._checkMountain(stn.stnId);
+                stn.save(function(err) {
+                    aCallback(err);
+                });
+            },
+            function(err, results) {
+                callback(err, results) ;
+            });
+    });
+};
+
 module.exports = KmaScraper;
 
 

--- a/server/lib/lifeIndexKmaRequester.js
+++ b/server/lib/lifeIndexKmaRequester.js
@@ -421,7 +421,7 @@ KmaIndexService.prototype.getLifeIndex = function (indexName, areaNo, callback) 
     else {
         this.requestCount[indexName]++;
     }
-    log.info(indexName+" request count="+this.requestCount[indexName]);
+    log.silly(indexName+" request count="+this.requestCount[indexName]);
 
     req(url, {timeout: 1000*30, json:true}, function (err, response, body) {
         if (err) {

--- a/server/models/modelKmaStnInfo.js
+++ b/server/models/modelKmaStnInfo.js
@@ -15,6 +15,7 @@ var ksiSchema = new mongoose.Schema({
     },
     rnsHit: Number,
     rnsCount: Number,
+    isMountain: Boolean,
 });
 
 ksiSchema.index({stnName:'text'}, {default_language: 'none'});

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "node --expose-gc --max-old-space-size=4096 ./bin/www",
+    "start": "node --expose-gc --max-old-space-size=512 ./bin/www",
     "test": "./node_modules/mocha/bin/mocha",
     "initdata": "node ./utils/initForecasteDataToMongo && node ./utils/initTownDataToMongo && node ./utils/initMidDataToMongo"
   },
@@ -32,7 +32,7 @@
     "jade": "~1.11.0",
     "jsonwebtoken": "^5.7.0",
     "jwt-simple": "^0.3.0",
-    "mongoose": "^4.3.4",
+    "mongoose": "^4.5.3",
     "morgan": "~1.6.1",
     "newrelic": "^1.24.1",
     "node-gcm": "^0.14.0",

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "node --expose-gc --max-old-space-size=512 ./bin/www",
+    "start": "node --max-old-space-size=512 ./bin/www",
     "test": "./node_modules/mocha/bin/mocha",
     "initdata": "node ./utils/initForecasteDataToMongo && node ./utils/initTownDataToMongo && node ./utils/initMidDataToMongo"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www",
+    "start": "node --expose-gc --max-old-space-size=4096 ./bin/www",
     "test": "./node_modules/mocha/bin/mocha",
     "initdata": "node ./utils/initForecasteDataToMongo && node ./utils/initTownDataToMongo && node ./utils/initMidDataToMongo"
   },

--- a/server/routes/v000001/routeGather.js
+++ b/server/routes/v000001/routeGather.js
@@ -31,8 +31,8 @@ router.get('/past', function(req, res) {
         if (err) {
             log.error(err);
         }
-        res.send();
     });
+    res.send();
 });
 
 router.get('/shortrss', function(req, res) {

--- a/server/test/testKmaScraper.js
+++ b/server/test/testKmaScraper.js
@@ -197,5 +197,31 @@ describe('unit test - kma city weather scraping', function() {
     //        done();
     //    });
     //});
+
+    //it('test reset mountain info', function (done) {
+    //    this.timeout( 300*1000);
+    //
+    //    var controllerManager = require('../controllers/controllerManager');
+    //    global.manager = new controllerManager();
+    //
+    //    var mongoose = require('mongoose');
+    //    mongoose.connect('localhost/todayweather', function(err) {
+    //        if (err) {
+    //            console.error('Could not connect to MongoDB!');
+    //            console.log(err);
+    //        }
+    //    });
+    //    mongoose.connection.on('error', function(err) {
+    //        console.error('MongoDB connection error: ' + err);
+    //    });
+    //
+    //    var scrape = new Scrape();
+    //    scrape.resetMoutainInfo(function (err) {
+    //        if (err) {
+    //            log.error(err);
+    //        }
+    //        done();
+    //    });
+    //});
 });
 


### PR DESCRIPTION
#653 #977 
**frontEnd**
현재위치 포인트 크기 조건문 수정.
글자색에 대한 조건문 수정.
정각일때 오류 나는 문제 수정.

**backEnd**
scrape mode를 추가하고, gather server에서 scrape mode 개별 프로세스로 동작함. 
성능문제로 scrape mode 에서는 2분당데이터만 수집함.
측정소 날씨를 범위 0.3에서 0.2로 조정.
측정소의 isMountain 이 true인 경우 사용에서 제외함.(산으로 보고 제외함)
실시간 날씨 수집이 2분데이터로 하기 때문에 그에 맞추어 rns사용여부와 rnsHitRate관련 조건문 수정.
new resetMoutainInfo

etc
life index request count 출력하는 로그 레벨 수정.
past gather에 대한 실행문 수정.