### PR TITLE
#1016 시간별 날씨에서 차트 스크롤 안되는 경우

### DIFF
--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -665,8 +665,12 @@ angular.module('starter.controllers', [])
                     $scope.shortTable =  $sce.trustAsHtml(getShortTable());
 
                     setTimeout(function () {
-                        // ionic native scroll 사용시에 화면이 제대로 안그려지는 경우가 있어서 animation 필수.
-                        $ionicScrollDelegate.$getByHandle("timeChart").scrollTo(getTodayPosition(), 0, true);
+                        // ios에서 ionic native scroll 사용시에 화면이 제대로 안그려지는 경우가 있어서 animation 필수.
+                        if (ionic.Platform.isAndroid()) {
+                            $ionicScrollDelegate.$getByHandle("timeChart").scrollTo(getTodayPosition(), 0, false);
+                        } else {
+                            $ionicScrollDelegate.$getByHandle("timeChart").scrollTo(getTodayPosition(), 0, true);
+                        }
                     }, 0);
                 }
                 else {
@@ -678,8 +682,13 @@ angular.module('starter.controllers', [])
                     $scope.midTable = $sce.trustAsHtml(getMidTable());
 
                     setTimeout(function () {
-                        $ionicScrollDelegate.$getByHandle("weeklyChart").scrollTo(getTodayPosition(), 0, true);
-                        $ionicScrollDelegate.$getByHandle("weeklyTable").scrollTo(300, 0, true);
+                        if (ionic.Platform.isAndroid()) {
+                            $ionicScrollDelegate.$getByHandle("weeklyChart").scrollTo(getTodayPosition(), 0, false);
+                            $ionicScrollDelegate.$getByHandle("weeklyTable").scrollTo(300, 0, false);
+                        } else {
+                            $ionicScrollDelegate.$getByHandle("weeklyChart").scrollTo(getTodayPosition(), 0, true);
+                            $ionicScrollDelegate.$getByHandle("weeklyTable").scrollTo(300, 0, true);
+                        }
                     }, 0);
                 }
 


### PR DESCRIPTION
#1016 시간별 날씨에서 차트 스크롤 안되는 경우
* 재현 경로
 - 현재 위치가 아닌 도시가 추가된 상태에서 app 실행 시 차트의 가로 스크롤이 동작하지 않음(Note3, Android 5.0)
 - 현재 위치가 last index인 경우에는 재현되지 않음
* applyWeatherData에서 scrollTo 호출 시에 animation을 끄면 정상 동작함
* ios에서만 animation을 지원하도록 조건문 추가