### PR TITLE
뒷부분의 t3h가 -50로 표시 되는 문제

### DIFF
--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -291,7 +291,7 @@ function ControllerTown24h() {
 
         i = req.short.length - 1;
         for(;i>=0;i--) {
-            if(req.short[i].reh !== -1) {
+            if(req.short[i].t3h !== -50) {
                 break;
             }
         }


### PR DESCRIPTION
#1052
rss의 경우 api보다 데이터 양이 적기 때문에 뒷분의 데이터가 부족한 경우가 발생함.
invalid상태를 reh가 아니라, t3h로 변경.