### PR TITLE
android에서 location permission 주지 않는 경우, 무한 reloading 문제.

### DIFF
--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -1495,7 +1495,7 @@ angular.module('starter.services', [])
         WeatherInfo.loadTowns();
         $ionicPlatform.on('resume', function(){
             if (WeatherInfo.canLoadCity(WeatherInfo.getCityIndex()) === true) {
-                $rootScope.$broadcast('reloadEvent');
+                $rootScope.$broadcast('reloadEvent', 'resume');
             }
         });
         $ionicPlatform.ready(function() {


### PR DESCRIPTION
#1082
reloadEvent를 resume과, tab으로 분리
resume일 경우에는 retry popup이 있는 경우 loadWeatherData를 호출하지 않음.
popup window가 없는 경우 confirmPopup 변수를 항상 undefined로 유지해야 함.