### PR TITLE
device ready 이후 js 실행.

### DIFF
--- a/client/ionic.project
+++ b/client/ionic.project
@@ -14,12 +14,5 @@
       "path": "/v000705",
       "proxyUrl": "http://tw-wzdfac.rhcloud.com/v000705"
     }
-  ],
-  "browsers": [
-    {
-      "platform": "android",
-      "browser": "crosswalk",
-      "version": "12.41.296.5"
-    }
   ]
 }

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -15,11 +15,16 @@ angular.module('starter', [
     'ionic-timepicker'
 ])
     .run(function($ionicPlatform, Util, $rootScope, $location, WeatherInfo) {
-        $ionicPlatform.ready(function() {
+        //splash screen을 빠르게 닫기 위해 event 분리
+        //차후 device ready이후 순차적으로 실행할 부분 넣어야 함.
+        document.addEventListener("deviceready", function () {
             if (navigator.splashscreen) {
+                console.log('splash screen hide!!!');
                 navigator.splashscreen.hide();
             }
+        }, false);
 
+        $ionicPlatform.ready(function() {
             if (Util.isDebug()) {
                 Util.ga.debugMode();
             }
@@ -80,9 +85,14 @@ angular.module('starter', [
                     if (guideVersion === null || Util.guideVersion > Number(guideVersion)) {
                         $location.path('/guide');
                         return;
-                    } else if (WeatherInfo.getEnabledCityCount() === 0) {
-                        $location.path('/tab/search');
-                        return;
+                    } else {
+                        //추후 개선 필요해 보임.
+                        ionic.Platform.ready(function () {
+                            if (WeatherInfo.getEnabledCityCount() === 0) {
+                                $location.path('/tab/search');
+                                return;
+                            }
+                        });
                     }
                 }
 

--- a/client/www/js/controller.purchase.js
+++ b/client/www/js/controller.purchase.js
@@ -142,8 +142,6 @@ angular.module('controller.purchase', [])
     })
     .run(function($ionicPlatform, $ionicPopup, $q, Purchase) {
 
-        Purchase.loadPurchaseInfo();
-
         /**
          * check validation receipt by saved data in local storage
          */
@@ -199,6 +197,8 @@ angular.module('controller.purchase', [])
         }
 
         $ionicPlatform.ready(function() {
+
+            Purchase.loadPurchaseInfo();
 
             //check purchase state is canceled or refund
             if (Purchase.loaded) {

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -191,7 +191,6 @@ angular.module('starter.controllers', [])
             }
             $scope.cityCount = WeatherInfo.getEnabledCityCount();
 
-            $ionicLoading.show();
             applyWeatherData();
             loadWeatherData();
         }
@@ -900,7 +899,9 @@ angular.module('starter.controllers', [])
             }
         };
 
-        init();
+        ionic.Platform.ready(function () {
+            init();
+        });
     })
 
     .controller('SearchCtrl', function ($scope, $rootScope, $ionicPlatform, $ionicScrollDelegate, TwAds, $q,

--- a/client/www/js/service.push.js
+++ b/client/www/js/service.push.js
@@ -313,10 +313,10 @@ angular.module('service.push', [])
         return obj;
     })
     .run(function($ionicPlatform, Push) {
-
-        Push.loadPushInfo();
-
         $ionicPlatform.ready(function() {
+
+            Push.loadPushInfo();
+
             if (!window.PushNotification) {
                 console.log("push notification plugin is not set");
                 return;

--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -1489,11 +1489,13 @@ angular.module('starter.services', [])
         return obj;
     })
     .run(function($rootScope, $ionicPlatform, WeatherInfo, Util) {
-        WeatherInfo.loadCities();
-        WeatherInfo.loadTowns();
-        $ionicPlatform.on('resume', function(){
-            if (WeatherInfo.canLoadCity(WeatherInfo.getCityIndex()) === true) {
-                $rootScope.$broadcast('reloadEvent', 'resume');
-            }
+        $ionicPlatform.ready(function () {
+            WeatherInfo.loadCities();
+            WeatherInfo.loadTowns();
+            $ionicPlatform.on('resume', function(){
+                if (WeatherInfo.canLoadCity(WeatherInfo.getCityIndex()) === true) {
+                    $rootScope.$broadcast('reloadEvent', 'resume');
+                }
+            });
         });
     });


### PR DESCRIPTION
#1130
splashscreen을 빠르게 닫기 위해 event 분리
run에서 실해아하는 모든 것을 deviceready 이후로 변경.
ionicLoading은 loadWeatherData로 한정함.

remove crosswalk browser info in ionic.project