### PR TITLE
#1217 “TodayWeather@Wizardfactory” -> “광고없는 프리미엄 사용하기”

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -343,8 +343,6 @@ $font-family-base: "Bareun Dotum Pro", sans-serif !default;
 
 .purchase-content {
   background-color: #F5F5F5;
-  width: 100%;
-  height: 100%;
 }
 
 .item-center {

--- a/client/www/index.html
+++ b/client/www/index.html
@@ -46,9 +46,9 @@
   have templates inline in this html file if you'd like).
 -->
 <ion-nav-view></ion-nav-view>
-<div style="background-color: #444; width: 100%; height: 50px; position: absolute; bottom: 0; text-align: center"
-     ng-if="viewAdsBanner">
-    <h4 style="color: white; opacity: 0.84">TodayWeather@WizardFactory</h4>
+<div style="background-color: #444; width: 100%; height: 50px; position: absolute; bottom: 0; text-align: center; z-index: 4"
+     ng-if="viewAdsBanner" ng-click="clickAdsBanner();">
+    <h4 style="color: white; opacity: 0.84">광고없는 프리미엄 사용하기</h4>
 </div>
 </body>
 </html>

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -1540,9 +1540,7 @@ angular.module('starter.controllers', [])
         };
 
         $ionicPlatform.ready(function() {
-            $rootScope.viewAdsBanner = TwAds.enableAds;
-            $rootScope.contentBottom = TwAds.enableAds? 100 : 50;
-            angular.element(document.getElementsByClassName('tabs')).css('margin-bottom', TwAds.enableAds?'50px':'0px');
+            TwAds.setLayout(TwAds.enableAds === false? false : true);
         });
 
         init();

--- a/client/www/js/service.twads.js
+++ b/client/www/js/service.twads.js
@@ -3,7 +3,7 @@
  */
 
 angular.module('service.twads', [])
-    .factory('TwAds', function($rootScope, Util) {
+    .factory('TwAds', function($rootScope, $location, Util) {
         var obj = {};
         obj.enableAds;
         obj.showAds;
@@ -13,6 +13,11 @@ angular.module('service.twads', [])
         obj.ready = false;
         obj.bannerAdUnit = '';
         obj.interstitialAdUnit = '';
+
+        $rootScope.viewAdsBanner = true;
+        $rootScope.clickAdsBanner = function() {
+            $location.path('/purchase');
+        };
 
         obj.loadTwAdsInfo = function () {
             var twAdsInfo = JSON.parse(localStorage.getItem("twAdsInfo"));
@@ -39,12 +44,11 @@ angular.module('service.twads', [])
             localStorage.setItem("twAdsInfo", JSON.stringify(twAdsInfo));
         };
 
-        function _setLayout(enable) {
+        obj.setLayout = function (enable) {
             //close bottom box
-            $rootScope.viewAdsBanner = enable;
             $rootScope.contentBottom = enable?100:50;
             angular.element(document.getElementsByClassName('tabs')).css('margin-bottom', enable?'50px':'0px');
-        }
+        };
 
         obj._admobCreateBanner = function() {
             admob.createBannerView(
@@ -88,12 +92,12 @@ angular.module('service.twads', [])
                 });
 
                 obj.enableAds = enable;
-                _setLayout(enable);
+                obj.setLayout(enable);
                 Util.ga.trackEvent('app', 'account', 'premium');
             }
             else {
                 obj.enableAds = enable;
-                _setLayout(enable);
+                obj.setLayout(enable);
                 obj._admobCreateBanner();
                 Util.ga.trackEvent('app', 'account', 'free');
             }
@@ -101,6 +105,8 @@ angular.module('service.twads', [])
 
         obj.setShowAds = function(show) {
             console.log('set show ads show='+show);
+            $rootScope.viewAdsBanner = show;
+
             if(obj.showAds === show) {
                 console.log('already TwAds is show='+show);
                 return;


### PR DESCRIPTION
#1217 “TodayWeather@Wizardfactory” -> “광고없는 프리미엄 사용하기”
* ‘TodayWeather@WizardFactory’를 ‘광고없는 프리미엄 사용하기’으로 문구 변경
* ‘광고없는 프리미엄 사용하기’ 클릭 시 Purchase 페이지로 이동
 - 클릭 이벤트를 받지 못하는 문제 : ion-nav-view의 z-index가 3이라서 앞에 위치하도록 z-index 스타일 추가
 - TwAds에서 rootScope에 함수를 추가하여 ng-click에서 호출 : admob.setOptions가 실패한 경우 Purchase 페이지로 이동되지 않는 문제 처리
 - Purchase 페이지에서 ‘광고없는 프리미엄 사용하기’가 계속 보이는 문제 : viewAdsBanner를 TwAds의 enableAds 대신 setShowAds 함수의 show와 동기화 처리(ready되지 않은 상태에서도 설정되어야 함) & 프리미엄 사용자가 아닌 경우에 보이도록 true로 초기화
 - admob.setOptions가 실패한 경우 탭이 보이지 않는 문제 : TwAds.enableAds가 undefined 상태인 경우 TwAds.setLayout를 true로 설정
 - purchase의 하단에 1px 다른 색으로 표시되는 문제 : css의 purchase-content에서 width, height 제거