### PR TITLE
#1128 시간별날씨 차트에서 어제, 오늘 라인의 라벨 표시 추가

### DIFF
--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -31,8 +31,8 @@
                             </div>
                         </ion-scroll>
                         <div class="label">
-                            <div class="label-yesterday"></div> 어제<br/>
-                            <div class="label-today"></div> 오늘
+                            <div class="label-yesterday"></div> 전일 기온<br/>
+                            <div class="label-today"></div> 당일 기온
                         </div>
                     </div>
 


### PR DESCRIPTION
#1128 시간별날씨 차트에서 어제, 오늘 라인의 라벨 표시 추가
* 사용자 리뷰에서 기온 차트인지 인지하지 못하는 경우가 있어 문구를 ‘전일 기온/당일 기온’으로 변경