### PR TITLE
#1229 안드로이드에서 HistoryBack 기능 제거

### DIFF
--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -897,7 +897,7 @@ angular.module('starter.controllers', [])
         });
     })
 
-    .controller('SearchCtrl', function ($scope, $rootScope, $ionicPlatform, $ionicScrollDelegate, TwAds, $q,
+    .controller('SearchCtrl', function ($scope, $rootScope, $ionicPlatform, $ionicScrollDelegate, TwAds, $q, $ionicHistory,
                                         $location, WeatherInfo, WeatherUtil, Util, ionicTimePicker, Push, $ionicLoading) {
         $scope.searchWord = undefined;
         $scope.searchResults = [];
@@ -909,6 +909,8 @@ angular.module('starter.controllers', [])
         var searchIndex = -1;
 
         function init() {
+            $ionicHistory.clearHistory();
+
             for (var i = 0; i < WeatherInfo.getCityCount(); i += 1) {
                 var city = WeatherInfo.getCityOfIndex(i);
                 var address = WeatherUtil.getShortenAddress(city.address).split(",");
@@ -1283,8 +1285,10 @@ angular.module('starter.controllers', [])
         init();
     })
 
-    .controller('SettingCtrl', function($scope, $http, Util, Purchase) {
+    .controller('SettingCtrl', function($scope, $http, Util, Purchase, $ionicHistory) {
         function init() {
+            $ionicHistory.clearHistory();
+
             if (ionic.Platform.isAndroid()) {
                 //get interval time;
                 $scope.updateInterval = "0";
@@ -1543,7 +1547,7 @@ angular.module('starter.controllers', [])
     })
 
     .controller('GuideCtrl', function($scope, $rootScope, $ionicSlideBoxDelegate, $ionicNavBarDelegate,
-                                      $location, $ionicHistory, Util, TwAds, $ionicPopup, WeatherInfo) {
+                                      $location, Util, TwAds, $ionicPopup, WeatherInfo) {
         var guideVersion = null;
 
         $scope.data = { 'autoSearch': false };


### PR DESCRIPTION
#1229 안드로이드에서 HistoryBack 기능 제거
* Search, Setting 탭 전환 시 History Clear
* Setting 탭에서 Purchase, Guide 페이지 이동 시에는 History Back으로 다시 Setting으로 이동 가능함