### PR TITLE
#1255 guide에서 못 나가는 문제

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -137,7 +137,8 @@ $font-family-base: "Bareun Dotum Pro", sans-serif !default;
 .guide-close {
   font-size: 28px;
   padding: 10px;
-  float: right;
+  position: absolute;
+  right: 0px;
   color: inherit;
 }
 


### PR DESCRIPTION
#1255 guide에서 못 나가는 문제
* 닫기 버튼 위치에 의해 가이드 타이틀 글자 위치가 왼쪽으로 치우치는 문제 수정
 - float 대신 position 속성으로 대체