### PR TITLE
AWS의 측정값에 대하여 오류 체크 강화하기.

### DIFF
--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -1026,7 +1026,7 @@ function ControllerTown() {
                 var date = kmaTimeLib.convertDateToYYYYMMDD(now);
                 var time = kmaTimeLib.convertDateToHHMM(now);
                 log.info(date+time);
-                controllerKmaStnWeather.getStnMinute(townInfo, date+time, req.current.t1h, function (err, stnWeatherInfo) {
+                controllerKmaStnWeather.getStnCheckedMinute(townInfo, date+time, req.current, function (err, stnWeatherInfo) {
                     if (err) {
                         log.error(err);
                         next();
@@ -1039,8 +1039,12 @@ function ControllerTown() {
                         return;
                     }
 
+                    stnWeatherInfo.t1h = undefined;
+
                     for (var key in stnWeatherInfo) {
-                        req.current[key] = stnWeatherInfo[key];
+                        if (!(stnWeatherInfo[key] == undefined)) {
+                            req.current[key] = stnWeatherInfo[key];
+                        }
                     }
 
                     //24시 01분부터 1시까지 날짜 맞지 않음.

--- a/server/lib/kmaTimeLib.js
+++ b/server/lib/kmaTimeLib.js
@@ -112,6 +112,14 @@ kmaTimeLib.convertYYYYMMDDHHMMtoYYYYoMMoDDoHHoMM = function(dateStr) {
     return str;
 };
 
+kmaTimeLib.convertYYYYMMDDHHMMtoYYYYoMMoDDoHHoZZ = function(dateStr) {
+    var str = dateStr.substr(0,4)+'.'+dateStr.substr(4,2)+'.'+dateStr.substr(6,2);
+    if (dateStr.length > 8) {
+        str += '.' + dateStr.substr(8,2) + ':00';
+    }
+    return str;
+};
+
 /**
  * for kma scraper
  * @param date

--- a/server/routes/v000705/dailySummary.js
+++ b/server/routes/v000705/dailySummary.js
@@ -25,7 +25,7 @@ function divideParams(req, res, next) {
 
 
 router.get('/town/*', [divideParams, cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,

--- a/server/routes/v000705/routeTownForecast.js
+++ b/server/routes/v000705/routeTownForecast.js
@@ -41,7 +41,7 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -50,7 +50,7 @@ router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRs
                                     cTown.getSummary, cTown.dataToFixed, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -63,7 +63,7 @@ router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getS
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -87,7 +87,7 @@ router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTo
 router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.convert0Hto24H, cTown.insertIndex,
                                     cTown.insertStrForData, cTown.dataToFixed, cTown.sendResult]);
 
-router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
                                     cTown.insertStrForData, cTown.getSummary, cTown.dataToFixed, cTown.sendResult]);
 

--- a/server/routes/v000803/routeTownForecast.js
+++ b/server/routes/v000803/routeTownForecast.js
@@ -41,7 +41,7 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -50,7 +50,7 @@ router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRs
                                     cTown.getSummary, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -63,7 +63,7 @@ router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getS
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeCurrentByShortest,  cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -87,7 +87,7 @@ router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTo
 router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.convert0Hto24H, cTown.insertIndex,
                                             cTown.insertStrForData, cTown.sendResult]);
 
-router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnHourlyWeather, cTown.getKmaStnMinuteWeather,
+router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.getKmaStnMinuteWeather,
                                             cTown.convert0Hto24H, cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
                                             cTown.insertStrForData, cTown.getSummary, cTown.sendResult]);
 


### PR DESCRIPTION
#1294
동네예보의 정보를 가지고 AWS의 동일한 시간에 데이터와 갭이 많이 나지 않는 경우에만 데이터를 사용.
t1h, rain 두개로 분리
t1h의 측정소에서 wsd, reh값이 크게 벗어나지 않으면 사용.
적정 범위내의 데이터가 없으면 측정소의 값음 버림.