### PR TITLE
update kma shortest forecast

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -69,7 +69,7 @@ app.use('/v000803', require('./routes/v000803'));
 
 global.curString = ['t1h', 'rn1', 'sky', 'uuu', 'vvv', 'reh', 'pty', 'lgt', 'vec', 'wsd'];
 global.shortString = ['pop', 'pty', 'r06', 'reh', 's06', 'sky', 't3h', 'tmn', 'tmx', 'uuu', 'vvv', 'wav', 'vec', 'wsd'];
-global.shortestString = ['pty', 'rn1', 'sky', 'lgt'];
+global.shortestString = ['pty', 'rn1', 'sky', 'lgt', 't1h', 'uuu', 'vvv', 'reh', 'vec', 'wsd'];
 global.commonString = ['date', 'time'];
 global.rssString = ['ftm', 'date', 'temp', 'tmx', 'tmn', 'sky', 'pty', 'wfKor', 'wfEn', 'pop', 'r12', 's12', 'ws', 'wd', 'wdKor', 'wdEn', 'reh', 'r06', 's06'];
 global.forecastString = ['cnt', 'wfsv'];

--- a/server/lib/collectTownForecast.js
+++ b/server/lib/collectTownForecast.js
@@ -530,7 +530,13 @@ CollectData.prototype.organizeShortestData = function(index, listData) {
         pty: -1, /* 강수 형태 : 1%, invalid : -1 */
         rn1: -1, /* 1시간 강수량 : ~1mm(1) 1~4(5) 5~9(10) 10~19(20) 20~39(40) 40~69(70) 70~(100), invalid : -1 */
         sky: -1, /* 하늘상태 : 맑음(1) 구름조금(2) 구름많음(3) 흐림(4) , invalid : -1*/
-        lgt: -1 /* 낙뢰 : 확률없음(0) 낮음(1) 보통(2) 높음(3), invalid : -1 */
+        lgt: -1, /* 낙뢰 : 확률없음(0) 낮음(1) 보통(2) 높음(3), invalid : -1 */
+        t1h: -50,
+        reh: -1,
+        uuu: -100,
+        vvv: -100,
+        vec: -1,
+        wsd: -1
     };
 
     //log.info('shortestData count : ' + listItem.length);
@@ -563,14 +569,20 @@ CollectData.prototype.organizeShortestData = function(index, listData) {
                 result.my = parseInt(item.ny[0]);
 
                 var val = parseFloat(item.fcstValue[0]);
-                if (val < 0) {
-                    log.error('organize Shortest Get invalid data '+ item.category[0]+ ' result'+ JSON.stringify(result));
-                }
+                //if (val < 0) {
+                //    log.error('organize Shortest Get invalid data '+ item.category[0]+ ' result'+ JSON.stringify(result));
+                //}
 
                 if(item.category[0] === 'PTY') {result.pty = val;}
                 else if(item.category[0] === 'RN1') {result.rn1 = val;}
                 else if(item.category[0] === 'SKY') {result.sky = val;}
                 else if(item.category[0] === 'LGT') {result.lgt = val;}
+                else if(item.category[0] === 'T1H') {result.t1h = val;}
+                else if(item.category[0] === 'REH') {result.reh = val;}
+                else if(item.category[0] === 'UUU') {result.uuu = val;}
+                else if(item.category[0] === 'VVV') {result.vvv = val;}
+                else if(item.category[0] === 'VEC') {result.vec = val;}
+                else if(item.category[0] === 'WSD') {result.wsd = val;}
                 else{
                     log.error(new Error('Known property '+item.category[0]));
                 }

--- a/server/models/modelShortest.js
+++ b/server/models/modelShortest.js
@@ -18,7 +18,13 @@ var shortestSchema = new mongoose.Schema({
         pty: {type:Number, default:-1},
         rn1: {type:Number, default:-1},
         sky: {type:Number, default:-1},
-        lgt: {type:Number, default:-1}
+        lgt: {type:Number, default:-1},
+        t1h: {type:Number, default:-50},
+        reh: {type:Number, default:-1},
+        uuu: {type:Number, default:-100},
+        vvv: {type:Number, default:-100},
+        vec: {type:Number, default:-1},
+        wsd: {type:Number, default:-1}
     }]
 });
 

--- a/server/routes/v000705/routeTownForecast.js
+++ b/server/routes/v000705/routeTownForecast.js
@@ -41,8 +41,8 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -50,8 +50,8 @@ router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRs
                                     cTown.getSummary, cTown.dataToFixed, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -63,8 +63,8 @@ router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getS
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,

--- a/server/routes/v000803/routeTownForecast.js
+++ b/server/routes/v000803/routeTownForecast.js
@@ -41,8 +41,8 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -50,8 +50,8 @@ router.get('/:region', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRs
                                     cTown.getSummary, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,
@@ -63,8 +63,8 @@ router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.getShort, cTown.getS
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest,  cTown.mergeShortWithCurrentList,
+                                    cTown.getCurrent, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.convert0Hto24H,  cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,


### PR DESCRIPTION
#1312
update modelShortest (new t1h, reh, uuu, vvv, vec, wsd)
current에 shortest를 적용하고, AWS데이터 적용함.

fixed
과거 데이터가 없는 경우, KMA로부터 데이터를 가지고 오면 전일 동일 시간의 한시간 후 부터 데이터가 있음