### PR TITLE
#1085 권한이 없는 경우와 위치 정보를 못 가지고 오는 경우 분리.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -72,7 +72,8 @@
         "DEEPLINK_HOST": "net.wizardfactory.todayweather",
         "ANDROID_PATH_PREFIX": "/"
       }
-    }
+    },
+    "cordova.plugins.diagnostic"
   ],
   "cordovaPlatforms": [
     "ios",

--- a/client/www/js/services.js
+++ b/client/www/js/services.js
@@ -1542,6 +1542,27 @@ angular.module('starter.services', [])
         //obj.url = "https://todayweather.wizardfactory.net/v000705";
         //obj.url = window.twClientConfig.serverUrl;
 
+        // android는 diagnostic.locationMode, ios는 diagnostic.permissionStatus를 나타냄
+        obj.locationStatus = undefined;
+
+        obj.isLocationEnabled = function() {
+            var that = this;
+
+            if (ionic.Platform.isIOS()) {
+                if (that.locationStatus === cordova.plugins.diagnostic.permissionStatus.GRANTED
+                    || that.locationStatus === cordova.plugins.diagnostic.permissionStatus.GRANTED_WHEN_IN_USE) {
+                    return true;
+                }
+            } else if (ionic.Platform.isAndroid()) {
+                if (that.locationStatus === cordova.plugins.diagnostic.locationMode.HIGH_ACCURACY
+                    || that.locationStatus === cordova.plugins.diagnostic.locationMode.BATTERY_SAVING
+                    || that.locationStatus === cordova.plugins.diagnostic.locationMode.DEVICE_ONLY) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
         return obj;
     })
     .run(function($rootScope, $ionicPlatform, WeatherInfo, Util) {
@@ -1552,6 +1573,13 @@ angular.module('starter.services', [])
 
         if (ionic.Platform.isIOS()) {
             Util.ga.startTrackerWithId(twClientConfig.gaIOSKey);
+
+            // isLocationEnabled 요청해야 registerLocationStateChangeHandler가 호출됨
+            cordova.plugins.diagnostic.isLocationEnabled(function(enabled) {
+                console.log("Location setting is " + (enabled ? "enabled" : "disabled"));
+            }, function(error) {
+                console.error("Error getting for location enabled status: " + error);
+            });
         } else if (ionic.Platform.isAndroid()) {
             Util.ga.startTrackerWithId(twClientConfig.gaAndroidKey, 30);
 
@@ -1559,6 +1587,13 @@ angular.module('starter.services', [])
              * 기존 버전 호환성이슈로 Android는 유지.
              */
             Util.suiteName = "net.wizardfactory.todayweather_preferences";
+
+            // android는 실행 시 registerLocationStateChangeHandler 호출되지 않으므로 직접 locationMode를 가져와서 설정함
+            cordova.plugins.diagnostic.getLocationMode(function(locationMode) {
+                Util.locationStatus = locationMode;
+            }, function(error) {
+                console.error("Error getting for location mode: " + error);
+            });
         }
         else {
             console.log("Error : Unknown platform");
@@ -1620,8 +1655,20 @@ angular.module('starter.services', [])
         WeatherInfo.loadCities();
         WeatherInfo.loadTowns();
         $ionicPlatform.on('resume', function(){
-            if (WeatherInfo.canLoadCity(WeatherInfo.getCityIndex()) === true) {
-                $rootScope.$broadcast('reloadEvent', 'resume');
+            $rootScope.$broadcast('reloadEvent', 'resume');
+        });
+
+        // ios는 실행 시 registerLocationStateChangeHandler 호출되어 locationStatus가 설정됨
+        cordova.plugins.diagnostic.registerLocationStateChangeHandler(function (state) {
+            var oldLocationEnabled = Util.isLocationEnabled();
+
+            console.log("Location state changed to: " + state);
+            Util.locationStatus = state;
+
+            if (oldLocationEnabled === false && Util.isLocationEnabled()) {
+                $rootScope.$broadcast('reloadEvent', 'locationOn');
             }
+        }, function (error) {
+            console.error("Error registering for location state changes: " + error);
         });
     });


### PR DESCRIPTION
#1085 권한이 없는 경우와 위치 정보를 못 가지고 오는 경우 분리.
* cordova.plugins.diagnostic 플러그인 추가
* 시간별날씨/일별날씨에서 현재 위치 찾기
 - 위치 서비스 On 상태
  + 위치 접근 권한 있는 경우 : 현재 위치 찾기(찾은 경우에는 날씨 정보 요청)
  + 위치 접근 권한 설정이 되어 있지 않은 경우 : 권한 요청 팝업 표시
  + 위치 접근 권한이 거부되어 있는 경우 : 저장된 위치가 없으면 에러 팝업 표시 / 저장된 위치가 있으면 저장된 위치로 날씨 정보 업데이트
 - 위치 서비스 Off 상태 : 저장된 위치가 없으면 에러 팝업 표시 / 저장된 위치가 있으면 저장된 위치로 날씨 정보 업데이트
* 즐겨찾기의 현재 위치 찾기
 - 위치 서비스 On 상태
  + 위치 접근 권한 있는 경우 : 현재 위치 찾기
  + 위치 접근 권한 설정이 되어 있지 않은 경우 : 권한 요청 팝업 표시
  + 위치 접근 권한이 거부되어 있는 경우 : 에러 팝업 표시
 - 위치 서비스 Off 상태 : 에러 팝업 표시
* 즐겨찾는 지역 목록에 표시되는 현재 위치 날씨 정보는 저장된 위치를 기준으로 날씨 데이터를 업데이트함(저장된 위치가 없으면 표시 안함)