### PR TITLE
unused mergeCurrentByShortest

### DIFF
--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -990,6 +990,13 @@ function ControllerTown() {
         return this;
     };
 
+    /**
+     * 사용하지 않음. #823
+     * @param req
+     * @param res
+     * @param next
+     * @returns {ControllerTown}
+     */
     this.mergeCurrentByShortest = function (req, res, next) {
         var meta = {};
 

--- a/server/routes/v000705/dailySummary.js
+++ b/server/routes/v000705/dailySummary.js
@@ -26,7 +26,7 @@ function divideParams(req, res, next) {
 
 router.get('/town/*', [divideParams, cTown.getAllDataFromDb, cTown.getShort, cTown.getShortRss, cTown.getShortest,
                                     cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeCurrentByShortest, cTown.mergeShortWithCurrentList,
+                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getKeco, cTown.getKecoDustForecast,

--- a/server/routes/v000705/routeTownForecast.js
+++ b/server/routes/v000705/routeTownForecast.js
@@ -41,7 +41,7 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -50,7 +50,7 @@ router.get('/:region', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.g
                                     cTown.getSummary, cTown.dataToFixed, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -63,7 +63,7 @@ router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.checkDBValidation, c
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,

--- a/server/routes/v000803/routeTownForecast.js
+++ b/server/routes/v000803/routeTownForecast.js
@@ -41,7 +41,7 @@ router.get('/', [cTown.getSummary], function(req, res) {
 });
 
 router.get('/:region', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -50,7 +50,7 @@ router.get('/:region', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.g
                                     cTown.getSummary, cTown.sendResult]);
 
 router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
@@ -63,7 +63,7 @@ router.get('/:region/:city', [cTown.getAllDataFromDb, cTown.checkDBValidation, c
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
 router.get('/:region/:city/:town', [cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.mergeCurrentByShortest, cTown.getKmaStnMinuteWeather,
+                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H,  cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,


### PR DESCRIPTION
#823
예보시간 변경으로 다가올 shotest는 30분 발표가 아니라, 1시간 30분전 발표 내용이라 제외함.