### PR TITLE
데이터 업데이트는 늦는 경우 무시, current가 없는 경우 고려.

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -89,7 +89,7 @@ if (config.mode === 'gather' || config.mode === 'local') {
     manager.startManager();
 }
 
-if (config.mode === 'push' || config.mode === 'local') {
+if (config.mode === 'push') {
     var ControllerPush = require('./controllers/controllerPush');
     var co = new ControllerPush();
     co.start();

--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -576,6 +576,11 @@ controllerKmaStnWeather.getStnCheckedMinute = function (townInfo, dateTime, curr
                 var cityWeatherIndex;
                 var pushedIndex;
                 stnHourWeatherList.forEach(function (stnHourWeather, index) {
+                    if (current.t1h == undefined && stnHourWeather.isCityWeather) {
+                        stnHourWeather.isT1hStn = true;
+                        listFiltered.push(stnHourWeather);
+                        t1hIndex = pushedIndex = index;
+                    }
                     if (Math.abs(stnHourWeather.t1h - current.t1h) < 1 && t1hIndex == undefined) {
                         stnHourWeather.isT1hStn = true;
                         listFiltered.push(stnHourWeather);
@@ -611,7 +616,7 @@ controllerKmaStnWeather.getStnCheckedMinute = function (townInfo, dateTime, curr
                     opt.skipReh = true;
                     opt.skipWsd = true;
                 }
-                if (rainIndex == undefined) {
+                if (!(current.pty == undefined) && rainIndex == undefined) {
                     opt.skipRain = true;
                 }
                 aCallback(undefined, listFiltered);
@@ -631,7 +636,12 @@ controllerKmaStnWeather.getStnCheckedMinute = function (townInfo, dateTime, curr
             }, function (stnList, aCallback) {
                 self._getStnMinuteList(stnList, stnDateTime, function (err, results) {
                     if (err) {
-                        return aCallback(err);
+                        log.error(err);
+                        return aCallback(undefined, stnList);
+                    }
+                    if (results.length == 0) {
+                        log.error("Fail to get stn minute, so use hourly");
+                        return aCallback(undefined, stnList);
                     }
                     aCallback(err, results);
                 })

--- a/server/lib/collectTownForecast.js
+++ b/server/lib/collectTownForecast.js
@@ -313,7 +313,12 @@ CollectData.prototype.getData = function(index, dataType, url, options, callback
 
     req.get(url, {timeout: 1000*10}, function(err, response, body){
         if(err) {
-            log.warn(err);
+            if (err.code == "ETIMEDOUT") {
+                log.debug(err);
+            }
+            else {
+                log.warn(err);
+            }
             //log.error('#', meta);
 
             self.emit('recvFail', index);
@@ -353,8 +358,8 @@ CollectData.prototype.getData = function(index, dataType, url, options, callback
                 if(err || (result.response.header[0].resultCode[0] !== '0000') ||
                     (result.response.body[0].totalCount[0] === '0')) {
                     // there is error code or totalcount is zero as no valid data.
-                    log.error('There are no data', result.response.header[0].resultCode[0], result.response.body[0].totalCount[0]);
-                    log.error(meta);
+                    log.warn('There are no data', result.response.header[0].resultCode[0], result.response.body[0].totalCount[0]);
+                    log.warn(meta);
                     self.emit('recvFail', index);
                 }
                 else{


### PR DESCRIPTION
#1328
업데이트 늦은 경우에는 무시함 - 시간이 오래 걸리고, 기존 데이터와 머지해야 함.

#1294
current가 없는 경우 측정소 정보로 current를 생성함.
AWS STN의 분단위 데이터가 없는 경우 시단위 데이터라도 넘김.
AWS STN 데이터는 current의 pubdate보다 최신인 경우에만 사용.

etc
local에서는 push 동작안함.
ETIMEOUT의 경우 debug로 loglevel 조정.
data 없는 경우도 loglevel 조정.