### PR TITLE
release 0.9.26

### DIFF
--- a/client/config-androidsdk14.xml
+++ b/client/config-androidsdk14.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="net.wizardfactory.todayweather" version="0.9.24" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="net.wizardfactory.todayweather" version="0.9.26" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>TodayWeather</name>
   <description>
         Inform how warm or cold it is today than yesterday.
@@ -14,6 +14,7 @@
   <preference name="DisallowOverscroll" value="true"/>
   <preference name="android-minSdkVersion" value="14"/>
   <preference name="android-maxSdkVersion" value="18" />
+  <preference name="android-targetSdkVersion" value="24"/>
   <preference name="BackupWebStorage" value="local"/>
   <preference name="SplashScreen" value="screen"/>
   <preference name="FadeSplashScreen" value="false"/>

--- a/client/config-androidsdk19.xml
+++ b/client/config-androidsdk19.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="net.wizardfactory.todayweather" version="0.9.24" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="net.wizardfactory.todayweather" version="0.9.26" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>TodayWeather</name>
   <description>
         Inform how warm or cold it is today than yesterday.
@@ -13,6 +13,7 @@
   <preference name="UIWebViewBounce" value="false"/>
   <preference name="DisallowOverscroll" value="true"/>
   <preference name="android-minSdkVersion" value="19"/>
+  <preference name="android-targetSdkVersion" value="24"/>
   <preference name="BackupWebStorage" value="local"/>
   <preference name="SplashScreen" value="screen"/>
   <preference name="FadeSplashScreen" value="false"/>

--- a/client/config.xml
+++ b/client/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="net.wizardfactory.todayweather" version="0.9.24" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="net.wizardfactory.todayweather" version="0.9.26" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>TodayWeather</name>
   <description>
         Inform how warm or cold it is today than yesterday.
@@ -13,6 +13,7 @@
   <preference name="UIWebViewBounce" value="false"/>
   <preference name="DisallowOverscroll" value="true"/>
   <preference name="android-minSdkVersion" value="14"/>
+  <preference name="android-targetSdkVersion" value="24"/>
   <preference name="BackupWebStorage" value="local"/>
   <preference name="SplashScreen" value="screen"/>
   <preference name="FadeSplashScreen" value="false"/>
@@ -85,4 +86,5 @@
   <icon src="resources/android/icon/drawable-xhdpi-icon.png"/>
   <allow-navigation href="*"/>
   <allow-intent href="mailto:*"/>
+  <plugin name="cordova-plugin-google-analytics" spec="1.7.1" />
 </widget>

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -94,7 +94,7 @@ gulp.task('release-nonpaid', shell.task([
   '~/Library/Android/sdk/build-tools/23.0.3/zipalign -v 4 android-release.apk TodayWeather_ads_onestore_v'+json.version+'_min19.apk',
 
   'cp ads.ios_playstore.tw.client.config.js www/tw.client.config.js',
-  'cordova plugin add cordova-plugin-inapppurchase',
+  'cordova plugin add cordova-plugin-inapppurchase@1.0.0',
   'ionic build android --release',
   'cp platforms/android/build/outputs/apk/android-release.apk ./',
   '~/Library/Android/sdk/build-tools/23.0.3/zipalign -v 4 android-release.apk TodayWeather_ads_playstore_v'+json.version+'_min19.apk',

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TodayWeather",
-  "version": "0.9.24",
+  "version": "0.9.26",
   "description": "TodayWeather: Inform how warm or cold it is today than yesterday.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
android-targetSdkVersion=24
fixed version of inapppurchase to 1.0.0

0.9.26
inapppurchase version downgrade

0.9.25
적설량 단위 오류 수정
안드로이드 위젯 현재온도 소수점 한자리까지 지원(세계날씨용 위젯 적용)
위치정보에 대하여 권한이 없는 경우와 못 가지고 오는 경우에 대한 에러 세분화
위치정보가 꺼져 있는 경우 날씨정보만 갱신
광고제거 페이지 오류 수정