### PR TITLE
timeZone 계산 수정

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -64,8 +64,8 @@ app.use('/', require('./routes/v000001'));
 app.use('/v000001', require('./routes/v000001'));
 app.use('/v000705', require('./routes/v000705'));
 app.use('/v000803', require('./routes/v000803'));
-//app.use('/ww', require('./routes/worldweather/routeWeather'));
-//app.use('/req', require('./routes/worldweather/routeRequester'));
+app.use('/ww', require('./routes/worldweather/routeWeather'));
+app.use('/req', require('./routes/worldweather/routeRequester'));
 
 global.curString = ['t1h', 'rn1', 'sky', 'uuu', 'vvv', 'reh', 'pty', 'lgt', 'vec', 'wsd'];
 global.shortString = ['pop', 'pty', 'r06', 'reh', 's06', 'sky', 't3h', 'tmn', 'tmx', 'uuu', 'vvv', 'wav', 'vec', 'wsd'];

--- a/server/controllers/worldWeather/controllerWorldWeather.js
+++ b/server/controllers/worldWeather/controllerWorldWeather.js
@@ -372,9 +372,8 @@ function controllerWorldWeather(){
                         if(err){
                             log.error('Fail to get LocalTimezone : ', err);
                         }
+                        return callback(null);
                     });
-
-                    return callback(null);
                 },
                 /*
                 * No use WU data.
@@ -1028,7 +1027,7 @@ function controllerWorldWeather(){
             dsf.data.forEach(function(item){
                 item.hourly.data.forEach(function(dbItem){
                     var isExist = false;
-                    if(self._compareDateString(yesterdayDate, dbItem.dateObj)){
+                    if(self._compareDateString(yesterdayDate, dbItem.dateObj)) {
                         req.result.thisTime.forEach(function(thisTime, index){
                             if(thisTime.date != undefined &&
                                 self._compareDateString(yesterdayDate, thisTime.date)){
@@ -1054,7 +1053,7 @@ function controllerWorldWeather(){
                             }
                         });
                         if(!isExist){
-                            //log.info('NEW! DSF -> Hourly : ', dbItem.dateObj.toString());
+                            //log.info('NEW! DSF -> Hourly : ', dbItem.dateObj.toString(), JSON.stringify(dbItem));
                             req.result.hourly.push(self._makeHourlyDataFromDSF(dbItem));
                         }
                     }
@@ -1802,7 +1801,7 @@ function controllerWorldWeather(){
 
         async.parallel([
                 function(cb){
-                    modelWuCurrent.find({geocode:geocode}, function(err, list){
+                    modelWuCurrent.find({geocode:geocode}).lean().exec(function(err, list){
                         if(err){
                             log.error('gWU> fail to get WU Current data');
                             //cb(new Error('gFU> fail to get WU Current data'));
@@ -1822,7 +1821,7 @@ function controllerWorldWeather(){
                     });
                 },
                 function(cb){
-                    modelWuForecast.find({geocode:geocode}, function(err, list){
+                    modelWuForecast.find({geocode:geocode}).lean().exec(function(err, list){
                         if(err){
                             log.error('gWU> fail to get WU Forecast data');
                             //cb(new Error('gFU> fail to get WU Forecast data'));
@@ -1863,7 +1862,7 @@ function controllerWorldWeather(){
             lon: parseFloat(req.geocode.lon)
         };
 
-        modelDSForecast.find({geocode:geocode}, function(err, list){
+        modelDSForecast.find({geocode:geocode}).lean().exec(function(err, list){
             if(err){
                 log.error('gDSF> fail to get DSF data');
                 callback(err);


### PR DESCRIPTION
#1290
turn on world weather API
getTime()에서 timeZone이 고려되어 있으므로, 모든 값을 UTC로 초기화하고, date와 hours만 조정함.
ISOString()로 나오는 시간 값에 timeOffset를 더 했을때, 지역에서 원하는 시간이 나오면 됨.
getLocalTimezone 에서 callback 위치 오류 수정.
find().lean()을 사용하여 데이터 최적화