### PR TITLE
현재날씨 시간 오류 수정, 날씨를 도시별날씨+AWS우선으로 변경함.

### DIFF
--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -89,6 +89,7 @@ controllerKmaStnWeather._makeWeatherType = function (weatherStr) {
         case '번개': return 55;
         case '마른뇌전': return 56;
         case '뇌전끝': return 57;
+        case '얼음싸라기': return 58;
         default :
             log.error("Fail weatherStr="+weatherStr);
     }

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -891,13 +891,19 @@ function ControllerTown() {
         if (weather == undefined) {
             return 0;
         }
-        if (weather.indexOf("비") >= 0) {
+        if (weather.indexOf("끝") >= 0) {
+            return 0;
+        }
+        else if (weather.indexOf("비") >= 0) {
             return 1;
         }
         else if (weather.indexOf("진눈깨비") >= 0) {
             return 2;
         }
         else if (weather.indexOf("눈") >= 0) {
+            return 3;
+        }
+        else if (weather.indexOf("얼음") >= 0) { //얼음싸라기
             return 3;
         }
         else if (rns == true) {
@@ -1330,7 +1336,9 @@ function ControllerTown() {
                     }
 
                     /* 분단위 데이터지만, 분단위 데이터가 없는 경우 시간단위 데이터가 올수 있음. */
-                    /* todo: 분단위 데이터와 시단위 데이터를 분리해서 시단위는 동네예보와 우선순위 선정하는게 더 정확함. */
+                    /* todo: 분단위 데이터와 시단위 데이터를 분리해서 시단위는 동네예보와 우선순위 선정하는게 더 정확함.
+                        current -> 도시별 날씨 -> AWS 분단위 -> 초단기 */
+
                     var stnWeatherInfoTime = new Date(stnWeatherInfo.stnDateTime);
                     var stnFirst = true;
                     if (!(req.currentPubDate == undefined)) {
@@ -1353,18 +1361,30 @@ function ControllerTown() {
                         }
                     }
 
+                    if (stnFirst) {
+                        req.current.date = kmaTimeLib.convertDateToYYYYMMDD(stnWeatherInfoTime);
+                        req.current.time = kmaTimeLib.convertDateToHHZZ(stnWeatherInfoTime);
+                    }
 
-                    if (req.current.rn1 == undefined) {
-                        req.current.rn1 = stnWeatherInfo.rs1h;
+                    if (req.current.rn1 == undefined || stnFirst) {
+                        if (!(stnWeatherInfo.rs1h == undefined)) {
+                            req.current.rn1 = stnWeatherInfo.rs1h;
+                        }
                     }
-                    if (req.current.sky == undefined) {
-                        req.current.sky = _convertCloud2SKy(stnWeatherInfo.cloud);
+                    if (req.current.sky == undefined || stnFirst) {
+                        if (!(stnWeatherInfo.cloud == undefined)) {
+                            req.current.sky = _convertCloud2SKy(stnWeatherInfo.cloud);
+                        }
                     }
-                    if (req.current.pty == undefined) {
-                        req.current.pty = _convertStnWeather2Pty(stnWeatherInfo.rns, stnWeatherInfo.weather);
+                    if (req.current.pty == undefined || stnFirst) {
+                        if (!(stnWeatherInfo.weather == undefined) && !(stnWeatherInfo.rns == undefined)) {
+                            req.current.pty = _convertStnWeather2Pty(stnWeatherInfo.rns, stnWeatherInfo.weather);
+                        }
                     }
-                    if (req.current.lgt == undefined) {
-                        req.current.lgt = _convertStnWeather2Lgt(stnWeatherInfo.weather);
+                    if (req.current.lgt == undefined || stnFirst) {
+                        if (!(stnWeatherInfo.weather == undefined)) {
+                            req.current.lgt = _convertStnWeather2Lgt(stnWeatherInfo.weather);
+                        }
                     }
 
                     if (stnFirst) {


### PR DESCRIPTION
#1372
liveTime이 존재하는 경우, current.date와 current.time을 stnDateTime에 맞춤.
#1278
'얼음싸라기' 추가.
weather에 '끝'이 들어가면 pty는 0으로 설정, '얼음'은 눈으로 간주.
sky, pty, lgt, rn1을 도시별날씨와 AWS정보를 우선하게 수정.