### PR TITLE
도시별날씨가 업데이트 되지 않은 경우 고려

### DIFF
--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -555,7 +555,7 @@ controllerKmaStnWeather.getStnCheckedMinute = function (townInfo, dateTime, curr
                         return pCallback(err, kmaStnList);
                     });
                 }, function (pCallback) {
-                    KmaStnInfo.find({geo: {$near:coords, $maxDistance: 1}, isCityWeather: true}).limit(1).lean().exec(function (err, kmaStnList) {
+                    KmaStnInfo.find({geo: {$near:coords, $maxDistance: 1}, isCityWeather: true}).limit(3).lean().exec(function (err, kmaStnList) {
                         if (err) {
                             return pCallback(err);
                         }


### PR DESCRIPTION
#1438
특정 도시별날씨가 업데이트 되지 않은 경우 다음 가까운 도시별날씨를 사용하게 수정.
갯수를 늘려도, filter하는 곳에서 한개만 추출함.