### PR TITLE
#1043 Play store, App store featured 도전

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -1101,6 +1101,61 @@ angular.module('starter', [
             };
         });
 
+        $compileProvider.directive('tabsShrink', function($document) {
+            return {
+                restrict: 'A',
+                link: function($scope, $element, $attr) {
+                    var tabs = $document[0].body.querySelector('.tab-nav');
+                    var tabsHeight = 50;
+                    var prevTop = 0;
+                    var request = null;
+
+                    function shrinkTabs(y, amount) {
+                        if ($scope.$root === null) {
+                            return;
+                        }
+
+                        var top = y + amount;
+                        tabs.style[ionic.CSS.TRANSFORM] = 'translate3d(0, ' + top + 'px, 0)';
+                        for(var i = 0, j = tabs.children.length; i < j; i++) {
+                            tabs.children[i].style.opacity = 1 - (top / tabsHeight);
+                        }
+
+                        $scope.$root.tabsTop = top;
+                        $scope.$root.$apply();
+
+                        if (top !== 0 && top !== tabsHeight) {
+                            request = ionic.requestAnimationFrame(function() {
+                                shrinkTabs(top, amount);
+                            });
+                        }
+                    }
+
+                    function onScroll(e) {
+                        var scrollTop = e.target.scrollTop;
+
+                        if (request === null) {
+                            if(scrollTop > prevTop && $scope.$root.tabsTop === 0) {
+                                request = ionic.requestAnimationFrame(function() {
+                                    shrinkTabs(0, 5);
+                                });
+                            } else if(scrollTop < prevTop && $scope.$root.tabsTop === tabsHeight) {
+                                request = ionic.requestAnimationFrame(function() {
+                                    shrinkTabs(tabsHeight, -5);
+                                });
+                            }
+                        } else {
+                            if($scope.$root.tabsTop === 0 || $scope.$root.tabsTop === tabsHeight) {
+                                request = null;
+                            }
+                        }
+                        prevTop = scrollTop;
+                    }
+                    $element.bind('scroll', onScroll);
+                }
+            }
+        });
+
         // Ionic uses AngularUI Router which uses the concept of states
         // Learn more here: https://github.com/angular-ui/ui-router
         // Set up the various states which the app can be in.

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -2148,6 +2148,16 @@ angular.module('starter.controllers', [])
             });
         };
 
+        $scope.contentHeight = function() {
+            if ($rootScope.contentBottom === undefined) {
+                $rootScope.contentBottom = 0;
+            }
+            if ($rootScope.tabsTop === undefined) {
+                $rootScope.tabsTop = 0;
+            }
+            return $rootScope.contentBottom - $rootScope.tabsTop;
+        };
+
         init();
     })
 

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -24,9 +24,9 @@
             </div>
         </div>
     </ion-header-bar>
-    <ion-content id="ionContentBody" delegate-handle="body" direction="y" ng-style="{'bottom':contentBottom+'px'}"
+    <ion-content id="ionContentBody" delegate-handle="body" direction="y" ng-style="{'bottom':contentHeight()+'px'}"
                  overflow-scroll="true" on-scroll="headerScroll()" zooming="false" scrollbar-y="false"
-                 scrollbar-x="false" has-bouncing="false" style="top: 0">
+                 scrollbar-x="false" has-bouncing="false" style="top: 0" tabs-shrink>
         <div id="contentBody">
             <div md-header-picture ng-style="{'height':headerHeight+'px'}"></div>
             <div class="main-content mid-forecast">

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -25,9 +25,9 @@
             </div>
         </div>
     </ion-header-bar>
-    <ion-content id="ionContentBody" delegate-handle="body" direction="y" ng-style="{'bottom':contentBottom+'px'}"
+    <ion-content id="ionContentBody" delegate-handle="body" direction="y" ng-style="{'bottom':contentHeight()+'px'}"
                  overflow-scroll="true" on-scroll="headerScroll()" zooming="false" scrollbar-y="false"
-                 scrollbar-x="false" has-bouncing="false" style="top: 0">
+                 scrollbar-x="false" has-bouncing="false" style="top: 0" tabs-shrink>
         <div id="contentBody">
             <div md-header-picture ng-style="::{'height':headerHeight+'px'}"></div>
             <div class="main-content short-forecast">

--- a/client/www/templates/tab-search.html
+++ b/client/www/templates/tab-search.html
@@ -8,7 +8,7 @@
         <a ng-class="isEditing?'ion-ios-checkmark-outline':'ion-ios-close-outline'" ng-click="OnEdit()"></a>
     </ion-header-bar>
     <ion-content class="search-content" zooming="false" direction="y" has-bouncing="false" scrollbar-y="false"
-                 delegate-handle="cityList" on-scroll="OnScrollResults()" ng-style="{'bottom':contentBottom+'px'}">
+                 delegate-handle="cityList" on-scroll="OnScrollResults()" ng-style="{'bottom':contentHeight()+'px'}" tabs-shrink>
         <div style="height:16px;"></div>
         <div class="list list-inset" ng-if="searchWord!==undefined">
             <div class="item" ng-repeat="result in searchResults" ng-click="OnSelectResult(result)">
@@ -65,5 +65,6 @@
                 </div>
             </div>
         </div>
+        <div style="height:16px;"></div>
     </ion-content>
 </ion-view>

--- a/client/www/templates/tab-setting.html
+++ b/client/www/templates/tab-setting.html
@@ -1,6 +1,6 @@
 <ion-view hide-nav-bar="true">
     <ion-content scroll="true" zooming="false" direction="y" has-bouncing="false" scrollbar-y="false"
-                 ng-style="{'bottom':contentBottom+'px'}" style="color: white;">
+                 ng-style="{'bottom':contentHeight()+'px'}" style="color: white;" tabs-shrink>
         <div class="row" style="height: 10%"></div>
         <div class="row" style="height: 15%">
             <div class="col" style="height: 100%; text-align: center;">


### PR DESCRIPTION
#1043 Play store, App store featured 도전
* 하단 탐색바는 화면 스크롤링 시 동적으로 나타나고 사라져야 함
 - "tabs-shrink" directive 추가
   + 아래로 스크롤 되면 tab의 top을 높이만큼 내려주고, 위로 스크롤 되면 다시 올려줌
 - contentHeight() 함수 추가
   + 아래로 내려간 tabsTop 만큼 content의 bottom도 아래로 내려가야 함
   + contentBottom에서 tabsTop을 뺀 값을 content의 bottom으로 계산
 - tab의 스크롤 되는 ion-content에 tabs-shrink 추가 및 bottom을 contentBottom 대신 contentHeight() 함수로 binding
 - 즐겨찾기 tab에서 도시 갯수에 따라 아래로 스크롤이 되어 탐색바가 사라졌지만 스크롤되지 않는 상태라 다시 보여지지 않는 문제가 발생
   + 임시로 하단에 공백 추가하여 스크롤 되도록 함(화면 크기에 따라 동일 문제 발생할 수 있음)