### PR TITLE
location auth에 대한 개선

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -73,7 +73,8 @@
       }
     },
     "cordova-plugin-globalization",
-    "cordova.plugins.diagnostic@3.3.3"
+    "cordova.plugins.diagnostic@3.3.3",
+    "cordova-plugin-request-location-accuracy"
   ],
   "cordovaPlatforms": [
     "ios",

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -258,7 +258,6 @@ angular.module('controller.forecastctrl', [])
         var imgBigSkyStateSize;
 
         // retry popup이 없는 경우 항상 undefined여야 함.
-        var confirmPopup;
         var isLoadingIndicator = false;
         var strError = "Error";
         var strAddLocation = "Add locations";
@@ -711,119 +710,6 @@ angular.module('controller.forecastctrl', [])
             isLoadingIndicator = false;
         }
 
-        var gLocationAuthorizationStatus;
-
-        /**
-         * android 6.0이상에서 처음 현재위치 사용시에, android 현재위치 접근에 대한 popup때문에 앱 pause->resume이 됨.
-         * 그래서 init와 reloadevent가 둘다 오게 되는데 retry confirm이 두개 뜨지 않게 한개 있는 경우 닫았다가 새롭게 열게 함.
-         * @param title
-         * @param template
-         * @param callback
-         */
-        function showRetryConfirm(title, template) {
-            if (confirmPopup) {
-                confirmPopup.close();
-            }
-
-            var buttons = [];
-            buttons.push({
-                text: strClose,
-                onTap: function () {
-                    return 'close';
-                }
-            });
-
-            if (window.cordova && cordova.plugins.diagnostic &&
-                gLocationAuthorizationStatus == cordova.plugins.diagnostic.permissionStatus.DENIED_ALWAYS) {
-                template += '<br>';
-                template += $translate.instant("LOC_OPENS_THE_APP_INFO_PAGE");
-
-                buttons.push({
-                    text: $translate.instant("LOC_SEARCH"),
-                    onTap: function () {
-                        return 'search';
-                    }
-                });
-
-                buttons.push({
-                    text: $translate.instant("LOC_SETTING"),
-                    type: 'button-positive',
-                    onTap: function () {
-                        return 'settings';
-                    }
-                });
-                Util.ga.trackEvent('window', 'show', 'deniedAlwaysPopup');
-            }
-            else if (window.cordova && cordova.plugins.diagnostic &&
-                gLocationAuthorizationStatus == cordova.plugins.diagnostic.permissionStatus.DENIED) {
-                buttons.push({
-                    text: $translate.instant("LOC_SEARCH"),
-                    onTap: function () {
-                        return 'search';
-                    }
-                });
-
-                buttons.push({
-                    text: strRetry,
-                    type: 'button-positive',
-                    onTap: function () {
-                        return 'retry';
-                    }
-                });
-                Util.ga.trackEvent('window', 'show', 'deniedPopup');
-            }
-            else {
-                buttons.push({
-                    text: strRetry,
-                    type: 'button-positive',
-                    onTap: function () {
-                        return 'retry';
-                    }
-                });
-                Util.ga.trackEvent('window', 'show', 'retryPopup');
-            }
-
-            confirmPopup = $ionicPopup.show({
-                title: title,
-                template: template,
-                buttons: buttons
-            });
-
-            confirmPopup
-                .then(function (res) {
-                    if (res == 'retry') {
-                        console.log('retry');
-                        Util.ga.trackEvent('action', 'click', 'reloadEvent');
-                        setTimeout(function () {
-                            $scope.$broadcast('reloadEvent');
-                        }, 0);
-                    }
-                    else if (res == 'search') {
-                        console.log('go search');
-                        Util.ga.trackEvent('action', 'click', 'moveSearch');
-                        WeatherInfo.disableCity(true);
-                        $location.path('/tab/search');
-                    }
-                    else if (res == 'settings') {
-                        console.log("Opens settings page for this app.");
-                        Util.ga.trackEvent('action', 'click', 'settings');
-                        setTimeout(function () {
-                            cordova.plugins.diagnostic.switchToSettings(function () {
-                                console.log("Successfully switched to Settings app");
-                            }, function (error) {
-                                console.log("The following error occurred: "+error);
-                            });
-                        }, 0);
-                    } else {
-                        Util.ga.trackEvent('action', 'click', 'close');
-                        console.log("Close");
-                    }
-                })
-                .finally(function () {
-                    console.log('called finally');
-                    confirmPopup = undefined;
-                });
-        }
 
         function loadWeatherData() {
             if (cityData.address === null || WeatherInfo.canLoadCity(WeatherInfo.getCityIndex()) === true) {
@@ -834,12 +720,12 @@ angular.module('controller.forecastctrl', [])
                         hideLoadingIndicator();
                     }, function (msg) {
                         hideLoadingIndicator();
-                        showRetryConfirm(strError, msg);
+                        $scope.showRetryConfirm(strError, msg, 'forecast');
                     });
                 }, function(msg) {
                     hideLoadingIndicator();
                     if (msg !== null) {
-                        showRetryConfirm(strError, msg);
+                        $scope.showRetryConfirm(strError, msg, 'forecast');
                     }
                     else {
                         //pass for reload
@@ -875,7 +761,7 @@ angular.module('controller.forecastctrl', [])
                     if (Util.isLocationEnabled()) {
                         cordova.plugins.diagnostic.getLocationAuthorizationStatus(function (status) {
                             console.log('status='+status);
-                            gLocationAuthorizationStatus = status;
+                            $scope.setLocationAuthorizationStatus(status);
                             if (status === cordova.plugins.diagnostic.permissionStatus.GRANTED) {
                                 _getCurrentPosition(deferred, true, true);
                             } else if (status === cordova.plugins.diagnostic.permissionStatus.DENIED_ALWAYS) {
@@ -939,10 +825,8 @@ angular.module('controller.forecastctrl', [])
                         cordova.plugins.diagnostic.requestLocationAuthorization(function (status) {
                             // ios에서는 registerLocationStateChangeHandler에서 locationStatus가 변경되고 reload 이벤트가 발생함
                             if (ionic.Platform.isAndroid()) {
-                                gLocationAuthorizationStatus = status;
+                                $scope.setLocationAuthorizationStatus(status);
                                 if (status === cordova.plugins.diagnostic.permissionStatus.DENIED) {
-                                    // denied 후에 resume 시 reload를 하지 않도록 loadTime을 업데이트 함
-                                    WeatherInfo.updateCity(WeatherInfo.getCityIndex(), cityData);
                                     msg = $translate.instant("LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY");
                                     deferred.reject(msg);
                                     // popup으로 사용자에게 가이드 추가 필요
@@ -973,8 +857,25 @@ angular.module('controller.forecastctrl', [])
             }
             else if (isLocationEnabled === false) {
                 if (cityData.address === null && cityData.location === null) { // 현재 위치 정보가 없는 경우 에러 팝업 표시
-                    msg = $translate.instant("LOC_PLEASE_TURN_ON_LOCATION_SERVICES_TO_FIND_YOUR_CURRENT_LOCATION");
-                    deferred.reject(msg);
+                    if (window.cordova && cordova.plugins.locationAccuracy) {
+                        cordova.plugins.locationAccuracy.request(
+                            function (success) {
+                                Util.ga.trackEvent("position", "status", "successUserAgreed");
+                                //메세지 없이 통과시키고, reload by locationOn.
+                                deferred.reject(null);
+                            },
+                            function (error) {
+                                Util.ga.trackEvent("position", "error", error.message);
+                                msg = $translate.instant("LOC_PLEASE_TURN_ON_LOCATION_SERVICES_TO_FIND_YOUR_CURRENT_LOCATION");
+                                deferred.reject(msg);
+                            },
+                            cordova.plugins.locationAccuracy.REQUEST_PRIORITY_HIGH_ACCURACY);
+                    }
+                    else {
+                        Util.ga.trackEvent("plugin", "error", "loadLocationAccuracy");
+                        msg = $translate.instant("LOC_PLEASE_TURN_ON_LOCATION_SERVICES_TO_FIND_YOUR_CURRENT_LOCATION");
+                        deferred.reject(msg);
+                    }
                 }
                 else { // 위치 서비스가 꺼져있으면 저장된 위치로 날씨 업데이트
                     deferred.resolve();
@@ -1284,11 +1185,10 @@ angular.module('controller.forecastctrl', [])
         }
 
         $scope.$on('reloadEvent', function(event, sender) {
-            console.log("reloadEvent sender="+sender);
             Util.ga.trackEvent('reload', 'sender', sender);
 
-            if (confirmPopup) {
-                console.log('skip event when retry load popup is shown');
+            if ($scope.getConfirmPopup()) {
+                //console.log('skip event when retry load popup is shown');
                 Util.ga.trackEvent('reload', 'skip', 'popup', 1);
                 return;
             }

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -829,7 +829,6 @@ angular.module('controller.forecastctrl', [])
                                 if (status === cordova.plugins.diagnostic.permissionStatus.DENIED) {
                                     msg = $translate.instant("LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY");
                                     deferred.reject(msg);
-                                    // popup으로 사용자에게 가이드 추가 필요
                                 }
                                 else {
                                     console.log('status='+status+ ' by request location authorization and reload by resume');
@@ -1188,7 +1187,6 @@ angular.module('controller.forecastctrl', [])
             Util.ga.trackEvent('reload', 'sender', sender);
 
             if ($scope.getConfirmPopup()) {
-                //console.log('skip event when retry load popup is shown');
                 Util.ga.trackEvent('reload', 'skip', 'popup', 1);
                 return;
             }
@@ -1199,7 +1197,6 @@ angular.module('controller.forecastctrl', [])
                     return;
                 }
             } else if (sender === 'locationOn') {
-                // currentPosition이고 confirmPopup이 없는 경우에만 reload
                 if (cityData.currentPosition === false) {
                     Util.ga.trackEvent('reload', 'skip', 'currentPosition', 0);
                     return;

--- a/client/www/js/controller.searchctrl.js
+++ b/client/www/js/controller.searchctrl.js
@@ -527,7 +527,6 @@ angular.module('controller.searchctrl', [])
                                 if (status === cordova.plugins.diagnostic.permissionStatus.DENIED) {
                                     msg = $translate.instant("LOC_ACCESS_TO_LOCATION_SERVICES_HAS_BEEN_DENIED");
                                     deferred.reject(msg);
-                                    // popup으로 사용자에게 가이드 추가 필요
                                 }
                                 else {
                                     console.log('status='+status+ ' by request location authorization and reload by resume');

--- a/client/www/js/controller.searchctrl.js
+++ b/client/www/js/controller.searchctrl.js
@@ -43,7 +43,6 @@ angular.module('controller.searchctrl', [])
                 console.log('googleapis loaded');
                 service = new google.maps.places.AutocompleteService();
             }, function (e) {
-                console.log(e);
                 Util.ga.trackEvent('window', 'error', 'lazyLoad');
                 Util.ga.trackException(e, true);
                 window.alert(e);
@@ -55,7 +54,6 @@ angular.module('controller.searchctrl', [])
 
         var callbackAutocomplete = function(predictions, status) {
             if (google == undefined) {
-                console.log('Fail to load google maps places');
                 Util.ga.trackEvent('address', 'error', 'autoCompleteGoogleUndefined');
                 return;
             }
@@ -116,12 +114,10 @@ angular.module('controller.searchctrl', [])
           
             window.addEventListener('native.keyboardshow', function () {
                 // Describe your logic which will be run each time when keyboard is about to be shown.
-                console.log('keyboard will show');
                 Util.ga.trackEvent('window', 'show', 'keyboard');
             });
             window.addEventListener('native.keyboardhide', function () {
                 // Describe your logic which will be run each time when keyboard is about to be closed.
-                console.log('keyboard will hide');
                 Util.ga.trackEvent('window', 'hide', 'keyboard');
             });
 
@@ -155,112 +151,9 @@ angular.module('controller.searchctrl', [])
             }
         };
 
-        var gLocationAuthorizationStatus;
-
-        function showRetryConfirm(title, template) {
-            var confirmPopup;
-            //if (confirmPopup) {
-            //    confirmPopup.close();
-            //}
-
-            var buttons = [];
-            buttons.push({
-                text: $translate.instant("LOC_CLOSE"),
-                onTap: function () {
-                    return 'close';
-                }
-            });
-
-            if (gLocationAuthorizationStatus == cordova.plugins.diagnostic.permissionStatus.DENIED_ALWAYS) {
-                template += '<br>';
-                template += $translate.instant("LOC_OPENS_THE_APP_INFO_PAGE");
-
-                //buttons.push({
-                //    text: $translate.instant("LOC_SEARCH"),
-                //    onTap: function () {
-                //        return 'search';
-                //    }
-                //});
-
-                buttons.push({
-                    text: $translate.instant("LOC_SETTING"),
-                    type: 'button-positive',
-                    onTap: function () {
-                        return 'settings';
-                    }
-                });
-                Util.ga.trackEvent('window', 'show', 'deniedAlwaysPopup');
-            }
-            else if (gLocationAuthorizationStatus == cordova.plugins.diagnostic.permissionStatus.DENIED) {
-                //buttons.push({
-                //    text: $translate.instant("LOC_SEARCH"),
-                //    onTap: function () {
-                //        return 'search';
-                //    }
-                //});
-
-                buttons.push({
-                    text: $translate.instant("LOC_RETRY"),
-                    type: 'button-positive',
-                    onTap: function () {
-                        return 'retry';
-                    }
-                });
-                Util.ga.trackEvent('window', 'show', 'deniedPopup');
-            }
-            else {
-                buttons.push({
-                    text: $translate.instant("LOC_RETRY"),
-                    type: 'button-positive',
-                    onTap: function () {
-                        return 'retry';
-                    }
-                });
-                Util.ga.trackEvent('window', 'show', 'retryPopup');
-            }
-
-            confirmPopup = $ionicPopup.show({
-                title: title,
-                template: template,
-                buttons: buttons
-            });
-
-            confirmPopup
-                .then(function (res) {
-                    if (res == 'retry') {
-                        console.log('retry');
-                        Util.ga.trackEvent('action', 'click', 'reloadEvent');
-                        setTimeout(function () {
-                            $scope.OnSearchCurrentPosition();
-                            //$scope.$broadcast('reloadEvent');
-                        }, 0);
-                    }
-                    //else if (res == 'search') {
-                    //    console.log('go search');
-                    //    Util.ga.trackEvent('action', 'click', 'moveSearch');
-                    //    WeatherInfo.disableCity(true);
-                    //    $location.path('/tab/search');
-                    //}
-                    else if (res == 'settings') {
-                        console.log("Opens settings page for this app.");
-                        Util.ga.trackEvent('action', 'click', 'settings');
-                        setTimeout(function () {
-                            cordova.plugins.diagnostic.switchToSettings(function () {
-                                console.log("Successfully switched to Settings app");
-                            }, function (error) {
-                                console.log("The following error occurred: "+error);
-                            });
-                        }, 0);
-                    } else {
-                        Util.ga.trackEvent('action', 'click', 'close');
-                        console.log("Close");
-                    }
-                })
-                .finally(function () {
-                    console.log('called finally');
-                    confirmPopup = undefined;
-                });
-        }
+        $scope.$on('searchCurrentPositionEvent', function(event) {
+            $scope.OnSearchCurrentPosition();
+        });
 
         $scope.OnSearchCurrentPosition = function() {
             Util.ga.trackEvent('position', 'get', 'OnSearch');
@@ -279,12 +172,10 @@ angular.module('controller.searchctrl', [])
             }, function(msg) {
                 hideLoadingIndicator();
                 if (msg !== null) {
-                    showRetryConfirm(strError, msg);
+                    $scope.showRetryConfirm(strError, msg, 'search');
                 }
                 else {
-                    setTimeout(function () {
-                        $scope.OnSearchCurrentPosition();
-                    }, 0);
+                    $scope.$broadcast('searchCurrentPositionEvent');
                 }
             });
         };
@@ -575,6 +466,7 @@ angular.module('controller.searchctrl', [])
                 } else if (ionic.Platform.isAndroid()) {
                     if (Util.isLocationEnabled()) {
                         cordova.plugins.diagnostic.getLocationAuthorizationStatus(function (status) {
+                            $scope.setLocationAuthorizationStatus(status);
                             if (status === cordova.plugins.diagnostic.permissionStatus.GRANTED) {
                                 _getCurrentPosition(deferred, true, true);
                             } else if (status === cordova.plugins.diagnostic.permissionStatus.DENIED_ALWAYS) {
@@ -619,20 +511,20 @@ angular.module('controller.searchctrl', [])
                         }
                         deferred.reject(msg);
                     });
-                } else if (isLocationAuthorized === false) {
+                }
+                else if (isLocationAuthorized === false) {
                     msg = $translate.instant("LOC_ACCESS_TO_LOCATION_SERVICES_HAS_BEEN_DENIED");
                     deferred.reject(msg);
-                } else if (isLocationAuthorized === undefined) {
+                }
+                else if (isLocationAuthorized === undefined) {
                     $ionicLoading.hide();
                     if (window.cordova && window.cordova.plugins && window.cordova.plugins.diagnostic) {
                         // ios : 앱을 사용하는 동안 '오늘날씨'에서 사용자의 위치에 접근하도록 허용하겠습니까?
                         // android : 오늘날씨의 다음 작업을 허용하시겠습니까? 이 기기의 위치에 액세스하기
                         cordova.plugins.diagnostic.requestLocationAuthorization(function (status) {
                             if (ionic.Platform.isAndroid()) {
-                                gLocationAuthorizationStatus = status;
+                                $scope.setLocationAuthorizationStatus(status);
                                 if (status === cordova.plugins.diagnostic.permissionStatus.DENIED) {
-                                    // denied 후에 resume 시 reload를 하지 않도록 loadTime을 업데이트 함
-                                    // WeatherInfo.updateCity(WeatherInfo.getCityIndex(), cityData);
                                     msg = $translate.instant("LOC_ACCESS_TO_LOCATION_SERVICES_HAS_BEEN_DENIED");
                                     deferred.reject(msg);
                                     // popup으로 사용자에게 가이드 추가 필요
@@ -656,9 +548,27 @@ angular.module('controller.searchctrl', [])
                         deferred.reject(null);
                     }
                 }
-            } else if (isLocationEnabled === false) {
-                msg = $translate.instant("LOC_PLEASE_TURN_ON_LOCATION_SERVICES_TO_FIND_YOUR_CURRENT_LOCATION");
-                deferred.reject(msg);
+            }
+            else if (isLocationEnabled === false) {
+                if (window.cordova && cordova.plugins.locationAccuracy) {
+                    cordova.plugins.locationAccuracy.request (
+                        function (success) {
+                            Util.ga.trackEvent("position", "status", "successUserAgreed");
+                            //메세지 없이 통과시키고, reload by locationOn.
+                            deferred.reject(null);
+                        },
+                        function (error) {
+                            Util.ga.trackEvent("position", "error", error.message);
+                            msg = $translate.instant("LOC_PLEASE_TURN_ON_LOCATION_SERVICES_TO_FIND_YOUR_CURRENT_LOCATION");
+                            deferred.reject(msg);
+                        },
+                        cordova.plugins.locationAccuracy.REQUEST_PRIORITY_HIGH_ACCURACY);
+                }
+                else {
+                    Util.ga.trackEvent("plugin", "error", "loadLocationAccuracy");
+                    msg = $translate.instant("LOC_PLEASE_TURN_ON_LOCATION_SERVICES_TO_FIND_YOUR_CURRENT_LOCATION");
+                    deferred.reject(msg);
+                }
             }
         }
 

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -241,5 +241,175 @@ angular.module('controller.tabctrl', [])
             });
         };
 
+        var gLocationAuthorizationStatus;
+        $scope.setLocationAuthorizationStatus = function (status) {
+            gLocationAuthorizationStatus = status;
+        };
+
+        var confirmPopup;
+        $scope.getConfirmPopup = function () {
+           return confirmPopup;
+        };
+
+         /**
+         * android 6.0이상에서 처음 현재위치 사용시에, android 현재위치 접근에 대한 popup때문에 앱 pause->resume이 됨.
+         * 그래서 init와 reloadevent가 둘다 오게 되는데 retry confirm이 두개 뜨지 않게 한개 있는 경우 닫았다가 새롭게 열게 함.
+         * @param title
+         * @param template
+         * @param callback
+         */
+        $scope.showRetryConfirm = function showRetryConfirm(title, template, ctrl) {
+            if (confirmPopup) {
+                confirmPopup.close();
+            }
+
+            var strClose;
+            var strSearch;
+            var strSetting;
+            var strOpensTheAppInfoPage;
+
+            $translate(['LOC_CLOSE', 'LOC_SEARCH', 'LOC_SETTING',
+                'LOC_OPENS_THE_APP_INFO_PAGE']).then(function (translations) {
+                strClose = translations.LOC_CLOSE;
+                strSearch = translations.LOC_SEARCH;
+                strSetting = translations.LOC_SETTING;
+                strOpensTheAppInfoPage = translations.LOC_OPENS_THE_APP_INFO_PAGE;
+            }, function (translationIds) {
+                console.log("Fail to translate : " + JSON.stringify(translationIds));
+                Util.ga.trackEvent("translate", "error", "showRetryConfirm");
+            }).finally(function () {
+                var buttons = [];
+                if (ctrl == 'search') {
+                    buttons.push({
+                        text: strClose,
+                        onTap: function () {
+                            return 'close';
+                        }
+                    });
+                }
+
+                if (gLocationAuthorizationStatus == cordova.plugins.diagnostic.permissionStatus.DENIED_ALWAYS) {
+                    template += '<br>';
+                    template += strOpensTheAppInfoPage;
+
+                    if (ctrl == 'forecast') {
+                        buttons.push({
+                            text: strSearch,
+                            onTap: function () {
+                                return 'search';
+                            }
+                        });
+                    }
+
+                    buttons.push({
+                        text: strSetting,
+                        type: 'button-positive',
+                        onTap: function () {
+                            return 'settings';
+                        }
+                    });
+                    Util.ga.trackEvent('window', 'show', 'deniedAlwaysPopup');
+                }
+                else if (gLocationAuthorizationStatus == cordova.plugins.diagnostic.permissionStatus.DENIED) {
+                    if (ctrl == 'forecast') {
+                        buttons.push({
+                            text: strSearch,
+                            onTap: function () {
+                                return 'search';
+                            }
+                        });
+                    }
+
+                    buttons.push({
+                        text: strOkay,
+                        type: 'button-positive',
+                        onTap: function () {
+                            return 'retry';
+                        }
+                    });
+                    Util.ga.trackEvent('window', 'show', 'deniedPopup');
+                }
+                else {
+                    if (ctrl == 'forecast') {
+                        buttons.push({
+                            text: strSearch,
+                            onTap: function () {
+                                return 'search';
+                            }
+                        });
+                    }
+
+                    buttons.push({
+                        text: strSetting,
+                        onTap: function () {
+                            return 'locationSettings';
+                        }
+                    });
+
+                    buttons.push({
+                        text: strOkay,
+                        type: 'button-positive',
+                        onTap: function () {
+                            return 'retry';
+                        }
+                    });
+
+                    Util.ga.trackEvent('window', 'show', 'retryPopup');
+                }
+
+                confirmPopup = $ionicPopup.show({
+                    title: title,
+                    template: template,
+                    buttons: buttons
+                });
+
+                confirmPopup
+                    .then(function (res) {
+                        if (res == 'retry') {
+                            Util.ga.trackEvent('action', 'click', 'reloadEvent');
+                            setTimeout(function () {
+                                if (ctrl == 'search') {
+                                    $scope.$broadcast('searchCurrentPositionEvent');
+                                }
+                                else {
+                                    $scope.$broadcast('reloadEvent');
+                                }
+                            }, 0);
+                        }
+                        else if (res == 'search') {
+                            Util.ga.trackEvent('action', 'click', 'moveSearch');
+                            WeatherInfo.disableCity(true);
+                            $location.path('/tab/search');
+                        }
+                        else if (res == 'settings') {
+                            Util.ga.trackEvent('action', 'click', 'settings');
+                            setTimeout(function () {
+                                cordova.plugins.diagnostic.switchToSettings(function () {
+                                    console.log("Successfully switched to Settings app");
+                                }, function (error) {
+                                    console.log("The following error occurred: " + error);
+                                });
+                            }, 0);
+                        }
+                        else if (res == 'locationSettings') {
+                            setTimeout(function () {
+                                cordova.plugins.diagnostic.switchToLocationSettings(function () {
+                                    console.log("Successfully switched to location settings app");
+                                }, function (error) {
+                                    console.log("The following error occurred: " + error);
+                                });
+                            }, 0);
+                        }
+                        else {
+                            Util.ga.trackEvent('action', 'click', 'close');
+                        }
+                    })
+                    .finally(function () {
+                        console.log('called finally');
+                        confirmPopup = undefined;
+                    });
+            });
+        };
+
         init();
     });

--- a/client/www/js/service.util.js
+++ b/client/www/js/service.util.js
@@ -105,6 +105,9 @@ angular.module('service.util', [])
                 }
             },
             trackEvent: function (category, action, label, value, newSession) {
+                if (twClientConfig.debug) {
+                   console.log('category='+category+' action='+action+' label='+label+' value='+value);
+                }
                 if (typeof $window.ga !== "undefined") {
                     return $window.ga.trackEvent(category, action, label, value, newSession, function(result) {
                         console.log("trackEvent success = " + result);
@@ -118,6 +121,9 @@ angular.module('service.util', [])
                 }
             },
             trackException: function (description, fatal) {
+                if (twClientConfig.debug) {
+                   console.log('description='+description+' fatal='+fatal);
+                }
                 if (typeof $window.ga !== "undefined") {
                     return $window.ga.trackException(description, fatal, function(result) {
                         console.log("trackException success = " + result);


### PR DESCRIPTION
#1490 #1085
location permission 요청을 denied한 경우 popup보여줌.
gLocationAuthorizationStatus, confirmPopup, showRetryConfirm을 tabCtrl 로 옮김.
search에서는 닫기버튼으로 보여주고, forecast에서는 검색 버튼만 보여줌.
locationServices가 disabled되어 있으면 locationAccuracy.request호출함.
search에서는 권한 수정에 따른 재시도를 위해 'searchCurrentPositionEvent' 추가
new cordova-plugin-request-location-accuracy

etc
debut mode 일때, trackEvent, trackException parameter 출력