### PR TITLE
1322 2 support global language

### DIFF
--- a/ios/Base.lproj/InfoPlist.strings
+++ b/ios/Base.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  TodayWeather
+
+  Created by Alec Kim on 2016. 6. 26..
+
+*/
+CFBundleDisplayName = "TodayWeather";

--- a/ios/de.lproj/InfoPlist.strings
+++ b/ios/de.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  TodayWeather
+
+  Created by Alec Kim on 2016. 6. 26..
+
+*/
+CFBundleDisplayName = "HeuteWetter";

--- a/ios/ja.lproj/InfoPlist.strings
+++ b/ios/ja.lproj/InfoPlist.strings
@@ -5,4 +5,4 @@
   Created by Alec Kim on 2016. 6. 26..
 
 */
-CFBundleDisplayName = "今日の天気";
+CFBundleDisplayName = "今日天気";

--- a/ios/ja.lproj/InfoPlist.strings
+++ b/ios/ja.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  TodayWeather
+
+  Created by Alec Kim on 2016. 6. 26..
+
+*/
+CFBundleDisplayName = "今日の天気";

--- a/ios/ko.lproj/InfoPlist.strings
+++ b/ios/ko.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  TodayWeather
+
+  Created by Alec Kim on 2016. 6. 26..
+
+*/
+CFBundleDisplayName = "오늘날씨";

--- a/ios/zh-Hans.lproj/InfoPlist.strings
+++ b/ios/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  TodayWeather
+
+  Created by Alec Kim on 2016. 6. 26..
+
+*/
+CFBundleDisplayName = "今天的天气";

--- a/ios/zh-Hans.lproj/InfoPlist.strings
+++ b/ios/zh-Hans.lproj/InfoPlist.strings
@@ -5,4 +5,4 @@
   Created by Alec Kim on 2016. 6. 26..
 
 */
-CFBundleDisplayName = "今天的天气";
+CFBundleDisplayName = "今日天气";

--- a/ios/zh-Hant.lproj/InfoPlist.strings
+++ b/ios/zh-Hant.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  TodayWeather
+
+  Created by Alec Kim on 2016. 6. 26..
+
+*/
+CFBundleDisplayName = "今天天氣";

--- a/ios/zh-Hant.lproj/InfoPlist.strings
+++ b/ios/zh-Hant.lproj/InfoPlist.strings
@@ -5,4 +5,4 @@
   Created by Alec Kim on 2016. 6. 26..
 
 */
-CFBundleDisplayName = "今天天氣";
+CFBundleDisplayName = "今日天氣";


### PR DESCRIPTION
* 다국어 지원을 위한 InfoPlist.strings 추가 
#1322
+ iOS Native 부분 다국어 지원
- 빌드 에러 fix
- ja, zh-Hans, zh-Hant CFBundleDisplayName 수정 