### PR TITLE
* [iOS][widget] 지역명 / 위젯타이틀 다국어 에러 #1636

### DIFF
--- a/ios/widget/zh-Hant.lproj/InfoPlist.strings
+++ b/ios/widget/zh-Hant.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  TodayWeather
+
+  Created by KwangHo Kim on 2017. 8. 14..
+
+*/
+CFBundleDisplayName = "今日天氣";


### PR DESCRIPTION
  - 중국어 번체 display name 수정