### PR TITLE
#1672 해외를 국내로 인식하는 문제

### DIFF
--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -816,6 +816,11 @@ angular.module('controller.forecastctrl', [])
                             //device location을 사용하기 위해서는 아래 코드 사용하면 됨.
                             //cityData.location = WeatherUtil.geolocationNormalize({"lat": coords.latitude, "long": coords.longitude});
                             cityData.location = geoInfo.location;
+                            if (geoInfo.country === "KR") {
+                                cityData.source = "KMA";
+                            } else {
+                                cityData.source = "DSF"; // default source로 설정해야 함
+                            }
                             WeatherInfo.updateCity(WeatherInfo.getCityIndex(), cityData);
                             deferred.resolve();
                         }, function () {

--- a/client/www/js/service.weatherinfo.js
+++ b/client/www/js/service.weatherinfo.js
@@ -219,16 +219,15 @@ angular.module('service.weatherinfo', [])
             if (newCityInfo.dayChart) {
                 city.dayChart = newCityInfo.dayChart;
             }
+            if (newCityInfo.source) {
+                city.source = newCityInfo.source;
+            }
             if (window.push && city.currentPosition == true) {
                 if (window.push.getAlarm(index)) {
                     window.push.updateAlarm(index, city.address);
                 }
             }
             city.loadTime = new Date();
-
-            if (newCityInfo.source) {
-                city.source = newCityInfo.source;
-            }
 
             that.saveCities();
         };


### PR DESCRIPTION
#1672 해외를 국내로 인식하는 문제
[재현 경로]
현재 위치가 국내로 설정되어 있고 Push가 켜져 있을 때 해외에서 현재 위치가 업데이트 된 경우 Push 서버에서 Source를 "KMA"로 요청하는 문제임
1. 현재 위치가 국내일 때 WeatherInfo.cities[0] 의 source는 "KMA"로 설정되어 있음
2. WeatherUtil.getGeoInfoFromGeolocation()로 가져온 위치를 WeatherInfo.cities[0]에 업데이트
- updateCity()에서 name, country, address, location 업데이트되고 Push 정보 업데이트(source = "KMA")
3. WeatherUtil.getWorldWeatherInfo()에서 가져온 날씨 정보를 WeatherInfo.cities[0]에 업데이트
- updateCity()에서 currentWeather, timeTable, timeChart, dayTable, dayChart 업데이트되고 Push 정보 업데이트(source = "KMA") 된 이후에 source가 "DSF"으로 업데이트됨
[수정 내용]
1. source는 현재 위치를 가져온 시점에서는 업데이트 되지 않고 날씨 정보를 가져와서 parsing할 때 설정되는 문제
- 현재 위치를 가져온 후에 country를 보고 source도 설정하도록 함(세계날씨 지원하는 source가 여러 가지가 생기면 실제로 요청할 source로 설정해야 함)
2. source 업데이트 이전에 Push 업데이트를 먼저 하는 문제
- updateCity()에서 source 적용 후에 Push 정보 업데이트하도록 수정