### PR TITLE
#1787 시작 화면 설정 기능

### DIFF
--- a/client/www/index.html
+++ b/client/www/index.html
@@ -78,6 +78,14 @@
                     <i class="icon ion-chevron-right" ng-if="!isAndroid()" style="float: right;"></i>
                 </a>
                 <a class="item item-borderless item-select">
+                    {{'LOC_STARTUP_PAGE'|translate}}
+                    <select class="item-note" ng-model="startupPage" ng-change="setStartupPage(startupPage)">
+                        <option value="0">{{'LOC_HOURLY_FORECAST'|translate}}</option>
+                        <option value="1">{{'LOC_DAILY_FORECAST'|translate}}</option>
+                        <option value="2">{{'LOC_SAVED_LOCATIONS'|translate}}</option>
+                    </select>
+                </a>
+                <a class="item item-borderless item-select">
                     {{'LOC_REFRESH_INTERVAL'|translate}}
                     <select class="item-note" ng-model="refreshInterval" ng-change="setRefreshInterval(refreshInterval)">
                         <option value="0">{{'LOC_MANUAL'|translate}}</option>

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -1268,7 +1268,14 @@ angular.module('starter', [
             });
 
         // if none of the above states are matched, use this as the fallback
-        $urlRouterProvider.otherwise('tab/forecast');
+        var startupPage = localStorage.getItem("startupPage");
+        if (startupPage === "1") { //일별날씨
+            $urlRouterProvider.otherwise('tab/dailyforecast');
+        } else if (startupPage === "2") { //즐겨찾기
+            $urlRouterProvider.otherwise('tab/search');
+        } else { //시간별날씨
+            $urlRouterProvider.otherwise('tab/forecast');
+        }
 
         $ionicConfigProvider.tabs.style('standard');
         $ionicConfigProvider.tabs.position('bottom');

--- a/client/www/js/controller.settingctrl.js
+++ b/client/www/js/controller.settingctrl.js
@@ -12,11 +12,19 @@ angular.module('controller.settingctrl', [])
         });
 
         function init() {
+            $scope.startupPage = localStorage.getItem("startupPage");
+            if ($scope.startupPage === null) {
+                $scope.startupPage = "0"; //시간별날씨
+            }
             $scope.refreshInterval = localStorage.getItem("refreshInterval");
             if ($scope.refreshInterval === null) {
                 $scope.refreshInterval = "0"; //수동
             }
         }
+
+        $scope.setStartupPage = function(startupPage) {
+            localStorage.setItem("startupPage", startupPage);
+        };
 
         $scope.setRefreshInterval = function(refreshInterval) {
             localStorage.setItem("refreshInterval", refreshInterval);

--- a/client/www/locales/de.json
+++ b/client/www/locales/de.json
@@ -250,5 +250,6 @@
   "LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY": "Berechtigungsanforderung verweigert Bitte suchen Sie nach Ortsnamen oder versuchen Sie es erneut",
   "LOC_FIND_BY_LOCATION": "Suche nach Ort",
   "LOC_SUNRISE": "Sonnenaufgang",
-  "LOC_SUNSET": "Sonnenuntergang"
+  "LOC_SUNSET": "Sonnenuntergang",
+  "LOC_STARTUP_PAGE" : "Startseite"
 }

--- a/client/www/locales/en.json
+++ b/client/www/locales/en.json
@@ -250,5 +250,6 @@
   "LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY": "Permission request denied. Please search by location name or retry.",
   "LOC_FIND_BY_LOCATION": "Find by location",
   "LOC_SUNRISE": "Sunrise",
-  "LOC_SUNSET": "Sunset"
+  "LOC_SUNSET": "Sunset",
+  "LOC_STARTUP_PAGE" : "Startup Page"
 }

--- a/client/www/locales/ja.json
+++ b/client/www/locales/ja.json
@@ -250,5 +250,6 @@
   "LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY": "許可要求が拒否されました。 地名で検索したり、再試行してください。",
   "LOC_FIND_BY_LOCATION": "場所で探す",
   "LOC_SUNRISE": "日出",
-  "LOC_SUNSET": "日没"
+  "LOC_SUNSET": "日没",
+  "LOC_STARTUP_PAGE" : "起動ページ"
 }

--- a/client/www/locales/ko.json
+++ b/client/www/locales/ko.json
@@ -250,5 +250,6 @@
   "LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY": "권한 요청이 거부되었습니다. 지역검색으로 이동하거나, 재시도해주세요.",
   "LOC_FIND_BY_LOCATION": "현재위치로 지역찾기",
   "LOC_SUNRISE": "일출",
-  "LOC_SUNSET": "일몰"
+  "LOC_SUNSET": "일몰",
+  "LOC_STARTUP_PAGE" : "시작 페이지"
 }

--- a/client/www/locales/zh-CN.json
+++ b/client/www/locales/zh-CN.json
@@ -250,5 +250,6 @@
   "LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY": "拒绝请求 请按地点名称搜索或重试",
   "LOC_FIND_BY_LOCATION": "按位置查找",
   "LOC_SUNRISE": "日出",
-  "LOC_SUNSET": "日落"
+  "LOC_SUNSET": "日落",
+  "LOC_STARTUP_PAGE" : "启动页"
 }

--- a/client/www/locales/zh-TW.json
+++ b/client/www/locales/zh-TW.json
@@ -250,6 +250,7 @@
   "LOC_PERMISSION_REQUEST_DENIED_PLEASE_SEARCH_BY_LOCATION_NAME_OR_RETRY": "拒絕請求 請按地點名稱搜索或重試",
   "LOC_FIND_BY_LOCATION": "按位置查找",
   "LOC_SUNRISE": "日出",
-  "LOC_SUNSET": "日落"
+  "LOC_SUNSET": "日落",
+  "LOC_STARTUP_PAGE" : "始網頁"
 }
 


### PR DESCRIPTION
#1787 시작 화면 설정 기능
* "시작 페이지" 설정 추가
 - 시간별날씨, 일별날씨, 즐겨찾기 중에서 선택 가능
 - Default는 시간별날씨
* 설정 변경 시에 LocalStorage에 저장
* 앱 시작 시에 LocalStorage에 저장된 시작 페이지로 로드