### PR TITLE
#1787 시작 화면 설정 기능

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -448,6 +448,15 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   margin: auto;
 }
 
+.menu-left .menu-content i {
+  padding-right: 16px;
+  padding-top: 10px;
+  position: absolute;
+  right: 0;
+  color: #333;
+  font-size: 14px;
+}
+
 .menu-content .item-select:after {
   content: none !important;
 }
@@ -639,6 +648,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 
 .has-header.overflow-scroll {
   overflow-y: auto !important;
+  -webkit-overflow-scrolling: auto !important;
 }
 
 /* popup */

--- a/client/www/index.html
+++ b/client/www/index.html
@@ -73,21 +73,27 @@
         </header>
         <ion-content class="has-header menu-content">
             <div class="list">
-                <a class="item item-borderless" menu-toggle href="#/units">
-                    {{'LOC_UNITS'|translate}}
-                    <i class="icon ion-chevron-right" ng-if="!isAndroid()" style="float: right;"></i>
+                <a class="item item-input" ng-click="clickMenu('units')">
+                    <div class="input-label">
+                        {{'LOC_UNITS'|translate}}
+                    </div>
+                    <i class="icon ion-chevron-right" ng-if="!isAndroid()"></i>
                 </a>
-                <a class="item item-borderless item-select">
-                    {{'LOC_STARTUP_PAGE'|translate}}
-                    <select class="item-note" ng-model="startupPage" ng-change="setStartupPage(startupPage)">
+                <label class="item item-input item-select">
+                    <div class="input-label">
+                        {{'LOC_STARTUP_PAGE'|translate}}
+                    </div>
+                    <select ng-model="startupPage" ng-change="setStartupPage(startupPage)">
                         <option value="0">{{'LOC_HOURLY_FORECAST'|translate}}</option>
                         <option value="1">{{'LOC_DAILY_FORECAST'|translate}}</option>
                         <option value="2">{{'LOC_SAVED_LOCATIONS'|translate}}</option>
                     </select>
-                </a>
-                <a class="item item-borderless item-select">
-                    {{'LOC_REFRESH_INTERVAL'|translate}}
-                    <select class="item-note" ng-model="refreshInterval" ng-change="setRefreshInterval(refreshInterval)">
+                </label>
+                <label class="item item-input item-select">
+                    <div class="input-label">
+                        {{'LOC_REFRESH_INTERVAL'|translate}}
+                    </div>
+                    <select ng-model="refreshInterval" ng-change="setRefreshInterval(refreshInterval)">
                         <option value="0">{{'LOC_MANUAL'|translate}}</option>
                         <option value="30">{{'LOC_30_MINUTES'|translate}}</option>
                         <option value="60">{{'LOC_1_HOUR'|translate}}</option>
@@ -95,30 +101,42 @@
                         <option value="360">{{'LOC_6_HOURS'|translate}}</option>
                         <option value="720">{{'LOC_12_HOURS'|translate}}</option>
                     </select>
+                </label>
+                <a class="item item-input" ng-click="clickMenu('purchase')" ng-if="hasInAppPurchase()">
+                    <div class="input-label">
+                        {{'LOC_REMOVE_ADS'|translate}}
+                    </div>
+                    <i class="icon ion-chevron-right" ng-if="!isAndroid()"></i>
                 </a>
-                <a class="item item-borderless" menu-toggle href="#/purchase" ng-if="hasInAppPurchase()">
-                    {{'LOC_REMOVE_ADS'|translate}}
-                    <i class="icon ion-chevron-right" ng-if="!isAndroid()" style="float: right;"></i>
+                <a class="item item-input" ng-click="clickMenu('sendMail')">
+                    <div class="input-label">
+                        {{'LOC_SEND_FEEDBACK'|translate}}
+                    </div>
+                    <i class="icon ion-chevron-right" ng-if="!isAndroid()"></i>
                 </a>
-                <a class="item" menu-toggle ng-click="sendMail()">
-                    {{'LOC_SEND_FEEDBACK'|translate}}
-                    <i class="icon ion-chevron-right" ng-if="!isAndroid()" style="float: right;"></i>
+                <a class="item item-input" ng-click="clickMenu('openMarket')">
+                    <div class="input-label">
+                        {{'LOC_RATE_THIS_APP'|translate}}
+                    </div>
+                    <i class="icon ion-chevron-right" ng-if="!isAndroid()"></i>
                 </a>
-                <a class="item item-borderless" menu-toggle ng-click="openMarket()">
-                    {{'LOC_RATE_THIS_APP'|translate}}
-                    <i class="icon ion-chevron-right" ng-if="!isAndroid()" style="float: right;"></i>
+                <a class="item item-input" href="#">
+                    <div class="input-label">
+                        {{'LOC_VERSION'|translate}}
+                    </div>
+                    <i>{{version}}</i>
                 </a>
-                <a class="item" href="#">
-                    {{'LOC_VERSION'|translate}}
-                    <span style="float: right;">{{version}}</span>
+                <a class="item item-input" ng-click="clickMenu('guide')">
+                    <div class="input-label">
+                        {{'LOC_GUIDE'|translate}}
+                    </div>
+                    <i class="icon ion-chevron-right" ng-if="!isAndroid()"></i>
                 </a>
-                <a class="item item-borderless" menu-toggle href="#/guide">
-                    {{'LOC_GUIDE'|translate}}
-                    <i class="icon ion-chevron-right" ng-if="!isAndroid()" style="float: right;"></i>
-                </a>
-                <a class="item item-borderless" ng-click="openInfo()" ng-if="showAbout()">
-                    {{'LOC_ABOUT'|translate}}
-                    <i class="icon ion-chevron-right" ng-if="!isAndroid()" style="float: right;"></i>
+                <a class="item item-input" ng-click="clickMenu('openInfo')" ng-if="showAbout()">
+                    <div class="input-label">
+                        {{'LOC_ABOUT'|translate}}
+                    </div>
+                    <i class="icon ion-chevron-right" ng-if="!isAndroid()"></i>
                 </a>
             </div>
         </ion-content>


### PR DESCRIPTION
#1787 시작 화면 설정 기능
* iOS에서 메뉴을 열면 KeyboardAccessoryBar를 show하여 select의 목록 위에 Done이 표시되도록 함
* iOS에서 시작페이지, 업데이트 주기 변경 후에 흰색 화면으로 나오는 문제 수정
- .has-header.overflow-scroll일 때 -webkit-overflow-scrolling를 auto로 변경
* iOS에서 시작페이지, 업데이트 주기에서 select의 목록이 표시된 상태에서 다른 메뉴를 누르면 실행되지 않고 목록이 닫히도록 처리
* select 외의 caption 부분 클릭 시에도 목록이 열리도록 item-input 스타일로 변경