### PR TITLE
new geo location api

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -16,7 +16,6 @@ module.exports = {
         test_cert: (process.env.DATA_GO_KR_TEST_CERT_KEY || 'You have to set key of data.go.kr'),
         normal: (process.env.DATA_GO_KR_NORMAL_KEY || 'You have to set key of data.go.kr'),
         cert_key: (process.env.DATA_GO_KR_CERT_KEY || 'You have to set key of data.go.kr'),
-        daum_key: (process.env.DAUM_KEY || 'You have to set key of daum.net'),
         newrelic: (process.env.NEW_RELIC_LICENSE_KEY || 'Your New Relic license key'),
         aws_access_key:(process.env.AWS_ACCESS_KEY || 'You have to set key of AWS'),
         aws_secret_key:(process.env.AWS_SECRET_KEY || 'You have to set key of AWS'),
@@ -38,7 +37,9 @@ module.exports = {
         }],
         aqi_keys : [{
             key: (process.env.WAQI_SECRET_KEY || 'You have to set key of WAQI')
-        }]
+        }],
+        daum_keys : (process.env.DAUM_SECRET_KEYS || 'set string of array of daum keys ex:["aa","bb"]'),
+        google_key : (process.env.GOOGLE_SECRET_KEY || 'You have to set googe api ke')
     },
     logToken: {
         gather: (process.env.LOGENTRIES_GATHER_TOKEN||'Your Logentries key'),

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -38,7 +38,7 @@ module.exports = {
         aqi_keys : [{
             key: (process.env.WAQI_SECRET_KEY || 'You have to set key of WAQI')
         }],
-        daum_keys : (process.env.DAUM_SECRET_KEYS || 'set string of array of daum keys ex:["aa","bb"]'),
+        daum_keys : (process.env.DAUM_SECRET_KEYS || '["set string of array of daum keys","key1", "key2"]'),
         google_key : (process.env.GOOGLE_SECRET_KEY || 'You have to set googe api ke')
     },
     logToken: {

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -2319,7 +2319,7 @@ Manager.prototype.startManager = function(){
     self.midRssKmaRequester = midRssKmaRequester;
 
     keco.setServiceKey(config.keyString.normal);
-    keco.setDaumApiKey(config.keyString.daum_key);
+    keco.setDaumApiKeys(JSON.parse(config.keyString.daum_keys));
     keco.getCtprvnSidoList();
 
     self.keco = keco;

--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -572,10 +572,10 @@ function ControllerTown24h() {
         return this;
     };
 
-    this.sendResult = function (req, res) {
+    this.makeResult = function (req, res, next) {
         var meta = {};
 
-        var result = {};
+        var result;
         var regionName = req.params.region;
         var cityName = req.params.city;
         var townName = req.params.town;
@@ -585,6 +585,10 @@ function ControllerTown24h() {
         meta.city = cityName;
         meta.town = townName;
 
+        if (req.result == undefined) {
+            req.result = {};
+        }
+        result = req.result;
         result.regionName = regionName;
         result.cityName = cityName;
         result.townName = townName;
@@ -626,12 +630,15 @@ function ControllerTown24h() {
         if (req.dailySummary) {
             result.dailySummary = req.dailySummary;
         }
-
-        log.info('## - ' + decodeURI(req.originalUrl) + ' sID=' + req.sessionID);
-        res.json(result);
-
+        result.source = "KMA";
+        next();
         return this;
     };
+
+    this.sendResult = function (req, res) {
+        log.info('## - ' + decodeURI(req.originalUrl) + ' sID=' + req.sessionID);
+        res.json(req.result);
+    }
 }
 
 // subclass extends superclass

--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -638,7 +638,7 @@ function ControllerTown24h() {
     this.sendResult = function (req, res) {
         log.info('## - ' + decodeURI(req.originalUrl) + ' sID=' + req.sessionID);
         res.json(req.result);
-    }
+    };
 }
 
 // subclass extends superclass

--- a/server/controllers/geo.controller.js
+++ b/server/controllers/geo.controller.js
@@ -3,6 +3,8 @@
  * Created by aleckim on 2017. 11. 8..
  */
 
+"use strict";
+
 var async = require('async');
 var request = require('request');
 
@@ -162,7 +164,7 @@ GeoController.prototype._parseGoogleResult = function (data) {
     }
 
     if (country_name == undefined) {
-        throw new Error('country_name null latlng='+lat+","+lng);
+        throw new Error('country_name null');
     }
 
     var name;
@@ -171,7 +173,7 @@ GeoController.prototype._parseGoogleResult = function (data) {
     if (country_name == "KR") {
         if (sub_level2_name) {
             address += sub_level2_name;
-            name = sub_level2_name
+            name = sub_level2_name;
         }
     }
     if (sub_level1_name) {

--- a/server/controllers/geo.controller.js
+++ b/server/controllers/geo.controller.js
@@ -1,0 +1,333 @@
+/**
+ *
+ * Created by aleckim on 2017. 11. 8..
+ */
+
+var async = require('async');
+var request = require('request');
+
+var config = require('../config/config');
+
+
+function GeoController(lat, lon, lang, country) {
+    this.lat = lat;
+    this.lon = lon;
+    this.lang = lang;
+    this.country = country;
+    this.daumKeys = JSON.parse(config.keyString.daum_keys);
+    this.googleApiKey = config.keyString.google_key;
+    this.kmaAddress = null;
+    this.address = "";
+    this.name = "";
+}
+
+GeoController.prototype._request = function(url, callback) {
+    request(url, {json: true, timeout: 5000}, function(err, response, body) {
+        if (err) {
+            return callback(err);
+        }
+        if (response.statusCode >= 400) {
+            err = new Error("url="+url+" statusCode="+response.statusCode);
+            return callback(err);
+        }
+        callback(err, body);
+    });
+};
+
+/**
+ * {"type":"H","code":"1123064","name":"역삼1동","fullName":"서울특별시 강남구 역삼1동","regionId":"I10000901",
+ * "name0":"대한민국","code1":"11","name1":"서울특별시","code2":"11230","name2":"강남구","code3":"1123064",
+ * "name3":"역삼1동","x":127.03306535867272,"y":37.495359482762545}
+ * {"type":"H","code":"90003","name":"일본","fullName":"일본","name0":"일본",
+ * "x":135.2266257553163,"y":33.63189788608174}
+ * @param callback
+ * @private
+ */
+GeoController.prototype._getAddressFromDaum = function (callback) {
+    var that = this;
+    var index = 0;
+
+    async.retry(that.daumKeys.length,
+        function (cb) {
+            var url = 'https://apis.daum.net/local/geo/coord2addr'+
+                '?apikey=' + that.daumKeys[index] +
+                '&longitude='+ that.lon +
+                '&latitude='+that.lat+
+                '&inputCoordSystem=WGS84'+
+                '&output=json';
+            index++;
+
+            log.info(url);
+            that._request(url, function (err, result) {
+                if(err) {
+                    return cb(err);
+                }
+                cb(null, result);
+            });
+        },
+        function (err, result) {
+            if (err) {
+                return callback(err);
+            }
+
+            try {
+                if (result.name0 === "대한민국") {
+                    that.country = "KR";
+                    that.kmaAddress = {"region": result.name1, "city": result.name2, "town": result.name3};
+                    //if lang is not ko, get address from google api
+                    if (!that.lang) {
+                        that.lang = "ko";
+                    }
+                    if (that.lang === "ko") {
+                        that.address = result.fullName;
+                    }
+                    that.country = "KR";
+                    if (result.name3 && result.name3 != "") {
+                        that.name = result.name3;
+                    }
+                    else if (result.name2 && result.name2 != "") {
+                        that.name = result.name2;
+                    }
+                    else if (result.name1 && result.name1 != "") {
+                        that.name = result.name1;
+                    }
+                    else if (result.name0 && result.name0 != "") {
+                        that.name = result.name0;
+                    }
+                }
+                else {
+                    log.debug("It is not korea");
+                }
+
+            }
+            catch (e) {
+               return callback(e);
+            }
+            callback();
+        });
+
+    return this;
+};
+
+GeoController.prototype._parseGoogleResult = function (data) {
+    if (data.status !== "OK") {
+        //'ZERO_RESULTS', 'OVER_QUERY_LIMIT', 'REQUEST_DENIED',  'INVALID_REQUEST', 'UNKNOWN_ERROR'
+        throw new Error(data.status);
+    }
+
+    var sub_level2_types = [ "political", "sublocality", "sublocality_level_2" ];
+    var sub_level1_types = [ "political", "sublocality", "sublocality_level_1" ];
+    var local_types = [ "locality", "political" ];
+    var country_types = ["country"];
+    var sub_level2_name;
+    var sub_level1_name;
+    var local_name;
+    var country_name;
+
+    for (var i=0; i < data.results.length; i++) {
+        var result = data.results[i];
+        for (var j=0; j < result.address_components.length; j++) {
+            var address_component = result.address_components[j];
+            if ( address_component.types[0] == sub_level2_types[0]
+                && address_component.types[1] == sub_level2_types[1]
+                && address_component.types[2] == sub_level2_types[2] ) {
+                sub_level2_name = address_component.short_name;
+            }
+
+            if ( address_component.types[0] == sub_level1_types[0]
+                && address_component.types[1] == sub_level1_types[1]
+                && address_component.types[2] == sub_level1_types[2] ) {
+                sub_level1_name = address_component.short_name;
+            }
+
+            if ( address_component.types[0] == local_types[0]
+                && address_component.types[1] == local_types[1] ) {
+                local_name = address_component.short_name;
+            }
+
+            if ( address_component.types[0] == country_types[0] ) {
+                if (address_component.short_name.length <= 2) {
+                    country_name = address_component.short_name;
+                }
+            }
+
+            if (sub_level2_name && sub_level1_name && local_name && country_name) {
+                break;
+            }
+        }
+
+        if (sub_level2_name && sub_level1_name && local_name && country_name) {
+            break;
+        }
+    }
+
+    if (country_name == undefined) {
+        throw new Error('country_name null latlng='+lat+","+lng);
+    }
+
+    var name;
+    var address = "";
+    //국내는 동단위까지 표기해야 함.
+    if (country_name == "KR") {
+        if (sub_level2_name) {
+            address += sub_level2_name;
+            name = sub_level2_name
+        }
+    }
+    if (sub_level1_name) {
+        address += " " + sub_level1_name;
+        if (name == undefined) {
+            name = sub_level1_name;
+        }
+    }
+    if (local_name) {
+        address += " " + local_name;
+        if (name == undefined) {
+            name = local_name;
+        }
+    }
+    if (country_name) {
+        address += " " + country_name;
+        if (name == undefined) {
+            name = country_name;
+        }
+    }
+
+    if (name == undefined || name == country_name) {
+        throw new Error('failToFindLocation');
+    }
+
+    var geoInfo =  {country: country_name, address: address};
+    geoInfo.name = name;
+    return geoInfo;
+};
+
+GeoController.prototype._getAddressFromGoogle = function (callback) {
+    var that = this;
+    //retry with key
+    var url = "https://maps.googleapis.com/maps/api/geocode/json?latlng=" + that.lat + "," + that.lon;
+    if (that.lang) {
+        url += "&language="+that.lang;
+    }
+    if (that.googleApiKey) {
+        url += "&key="+that.googleApiKey;
+    }
+    else {
+        log.warn("google api key is not valid");
+    }
+    async.retry(3,
+        function (cb) {
+            that._request(url, function (err, result) {
+                if (err) {
+                    return cb(err);
+                }
+                cb(null, result);
+            });
+        },
+        function (err, result) {
+            if (err) {
+                return callback(err);
+            }
+            try {
+               var geoInfo = that._parseGoogleResult(result);
+                that.country = geoInfo.country;
+                that.name = geoInfo.name;
+                that.address = geoInfo.address;
+            }
+            catch(e) {
+                return callback(e);
+            }
+            callback();
+        });
+
+    return this;
+};
+
+GeoController.prototype.setInfoFromReq = function (req) {
+    var lat = req.params.lat;
+    var lon = req.params.lon;
+    var country = req.query.country;
+    var address = req.query.address;
+    var lang;
+
+    var al = req.headers['accept-language'];
+    if (al) {
+        lang = al.split('-')[0];
+    }
+    if (country) {
+        country = country.toUpperCase();
+    }
+    this.lat = lat;
+    this.lon = lon;
+    this.lang = lang;
+    this.country = country;
+    this.address = address;
+    //set units
+};
+
+/**
+ *
+ * @param req
+ * @param res
+ * @param next
+ * @returns {GeoController}
+ */
+GeoController.prototype.location2address = function(req, res, next) {
+    var that = this;
+
+    async.waterfall([
+            function (callback) {
+                if (that.country === undefined || that.country === 'KR') {
+                    that._getAddressFromDaum(function (err) {
+                        callback(err);
+                    });
+                }
+                else {
+                    callback();
+                }
+            },
+            function (callback) {
+                if (that.lang !== 'ko' ||
+                        that.country !== 'KR') {
+                   that._getAddressFromGoogle(function (err) {
+                       callback(err);
+                   });
+                }
+                else {
+                    callback();
+                }
+            }
+        ],
+        function (err) {
+            if (err) {
+                return next(err);
+            }
+            req.country = that.country;
+            if (that.kmaAddress) {
+                req.params.region = that.kmaAddress.region;
+                req.params.city = that.kmaAddress.city;
+                req.params.town = that.kmaAddress.town;
+            }
+            else {
+                req.params.category = 'current';
+                req.params.version = '010000';
+                req.query.gcode = req.params.lat + ',' + req.params.lon;
+            }
+
+            req.result = req.result?req.result:{};
+            req.result.location = {lat:req.params.lat, lon:req.params.lon};
+            req.result.name = that.name;
+            req.result.address = that.address;
+            req.result.country = that.country;
+
+            //req.result.location
+            //req.result.address
+            //req.result.name
+            //req.reqult.timezone
+            next();
+        });
+
+    return this;
+};
+
+module.exports = GeoController;

--- a/server/controllers/kecoController.js
+++ b/server/controllers/kecoController.js
@@ -765,7 +765,7 @@ arpltnController._appendFromKeco = function(town, current, callback) {
 
     var keyBox = require('../config/config').keyString;
     keco.setServiceKey(keyBox.normal);
-    keco.setDaumApiKey(keyBox.daum_key);
+    keco.setDaumApiKeys(JSON.parse(keyBox.daum_keys));
 
     async.waterfall([
         function(cb) {

--- a/server/controllers/worldWeather/controllerWorldWeather.js
+++ b/server/controllers/worldWeather/controllerWorldWeather.js
@@ -80,20 +80,22 @@ function controllerWorldWeather(){
      * @param res
      */
     self.sendResult = function(req, res){
-        if(req.error){
-            res.json(req.error);
+        var result;
+        if(req.error) {
+            result = req.error;
         }
         else if(req.result){
             if (req.result.thisTime.length != 2) {
                 log.error("thisTime's length is not 2 loc="+JSON.stringify(req.result.location));
             }
-            res.json(req.result);
-            return;
+            result = req.result;
         }
         else {
-            res.json({result: 'Unknown result'});
+            result = {result: 'Unknown result'};
         }
+
         log.info('## - ' + decodeURI(req.originalUrl) + ' Time[', (new Date()).toISOString() + '] sID=' + req.sessionID);
+        res.json(result);
         return;
     };
 
@@ -1609,6 +1611,7 @@ function controllerWorldWeather(){
             });
         }
 
+        req.result.source = "DSF";
         next();
     };
 

--- a/server/lib/kecoRequester.js
+++ b/server/lib/kecoRequester.js
@@ -34,7 +34,7 @@ function Keco() {
     this._svcKey ='';
     this._sidoList = [];
     this._currentSidoIndex = 0;
-    this._daumApiKey = '';  //for convert x,y
+    this._daumApiKeys = '';  //for convert x,y
 }
 
 /**
@@ -42,8 +42,8 @@ function Keco() {
  * @param key
  * @returns {Keco}
  */
-Keco.prototype.setDaumApiKey = function (key) {
-    this._daumApiKey = key;
+Keco.prototype.setDaumApiKeys = function (keys) {
+    this._daumApiKeys = keys;
     return this;
 };
 
@@ -52,7 +52,7 @@ Keco.prototype.setDaumApiKey = function (key) {
  * @returns {string|*}
  */
 Keco.prototype.getDaumApiKey = function () {
-    return this._daumApiKey;
+    return this._daumApiKeys[Math.floor(Math.random() * this._daumApiKeys.length)];
 };
 
 /**

--- a/server/routes/v000803/index.js
+++ b/server/routes/v000803/index.js
@@ -126,4 +126,6 @@ router.post('/', function(req,res) {
 
 router.use('/test', require('./route.test'));
 
+router.use('/geo', require('./route.geo'));
+
 module.exports = router;

--- a/server/routes/v000803/route.geo.js
+++ b/server/routes/v000803/route.geo.js
@@ -3,6 +3,8 @@
  * Created by aleckim on 2017. 11. 7..
  */
 
+"use strict";
+
 var router = require('express').Router();
 var async = require('async');
 

--- a/server/routes/v000803/route.geo.js
+++ b/server/routes/v000803/route.geo.js
@@ -1,0 +1,118 @@
+/**
+ *
+ * Created by aleckim on 2017. 11. 7..
+ */
+
+var router = require('express').Router();
+var async = require('async');
+
+var ControllerTown24h = require('../../controllers/controllerTown24h');
+var GeoController = require('../../controllers/geo.controller');
+var WorldWeather = require('../../controllers/worldWeather/controllerWorldWeather');
+
+var cTown = new ControllerTown24h();
+var worldWeather = new WorldWeather();
+
+
+router.use(function timestamp(req, res, next){
+    var printTime = new Date();
+    log.info('+ geo > request | Time[', printTime.toISOString(), ']');
+
+    next();
+});
+
+var kmaRouterList = [cTown.checkParamValidation, cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort,
+    cTown.getShortRss, cTown.getShortest, cTown.getCurrent, cTown.updateCurrentListForValidation,
+    cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather, cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
+    cTown.mergeByShortest, cTown.adjustShort, cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo,
+    cTown.getPastMid, cTown.mergeMidWithShort, cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco,
+    cTown.getKecoDustForecast, cTown.getRiseSetInfo, cTown.insertIndex, cTown.insertStrForData, cTown.insertSkyIcon,
+    cTown.getSummary, cTown.makeResult];
+
+var wwRouterList = [worldWeather.checkApiVersion, worldWeather.queryTwoDaysWeather, worldWeather.convertDsfLocalTime,
+    worldWeather.mergeDsfDailyData, worldWeather.mergeDsfCurrentData, worldWeather.mergeDsfHourlyData,
+    worldWeather.mergeAqi, worldWeather.dataSort];
+
+/**
+ * lat 위도
+ * lon 경도
+ * 구글지도의 입력 값과 같은 순서임
+ * 위도,경도 소수점 두자리까지 하면 1km,세자리까지 하면 100m
+ *
+ * pre daum api에 물어서 국내/해외 구분
+ * case 1 한국어로 국내 위치 요청 - daumapi물어서 주소 받아서 결과 생성
+ * case 2 한국어로 해외 위치 요청 - 구글api물어서 한국어 이름(and 주소) 전달
+ * case 3 외국어로 국내 위치 요청 - daumapi물어서 주소 받아 날씨 결과 생성, 요청한 언어 맞는 이름(and 주소) 전달
+ * case 4 외국어로 외국 위치 요청 - 구글api물어서 외국어 이름(and 주소) 전달
+ * 해외의 경우 국내와 같이 5km블록의 대표좌표로 변환해서 날씨정보 전달
+ *
+ * client에서 내장함수 사용하여 주소 전달하는 경우
+ * case 1 한국어로 국내 위치 요청 - 이름만 선정하고 날씨정보 붙여서 전달
+ * case 2 한국어로 해외 위치 요청 - 이름만 선정하고 날씨정보 붙여서 전달
+ * case 3 외국어로 국내 위치 요청 - 이름 선정하고 daumapi물어서 주소 받아 날씨 결과 생성
+ * case 4 외국어로 외국 위치 요청 - 이름만 선정
+ * client에서 해외의 경우 국내와 같이 5km블록의 대표좌표로 변환해서 요청
+ *
+ * normalize하면서 좌표가 바다로 되는 문제가 있음
+ * seoul 37.566,126.977
+ * busan 35.1795543,129.0756416
+ * daegu 35.8714354,128.601445
+ * tokyo 35.689,139.691
+ * yokohama 35.4437078,139.6380256
+ * osaka 34.6937378,135.5021651
+ * shanghai 31.230,121.473
+ * beijing 39.904,116.407
+ * chengdu 30.572815,104.066801
+ * new york 40.7127753,-74.0059728
+ * los angeles 34.0522342,-118.2436849
+ * chicago 41.8781136,-87.6297982
+ * london 51.507, -0.128
+ * berlin 52.520,13.404
+ * delhi 28.704,77.102
+ * karachi 24.861,67.010
+ * mosco 55.756,37.617
+ */
+router.get('/:lat/:lon',
+    function (req, res, next) {
+        var cGeo = new GeoController();
+        cGeo.setInfoFromReq(req);
+        cGeo.location2address(req, res, next);
+    },
+    function (req, res, next) {
+        var operations = [];
+        var funcList = req.country === 'KR'?kmaRouterList:wwRouterList;
+
+        funcList.forEach(function (func) {
+            operations.push(func.bind(null, req, res));
+        });
+
+        async.series(operations, function (err) {
+            if (err)  {
+                log.error(err);
+                return next(err);
+            }
+            next();
+        });
+    },
+    function (req, res) {
+        var result = req.result;
+
+        if(req.error) {
+            result = req.error;
+        }
+        else if (req.result == undefined) {
+            result = {result: 'Unknown result'};
+        }
+        else {
+            if (result.source === 'DSF') {
+                if (req.result.thisTime.length != 2) {
+                    log.error("thisTime's length is not 2 loc="+JSON.stringify(req.result.location));
+                }
+            }
+        }
+
+        log.info('## - ' + decodeURI(req.originalUrl) + ' Time[', (new Date()).toISOString() + '] sID=' + req.sessionID);
+        res.json(result);
+    });
+
+module.exports = router;

--- a/server/routes/v000803/routeTownForecast.js
+++ b/server/routes/v000803/routeTownForecast.js
@@ -40,55 +40,43 @@ router.get('/', [cTown.getSummary], function(req, res) {
     res.json(result);
 });
 
-router.get('/:region', [cTown.checkParamValidation, cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
-                                    cTown.mergeByShortest, cTown.adjustShort,
-                                    cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
-                                    cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco, cTown.getKecoDustForecast, cTown.getRiseSetInfo,
-                                    cTown.insertIndex, cTown.insertStrForData, cTown.insertSkyIcon,
-                                    cTown.getSummary, cTown.sendResult]);
-
-router.get('/:region/:city', [cTown.checkParamValidation, cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                    cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
-                                    cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
-                                    cTown.mergeByShortest, cTown.adjustShort,
-                                    cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
-                                    cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco, cTown.getKecoDustForecast, cTown.getRiseSetInfo,
-                                    cTown.insertIndex, cTown.insertStrForData, cTown.insertSkyIcon,
-                                    cTown.getSummary, cTown.sendResult]);
-
 /**
  * getCurrent가는 getShortest, getShort보다 앞에 올 수 없음.
  * getSummary는 getShortest, getCurrent보다 앞에 올수 없음.
  */
-router.get('/:region/:city/:town', [cTown.checkParamValidation, cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
+var routerList = [cTown.checkParamValidation, cTown.getAllDataFromDb, cTown.checkDBValidation, cTown.getShort, cTown.getShortRss, cTown.getShortest,
                                     cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
                                     cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
                                     cTown.mergeByShortest, cTown.adjustShort,
                                     cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid, cTown.mergeMidWithShort,
                                     cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco, cTown.getKecoDustForecast, cTown.getRiseSetInfo,
                                     cTown.insertIndex, cTown.insertStrForData, cTown.insertSkyIcon,
-                                    cTown.getSummary, cTown.sendResult]);
+                                    cTown.getSummary, cTown.makeResult, cTown.sendResult];
+
+router.get('/:region', routerList);
+
+router.get('/:region/:city', routerList);
+
+router.get('/:region/:city/:town', routerList);
 
 /**
  * mid, short, shortest 다 정상적으로 동작하기 위해서는 current, shorest, short의 데이타가 필요하다.
  */
-router.get('/:region/:city/:town/mid', [cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid,
-                                    cTown.mergeMidWithShort, cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco,
-                                    cTown.getKecoDustForecast, cTown.insertIndex, cTown.insertSkyIcon,
-                                    cTown.insertStrForData, cTown.insertSkyIcon, cTown.sendResult]);
-
-router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
-                                            cTown.convert0Hto24H, cTown.mergeShortWithCurrentList, cTown.adjustShort,
-                                            cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
-                                            cTown.insertStrForData, cTown.insertSkyIcon, cTown.sendResult]);
-
-router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.convert0Hto24H, cTown.insertIndex,
-                                            cTown.insertStrForData, cTown.insertSkyIcon, cTown.sendResult]);
-
-router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
-                                            cTown.convert0Hto24H, cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
-                                            cTown.insertStrForData, cTown.insertSkyIcon, cTown.getSummary, cTown.sendResult]);
+//router.get('/:region/:city/:town/mid', [cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo, cTown.getPastMid,
+//                                    cTown.mergeMidWithShort, cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco,
+//                                    cTown.getKecoDustForecast, cTown.insertIndex, cTown.insertSkyIcon,
+//                                    cTown.insertStrForData, cTown.insertSkyIcon, cTown.sendResult]);
+//
+//router.get('/:region/:city/:town/short', [cTown.getShort, cTown.getShortRss, cTown.getShortest,
+//                                            cTown.convert0Hto24H, cTown.mergeShortWithCurrentList, cTown.adjustShort,
+//                                            cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
+//                                            cTown.insertStrForData, cTown.insertSkyIcon, cTown.sendResult]);
+//
+//router.get('/:region/:city/:town/shortest', [cTown.getShortest, cTown.convert0Hto24H, cTown.insertIndex,
+//                                            cTown.insertStrForData, cTown.insertSkyIcon, cTown.sendResult]);
+//
+//router.get('/:region/:city/:town/current', [cTown.getCurrent, cTown.updateCurrentListForValidation, cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather,
+//                                            cTown.convert0Hto24H, cTown.getLifeIndexKma, cTown.getKeco, cTown.insertIndex,
+//                                            cTown.insertStrForData, cTown.insertSkyIcon, cTown.getSummary, cTown.sendResult]);
 
 module.exports = router;

--- a/server/test/testGeoController.js
+++ b/server/test/testGeoController.js
@@ -3,7 +3,8 @@
  * Created by aleckim on 2017. 11. 9..
  */
 
-var assert  = require('assert');
+"use strict";
+
 var GeoCtrl = require('../controllers/geo.controller');
 
 var Logger = require('../lib/log');

--- a/server/test/testGeoController.js
+++ b/server/test/testGeoController.js
@@ -1,0 +1,54 @@
+/**
+ *
+ * Created by aleckim on 2017. 11. 9..
+ */
+
+var assert  = require('assert');
+var GeoCtrl = require('../controllers/geo.controller');
+
+var Logger = require('../lib/log');
+global.log  = new Logger(__dirname + "/debug.log");
+
+describe('unit test - geo controller class', function() {
+    it('get address from daum', function(done) {
+       var geoCtrl = new GeoCtrl(37.507, 127.045);
+        geoCtrl._request = function (url, callback) {
+           console.log(url);
+            var result = '{"type":"H","code":"1123064","name":"역삼1동","fullName":"서울특별시 강남구 역삼1동","regionId":"I10000901","name0":"대한민국","code1":"11","name1":"서울특별시","code2":"11230","name2":"강남구","code3":"1123064","name3":"역삼1동","x":127.03306535867272,"y":37.495359482762545}';
+            callback(null, JSON.parse(result));
+        };
+
+        geoCtrl._getAddressFromDaum(function (err) {
+            if (err) {
+                console.error(err);
+            }
+            else {
+                console.info(geoCtrl);
+            }
+            done();
+        });
+    });
+
+    it('get address from google', function (done) {
+        var geoCtrl = new GeoCtrl(34.350, 131.295) ;
+
+        geoCtrl._request = function (url, callback) {
+            console.log(url);
+            var result = '{"results":[{"address_components":[{"long_name":"Kitaura Highway","short_name":"国道191号線","types":["route"]},{"long_name":"Nagato-shi","short_name":"Nagato-shi","types":["locality","political"]},{"long_name":"Yamaguchi-ken","short_name":"Yamaguchi-ken","types":["administrative_area_level_1","political"]},{"long_name":"Japan","short_name":"JP","types":["country","political"]},{"long_name":"759-3801","short_name":"759-3801","types":["postal_code"]}],"formatted_address":"Kitaura Highway, Nagato-shi, Yamaguchi-ken 759-3801, Japan","geometry":{"bounds":{"northeast":{"lat":34.3520329,"lng":131.2980671},"southwest":{"lat":34.3511533,"lng":131.2959762}},"location":{"lat":34.3515907,"lng":131.2970204},"location_type":"GEOMETRIC_CENTER","viewport":{"northeast":{"lat":34.3529420802915,"lng":131.2983706302915},"southwest":{"lat":34.3502441197085,"lng":131.2956726697085}}},"place_id":"ChIJVV9-yJWgRDURd28zpqNg488","types":["route"]},{"address_components":[{"long_name":"Misumikami","short_name":"Misumikami","types":["political","sublocality","sublocality_level_1"]},{"long_name":"Nagato","short_name":"Nagato","types":["locality","political"]},{"long_name":"Yamaguchi Prefecture","short_name":"Yamaguchi Prefecture","types":["administrative_area_level_1","political"]},{"long_name":"Japan","short_name":"JP","types":["country","political"]},{"long_name":"759-3801","short_name":"759-3801","types":["postal_code"]}],"formatted_address":"Misumikami, Nagato, Yamaguchi Prefecture 759-3801, Japan","geometry":{"bounds":{"northeast":{"lat":34.3702904,"lng":131.349357},"southwest":{"lat":34.3104089,"lng":131.2627181}},"location":{"lat":34.351022,"lng":131.2993422},"location_type":"APPROXIMATE","viewport":{"northeast":{"lat":34.3702904,"lng":131.349357},"southwest":{"lat":34.3104089,"lng":131.2627181}}},"place_id":"ChIJ9YG___GgRDURDDEHXfhx3ok","types":["political","sublocality","sublocality_level_1"]},{"address_components":[{"long_name":"Nagato","short_name":"Nagato","types":["locality","political"]},{"long_name":"Yamaguchi Prefecture","short_name":"Yamaguchi Prefecture","types":["administrative_area_level_1","political"]},{"long_name":"Japan","short_name":"JP","types":["country","political"]}],"formatted_address":"Nagato, Yamaguchi Prefecture, Japan","geometry":{"bounds":{"northeast":{"lat":34.4424146,"lng":131.349357},"southwest":{"lat":34.2617872,"lng":130.9321847}},"location":{"lat":34.3709562,"lng":131.1821947},"location_type":"APPROXIMATE","viewport":{"northeast":{"lat":34.4424146,"lng":131.349357},"southwest":{"lat":34.2617872,"lng":130.9321847}}},"place_id":"ChIJbcaHpZJnQzURubGPFww5jm0","types":["locality","political"]},{"address_components":[{"long_name":"759-3801","short_name":"759-3801","types":["postal_code"]},{"long_name":"Misumikami","short_name":"Misumikami","types":["political","sublocality","sublocality_level_1"]},{"long_name":"Nagato","short_name":"Nagato","types":["locality","political"]},{"long_name":"Yamaguchi Prefecture","short_name":"Yamaguchi Prefecture","types":["administrative_area_level_1","political"]},{"long_name":"Japan","short_name":"JP","types":["country","political"]}],"formatted_address":"759-3801, Japan","geometry":{"bounds":{"northeast":{"lat":34.3702904,"lng":131.349357},"southwest":{"lat":34.3104089,"lng":131.2627181}},"location":{"lat":34.3486297,"lng":131.3310303},"location_type":"APPROXIMATE","viewport":{"northeast":{"lat":34.3702904,"lng":131.349357},"southwest":{"lat":34.3104089,"lng":131.2627181}}},"place_id":"ChIJb9oaEpWgRDUR0olmLbHw5ew","types":["postal_code"]},{"address_components":[{"long_name":"Yamaguchi Prefecture","short_name":"Yamaguchi Prefecture","types":["administrative_area_level_1","political"]},{"long_name":"Japan","short_name":"JP","types":["country","political"]}],"formatted_address":"Yamaguchi Prefecture, Japan","geometry":{"bounds":{"northeast":{"lat":34.7982772,"lng":132.4917877},"southwest":{"lat":33.7129895,"lng":130.7751059}},"location":{"lat":34.1859563,"lng":131.4706493},"location_type":"APPROXIMATE","viewport":{"northeast":{"lat":34.7982772,"lng":132.4917877},"southwest":{"lat":33.7129895,"lng":130.7751059}}},"place_id":"ChIJ_Y9adhnHRDURcOJUU8K8DEk","types":["administrative_area_level_1","political"]},{"address_components":[{"long_name":"Japan","short_name":"JP","types":["country","political"]}],"formatted_address":"Japan","geometry":{"bounds":{"northeast":{"lat":45.6412626,"lng":154.0031455},"southwest":{"lat":20.3585295,"lng":122.8554688}},"location":{"lat":36.204824,"lng":138.252924},"location_type":"APPROXIMATE","viewport":{"northeast":{"lat":45.6412626,"lng":154.0031455},"southwest":{"lat":20.3585295,"lng":122.8554688}}},"place_id":"ChIJLxl_1w9OZzQRRFJmfNR1QvU","types":["country","political"]}],"status":"OK"}';
+            callback(null, JSON.parse(result));
+        };
+
+        geoCtrl.googleApiKey = null;
+
+        geoCtrl._getAddressFromGoogle(function (err) {
+            if (err) {
+                console.error(err);
+            }
+            else {
+                console.info(geoCtrl);
+            }
+            done();
+        });
+    });
+});
+

--- a/server/test/testKecoRequester.js
+++ b/server/test/testKecoRequester.js
@@ -27,6 +27,14 @@ describe('unit test - keco requester', function() {
         assert.equal(key, keco.getServiceKey(), '');
     });
 
+    //it('test set/get daum key', function () {
+    //    var config = require('../config/config');
+    //    keco.setDaumApiKeys(JSON.parse(config.keyString.daum_keys));
+    //    var daum_key = keco.getDaumApiKey();
+    //
+    //    assert.equal(daum_key, "65e0aacada12c166c6ee9ee76844164e" , '');
+    //});
+
     //it('_check data time', function (done) {
     //    var mongoose = require('mongoose');
     //    mongoose.connect('localhost/todayweather', function(err) {

--- a/server/utils/convertGeocode.js
+++ b/server/utils/convertGeocode.js
@@ -8,8 +8,11 @@ var convert = require('./coordinate2xy');
 var keyBox = require('../config/config').keyString;
 
 function convertGeocodeByDaum(first, second, third, callback) {
+    var keyList = JSON.parse(keyBox.daum_keys);
+    var daum_key = keyList[Math.floor(Math.random() * keyList.length)];
+
     var url = 'https://apis.daum.net/local/geo/addr2coord'+
-        '?apikey=' + keyBox.daum_key +
+        '?apikey=' + daum_key +
         '&q='+ encodeURIComponent(first + second + third) +
         '&output=json';
     var encodedUrl = url;

--- a/server/utils/getGeoCodeFromDaum.js
+++ b/server/utils/getGeoCodeFromDaum.js
@@ -2,6 +2,7 @@
  * Created by aleckim on 2015. 12. 3..
  */
 
+"use strict";
 
 var fs = require('fs');
 var req = require('request');

--- a/server/utils/getGeoCodeFromDaum.js
+++ b/server/utils/getGeoCodeFromDaum.js
@@ -30,8 +30,11 @@ function saveDst() {
 }
 
 function getGeoCodeFromDaum(address, callback) {
+    var keyList = JSON.parse(config.keyString.daum_keys);
+    var daum_key = keyList[Math.floor(Math.random() * keyList.length)];
+
     var url = 'https://apis.daum.net/local/geo/addr2coord'+
-        '?apikey=' + config.keyString.daum_key +
+        '?apikey=' + daum_key +
         '&q='+ encodeURIComponent(address) +
         '&output=json';
 

--- a/server/utils/updateAreaNo.js
+++ b/server/utils/updateAreaNo.js
@@ -31,8 +31,11 @@ lineList.shift();
 log.info('Source of Area Number File : ' + sourceFile);
 
 function getGeoCodeFromDaum(address, callback) {
+    var keyList = JSON.parse(config.keyString.daum_keys);
+    var daum_key = keyList[Math.floor(Math.random() * keyList.length)];
+
     var url = 'https://apis.daum.net/local/geo/addr2coord'+
-        '?apikey=' + config.keyString.daum_key +
+        '?apikey=' + daum_key +
         '&q='+ encodeURIComponent(address) +
         '&output=json';
 


### PR DESCRIPTION
#1646
geo api로 요청이 오면, get query에서 사용할 정도를 사용하고 없는 정보를 daum, google통해 취득 후 국가별로 routerList를 사용함.
sendResult와 makeResult를 분리해서 route.geo에서는 sendResult를 사용하지 않음
daum_key를 array형태로 변경함