### PR TITLE
use SMART_BANNER on iOS

### DIFF
--- a/client/www/js/service.twads.js
+++ b/client/www/js/service.twads.js
@@ -159,10 +159,12 @@ angular.module('service.twads', [])
                 self.interstitialAdUnit = twClientConfig.admobAndroidInterstitialAdUnit;
             }
 
+            var adSize = ionic.Platform.isIOS()?admob.AD_SIZE.SMART_BANNER:admob.AD_SIZE.BANNER;
+
             admob.setOptions({
                 publisherId:    self.bannerAdUnit,
                 interstitialAdId: self.interstitialAdUnit,
-                adSize:         admob.AD_SIZE.BANNER,
+                adSize:         adSize,
                 bannerAtTop:    false,
                 overlap:        false,
                 offsetStatusBar:    false,


### PR DESCRIPTION
#1210 #1799
iOS에서 BANNER 좌우에 흰색여백이 생겨서 SMART_BANNER로 변경함
android에서는 SMART_BANNER가 너무 켜서 기존 유지