### PR TITLE
ion-content, ion-scroll이 안나오거나, scroll이 동작하지 않는 문제

### DIFF
--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -40,17 +40,36 @@ angular.module('controller.tabctrl', [])
             TwAds.init();
         }
 
+        var lastClickTime = 0;
+
         $scope.doTabForecast = function(forecastType) {
+            var clickTime = new Date().getTime();
+            var gap = clickTime - lastClickTime;
+
+            console.info('do tab forecast gap='+gap);
+            lastClickTime = clickTime;
+
             if (WeatherInfo.getEnabledCityCount() === 0) {
                 $scope.startPopup();
                 return;
             }
             if ($location.path() === '/tab/forecast' && forecastType === 'forecast') {
-                $scope.$broadcast('reloadEvent');
-                Util.ga.trackEvent('action', 'tab', 'reload');
+                //iPhone6 debuging mode에서 6xx 나옴.
+                if (gap <= 700) {
+                    console.warn('skip reload event on tab!!');
+                }
+                else {
+                    $scope.$broadcast('reloadEvent', 'tab');
+                    Util.ga.trackEvent('action', 'tab', 'reload');
+                }
             }
             else if ($location.path() === '/tab/dailyforecast' && forecastType === 'dailyforecast') {
-                $scope.$broadcast('reloadEvent');
+                if (gap <= 700) {
+                    console.warn('skip reload event on tab!!');
+                }
+                else {
+                    $scope.$broadcast('reloadEvent', 'tab');
+                }
                 Util.ga.trackEvent('action', 'tab', 'reload');
             }
             else {
@@ -169,7 +188,7 @@ angular.module('controller.tabctrl', [])
                         Util.ga.trackEvent('action', 'click', 'auto search');
                         WeatherInfo.disableCity(false);
                         if ($location.path() === '/tab/forecast') {
-                            $scope.$broadcast('reloadEvent');
+                            $scope.$broadcast('reloadEvent', 'startPopup');
                         }
                         else {
                             $location.path('/tab/forecast');
@@ -360,7 +379,7 @@ angular.module('controller.tabctrl', [])
                                     $scope.$broadcast('searchCurrentPositionEvent');
                                 }
                                 else {
-                                    $scope.$broadcast('reloadEvent');
+                                    $scope.$broadcast('reloadEvent', 'retryPopup');
                                 }
                             }, 0);
                         }

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -10,7 +10,7 @@
                ng-click="switchToLocationSettings()">{{isLocationEnabled()?'&#xE0C8;':'&#xE0C7;'}}</i>
         </p>
     </ion-nav-title>
-    <ion-content delegate-handle="body" overflow-scroll="true" direction="y"
+    <ion-content delegate-handle="body" direction="y"
                  zooming="false" scrollbar-y="false" scrollbar-x="false" has-bouncing="false" tabs-shrink>
         <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()"
              class="row row-no-padding" ng-style="{'height':headerHeight+'px'}">

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -10,7 +10,7 @@
                ng-click="switchToLocationSettings()">{{isLocationEnabled()?'&#xE0C8;':'&#xE0C7;'}}</i>
         </p>
     </ion-nav-title>
-    <ion-content delegate-handle="body" overflow-scroll="true" direction="y"
+    <ion-content delegate-handle="body" direction="y"
                  zooming="false" scrollbar-y="false" scrollbar-x="false" has-bouncing="false" tabs-shrink>
         <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()"
              class="row row-no-padding" ng-style="{'height':headerHeight+'px'}">


### PR DESCRIPTION
#1777
Timing issue로 광고 영역에 대한 수정후 더 빈번히 발생함
overflow-scroll 제거 -> ion-content를 ion native scroll사용하게 변경
chart current postion으로 set하는 timing 조정
loading indicator는 실제로 데이터 업데이트시에만 표시
현재위치 업데이트 시에는 loading indicator 표시 하지 않음
데이터 업데이트 이후에 500ms 후에 loading indicator 제거 (너무 빨리 제거되지 않게 보완)

etc
applyWeatherData는 loadWeatherData 시작시에만 호출
tab click이 중복 발생하여 gap time 체크후 reload event 생성
reload event sender 모두 셋업