### PR TITLE
"전라남도/목포시"가 region 한개의 param으로 전달되는 문제.

### DIFF
--- a/server/routes/v000803/route.nation.js
+++ b/server/routes/v000803/route.nation.js
@@ -33,7 +33,12 @@ function requestApi(cityName, version, query, lang, callback) {
     version = version || 'v000901';
     apiEndpoint = version >= 'v000901'? '/kma/addr':'/town';
 
-    var url = config.push.serviceServer+"/"+version+apiEndpoint+"/"+encodeURIComponent(cityName);
+    var arrayCityName;
+    arrayCityName = cityName.split("/");
+    var url = config.push.serviceServer+"/"+version+apiEndpoint;
+    arrayCityName.forEach(function (name) {
+        url += "/"+encodeURIComponent(name);
+    });
 
     if (query) {
         var count = 0;


### PR DESCRIPTION
#1668 #739
문자열 "전라남도/목포시" 라면 분리해서 encode해야 함.