### PR TITLE
air_forecast -> airInfo

### DIFF
--- a/client/www/js/controller.air.js
+++ b/client/www/js/controller.air.js
@@ -12,26 +12,26 @@ angular.module('controller.air', [])
                     "color": ['blue', 'green', '#FFD600', 'red'],
                     "str": ['LOC_GOOD', 'LOC_MODERATE', 'LOC_UNHEALTHY', 'LOC_VERY_UNHEALTHY'],
                     "value": {
-                        "pm25": [0, 15, 50, 100],
-                        "pm10": [0, 30, 80, 150],
-                        "o3": [0, 0.03, 0.09, 0.15],
-                        "no2": [0, 0.03, 0.06, 0.2],
-                        "co": [0, 2, 9, 15],
-                        "so2": [0, 0.02, 0.05, 0.15],
-                        "aqi": [0, 50, 100, 250]
+                        "pm25" : [0, 15, 50, 100, 500],     //ug/m3 (avg 24h)
+                        "pm10" : [0, 30, 80, 150, 600],     //ug/m3 (avg 24h)
+                        "o3" : [0, 0.03, 0.09, 0.15, 0.6],  //ppm   (avg 1h)
+                        "no2" : [0, 0.03, 0.06, 0.2, 2],    //ppm   (avg 1h)
+                        "co" : [0, 2, 9, 15, 50],           //ppm   (avg 1h)
+                        "so2" : [0, 0.02, 0.05, 0.15, 1],   //ppm   (avg 1h)
+                        "aqi" : [0, 50, 100, 250, 500]      //index
                     }
                 },
                 "airkorea_who": {
                     "color": ['blue', 'green', '#FFD600', 'red'],
                     "str": ['LOC_GOOD', 'LOC_MODERATE', 'LOC_UNHEALTHY', 'LOC_VERY_UNHEALTHY'],
                     "value": {
-                        "pm25": [0, 15, 25, 50],
-                        "pm10": [0, 30, 50, 100],
-                        "o3": [0, 0.03, 0.09, 0.15],
-                        "no2": [0, 0.03, 0.06, 0.2],
-                        "co": [0, 2, 9, 15],
-                        "so2": [0, 0.02, 0.05, 0.15],
-                        "aqi": [0, 50, 100, 250]
+                        "pm25" : [0, 15, 25, 50, 500],      //ug/m3
+                        "pm10" : [0, 30, 50, 100, 600],     //ug/m3
+                        "o3" : [0, 0.03, 0.09, 0.15, 0.6],  //ppm
+                        "no2" : [0, 0.03, 0.06, 0.2, 2],    //ppm
+                        "co" : [0, 2, 9, 15, 50],           //ppm
+                        "so2" : [0, 0.02, 0.05, 0.15, 1],   //ppm
+                        "aqi" : [0, 50, 100, 250, 500]      //ppm
                     }
                 },
                 "airnow": {
@@ -39,27 +39,27 @@ angular.module('controller.air', [])
                     "str": ['LOC_GOOD', 'LOC_MODERATE', 'LOC_UNHEALTHY_FOR_SENSITIVE_GROUPS',
                         'LOC_UNHEALTHY', 'LOC_VERY_UNHEALTHY', 'LOC_HAZARDOUS'],
                     "value": {
-                        "pm25": [0, 12, 35.4, 55.4, 150.4, 250.4],
-                        "pm10": [0, 54, 154, 254, 354, 424],
-                        "o3": [0, 0.054, 0.124, 0.164, 0.204, 0.404],
-                        "no2": [0, 0.053, 0.1, 0.36, 0.649, 0.1249],
-                        "co": [0, 4.4, 9.4, 12.4, 15.4, 30.4],
-                        "so2": [0, 0.035, 0.075, 0.185, 0.304, 0.604],
-                        "aqi": [0, 50, 100, 150, 200, 300]
+                        "pm25" : [0, 12.0, 35.4, 55.4, 150.4, 250.4, 500.4],    //ug/m3 (avg 24h)
+                        "pm10" : [0, 54, 154, 254, 354, 424, 604],              //ug/m3 (avg 24h)
+                        "o3" : [0, 54, 124, 164, 204, 404, 604],                //ppb (avg 8h, 1h)
+                        "no2" : [0, 53, 100, 360, 649, 1249, 2049],             //ppb (avg 1h)
+                        "co" : [0, 4.4, 9.4, 12.4, 15.4, 30.4, 50.4],           //ppm (avg 8h)
+                        "so2" : [0, 35, 75, 185, 304, 604, 1004],               //ppb (avg 1h, 24h)
+                        "aqi" : [0, 50, 100, 150, 200, 300, 500]                //index
                     }
                 },
-                "aircn": {
+                "aqicn": {
                     "color": ['green', '#FFD600', 'orange', 'red', 'purple', 'maroon'],
                     "str": ['LOC_GOOD', 'LOC_MODERATE', 'LOC_UNHEALTHY_FOR_SENSITIVE_GROUPS',
                         'LOC_UNHEALTHY', 'LOC_VERY_UNHEALTHY', 'LOC_HAZARDOUS'],
                     "value": {
-                        "pm25": [0, 35, 75, 115, 150, 250],
-                        "pm10": [0, 50, 150, 250, 350, 420],
-                        "o3": [0, 0.16, 0.2, 0.3, 0.4, 0.8], //다시 구해야 함.
-                        "no2": [0, 0.1, 0.2, 0.7, 1.2, 2.34], //다시 구해야 함.
-                        "co": [0, 5, 10, 35, 60, 90], //다시 구해야 함.
-                        "so2": [0, 0.15, 0.5, 0.65, 0.8, 1.6], //다시 구해야 함.
-                        "aqi": [0, 50, 100, 150, 200, 300]
+                        "pm25" : [0, 35, 75, 115, 150, 250, 500],    //ug/m3 (avg 1h)
+                        "pm10" : [0, 50, 150, 250, 350, 420, 600],   //ug/m3 (avg 1h)
+                        "o3" : [0, 160, 200, 300, 400, 800, 1200],    //ug/m3 (avg 1h)
+                        "no2" : [0, 100, 200, 700, 1200, 2340, 3840], //ug/m3 (avg 1h)
+                        "co" : [0, 5, 10, 35, 60, 90, 150],          //ug/m3 (avg 1h)
+                        "so2" : [0, 150, 500, 650, 800, 1600, 2620],  //ug/m3
+                        "aqi" : [0, 50, 100, 150, 200, 300, 500]
                     }
                 }
             };
@@ -98,13 +98,7 @@ angular.module('controller.air', [])
                 else {
                     startV = 0;
                 }
-                //grade가 마지막 단계에는 end value가 없으므로, 그냥 두배로 한다.
-                if (grade < $scope.aqiStandard.length) {
-                    endV = $scope.aqiStandard[grade-1].value;
-                }
-                else {
-                    endV = startV*2;
-                }
+                endV = $scope.aqiStandard[grade-1].value;
 
                 diff = (val - startV)/(endV-startV);
                 gradeD = diff*gradeW;

--- a/client/www/js/controller.units.js
+++ b/client/www/js/controller.units.js
@@ -142,7 +142,7 @@ angular.module('controller.units', [])
             var airUnitStr = {"airkorea": "LOC_AIR_QUALITY_INDEX_KR",
                 "airkorea_who": "LOC_AIR_QUALITY_INDEX_KR_WHO",
                 "airnow": "LOC_AIR_QUALITY_INDEX_US",
-                "aircn": "LOC_AIR_QUALITY_INDEX_CN"};
+                "aqicn": "LOC_AIR_QUALITY_INDEX_CN"};
             return airUnitStr[unit];
         };
 
@@ -170,7 +170,7 @@ angular.module('controller.units', [])
                         {label: 'inch', value: 'in'}];
                 case 'airUnit':
                     return [{label: this.getAirUnitStr('airnow'), value: 'airnow'},
-                        {label: this.getAirUnitStr('aircn'), value: 'aircn'},
+                        {label: this.getAirUnitStr('aqicn'), value: 'aqicn'},
                         {label: this.getAirUnitStr('airkorea'), value: 'airkorea'},
                         {label: this.getAirUnitStr('airkorea_who'), value: 'airkorea_who'}];
                 default:

--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -5,9 +5,12 @@
 
 'use strict';
 
+var async = require('async');
+
 var ControllerTown = require('../controllers/controllerTown');
 var kmaTimeLib = require('../lib/kmaTimeLib');
 var UnitConverter = require('../lib/unitConverter');
+var AqiConverter = require('../lib/aqi.converter');
 var KecoController = require('../controllers/kecoController');
 
 /**
@@ -23,7 +26,7 @@ function ControllerTown24h() {
         /**
          *
          * temperatureUnit(C,F), windSpeedUnit(mph,km/h,m/s,bft,kr), pressureUnit(mmHg,inHg,hPa,mb),
-         * distanceUnit(km,mi), precipitationUnit(mm,in), airUnit(airkorea,airkorea_who,airnow,aircn)
+         * distanceUnit(km,mi), precipitationUnit(mm,in), airUnit(airkorea,airkorea_who,airnow,aqicn)
          */
         if(!req.hasOwnProperty('query')) {
             req.query = {};
@@ -653,6 +656,252 @@ function ControllerTown24h() {
         return this;
     };
 
+    function _getHourlyAqiData(airInfo, date) {
+       var obj;
+       obj = airInfo.pollutants.aqi.hourly.find(function (aqiHourlyObj) {
+          return aqiHourlyObj.date === date;
+       });
+       if (obj == undefined)  {
+           obj = {date: date};
+           airInfo.pollutants.aqi.hourly.push(obj);
+       }
+       return obj;
+    }
+
+    function _insertHourlyAqiData(airInfo, newData) {
+       var obj = _getHourlyAqiData(airInfo, newData.date);
+       if (obj.hasOwnProperty('val')) {
+           if (obj.val >= newData.val) {
+              return false;
+           }
+       }
+       for (var key in newData) {
+           obj[key] = newData[key];
+       }
+       return true;
+    }
+
+    this._insertForecastPollutants = function (req, hourlyForecasts, airUnit) {
+
+        hourlyForecasts.forEach(function (hourlyForecast) {
+            if (hourlyForecast == null) {
+                return;
+            }
+
+            var airInfo = self._getAirInfo(req);
+
+            var latestPastDate = {};
+            var code = hourlyForecast.code;
+
+            hourlyForecast.hourly.forEach(function (forecast) {
+                var pollutant = airInfo.pollutants[code];
+                if (pollutant == undefined) {
+                    pollutant = airInfo.pollutants[code] = {};
+                }
+                if (airInfo.forecastSource == undefined) {
+                    airInfo.forecastSource = hourlyForecast.source;
+                }
+                if (airInfo.forecastPubDate == undefined) {
+                    airInfo.forecastPubDate = kmaTimeLib.convertYYYY_MM_DD_HHStr2YYYY_MM_DD_HHoZZ(hourlyForecast.pubDate);
+                }
+
+                //copy latest past data time
+                if (latestPastDate[code] == undefined && pollutant.hourly.length) {
+                    latestPastDate[code] = pollutant.hourly[pollutant.hourly.length-1].date;
+                }
+
+                var hourlyData = pollutant.hourly.find(function (hourlyObj) {
+                    return hourlyObj.date == forecast.date || forecast.date <= latestPastDate[code];
+                });
+
+                if (hourlyData) {
+                    //skip past data
+                    return;
+                }
+                hourlyData = {date: forecast.date, val: forecast.val, grade: forecast.grade};
+
+                pollutant.hourly.push(hourlyData);
+
+                var aqiVal = AqiConverter.value2index(airUnit, code, forecast.val)
+                var aqiData = {date: forecast.date, code: code,
+                                val: aqiVal,
+                                grade: AqiConverter.value2grade(airUnit, 'aqi', aqiVal)};
+                _insertHourlyAqiData(airInfo, aqiData);
+            });
+        });
+    };
+
+    this._insertEmptyPollutantHourlyObj = function (lastDataTime) {
+        var list = [];
+        try {
+            var date = new Date(lastDataTime);
+            date.setHours(date.getHours()-24);
+            for (var i=0; i<=24; i++) {
+                var hourlyObj = {date: kmaTimeLib.convertDateToYYYY_MM_DD_HHoMM(date)};
+                list.push(hourlyObj);
+                date.setHours(date.getHours()+1);
+            }
+        }
+        catch (err) {
+            log.error(err);
+        }
+
+       return list;
+    };
+
+    /**
+     *
+     * @param pollutants
+     * @param arpltnList
+     * @param airUnit
+     * @private
+     */
+    this._insertHourlyPollutants = function (pollutants, arpltnList, airUnit) {
+        arpltnList.forEach(function (arpltn) {
+
+            arpltn = KecoController.recalculateValue(arpltn, airUnit);
+
+            ['pm25', 'pm10', 'o3', 'no2', 'co', 'so2', 'aqi'].forEach(function (propertyName) {
+                if (arpltn[propertyName+"Value"] == undefined)  {
+                    log.warn("Fail to find "+propertyName+"Value");
+                    return;
+                }
+
+                var pollutant = pollutants[propertyName];
+                if (pollutant == undefined) {
+                    pollutant = pollutants[propertyName] = {};
+                }
+                if (!Array.isArray(pollutant.hourly)) {
+                    pollutant.hourly = self._insertEmptyPollutantHourlyObj(arpltn.dataTime);
+                    //insert empty object
+                }
+
+                var hourlyData = pollutant.hourly.find(function (hourlyObj) {
+                    return hourlyObj.date === arpltn.dataTime;
+                });
+                if (hourlyData == undefined) {
+                    log.debug("Fail to find arpltn dataTime: "+arpltn.dataTime+", code: "+propertyName);
+                    return;
+                }
+                hourlyData.val = arpltn[propertyName+"Value"];
+                hourlyData.grade = arpltn[propertyName+"Grade"];
+            });
+        });
+    };
+
+    function _getDailyAqiData(airInfo, date) {
+        var obj;
+        if (!airInfo.pollutants.aqi.hasOwnProperty('daily')) {
+            airInfo.pollutants.aqi.daily = [];
+        }
+
+        obj = airInfo.pollutants.aqi.daily.find(function (aqiHourlyObj) {
+            return aqiHourlyObj.date === date;
+        });
+        if (obj == undefined)  {
+            obj = {date: date};
+            airInfo.pollutants.aqi.daily.push(obj);
+        }
+        return obj;
+    }
+
+    function _insertDailyAqiData(airInfo, newData) {
+        var obj = _getDailyAqiData(airInfo, newData.date);
+        if (obj.hasOwnProperty('maxVal')) {
+            if (obj.maxVal >= newData.maxVal) {
+                return false;
+            }
+        }
+        for (var key in newData) {
+            obj[key] = newData[key];
+        }
+        return true;
+    }
+
+    this._insertDailyPollutants = function (airInfo, dailyList, airUnit) {
+        var pollutants = airInfo.pollutants;
+
+        dailyList.forEach(function (dayObj) {
+            if ( !dayObj.hasOwnProperty('dustForecast') ) {
+                return;
+            }
+            ['pm25', 'pm10', 'o3'].forEach(function (propertyName) {
+                if (dayObj.dustForecast[propertyName.toUpperCase()+"Grade"] == undefined) {
+                    return;
+                }
+
+                var pollutant = pollutants[propertyName];
+                if (pollutant == undefined) {
+                    pollutant = pollutants[propertyName] = {};
+                }
+                if (!Array.isArray(pollutant.daily)) {
+                    pollutant.daily = [];
+                }
+
+                var dailyData = pollutant.daily.find(function (obj) {
+                    var date = kmaTimeLib.convertYYYYMMDDtoYYYY_MM_DD(dayObj.date);
+                    return obj.date === date;
+                });
+
+                if (dailyData == undefined) {
+                    dailyData = {date: kmaTimeLib.convertYYYYMMDDtoYYYY_MM_DD(dayObj.date)};
+                }
+                var grade = dayObj.dustForecast[propertyName.toUpperCase()+"Grade"]+1;
+                dailyData.minVal = AqiConverter.grade2minMaxValue('airkorea', propertyName, grade).min;
+                dailyData.maxVal = AqiConverter.grade2minMaxValue('airkorea', propertyName, grade).max;
+                dailyData.minGrade = AqiConverter.value2grade(airUnit, propertyName, dailyData.minVal);
+                dailyData.maxGrade = AqiConverter.value2grade(airUnit, propertyName, dailyData.maxVal);
+                pollutant.daily.push(dailyData);
+
+                var aqiMinVal = AqiConverter.value2index(airUnit, propertyName, dailyData.minVal);
+                var aqiMaxVal = AqiConverter.value2index(airUnit, propertyName, dailyData.maxVal);
+                var aqiData = {date: dailyData.date, code: propertyName,
+                            minVal: aqiMinVal,
+                            maxVal: aqiMaxVal,
+                            minGrade: AqiConverter.value2grade(airUnit, 'aqi', aqiMinVal),
+                            maxGrade: AqiConverter.value2grade(airUnit, 'aqi', aqiMaxVal)};
+                _insertDailyAqiData(airInfo, aqiData);
+            });
+        });
+    };
+
+    this._getAirInfo = function (req) {
+        if (req.airInfo == undefined) {
+            req.airInfo = {source: "airkorea"};
+        }
+        return req.airInfo;
+    };
+
+    this.makeAirInfo = function (req, res, next) {
+        try {
+            var airInfo;
+            var airUnit = req.query.airUnit || 'airkorea';
+            if (req.current.arpltn) {
+                airInfo = self._getAirInfo(req);
+                airInfo.last = req.current.arpltn;
+            }
+            if(req.arpltnList) {
+                if (airInfo == undefined) {
+                    airInfo = self._getAirInfo(req);
+                }
+
+                airInfo.pollutants = {};
+                self._insertHourlyPollutants(req.airInfo.pollutants, req.arpltnList, airUnit);
+            }
+            if ( req.midData && Array.isArray(req.midData.dailyData) ) {
+                var dailyList = req.midData.dailyData.filter(function (value) {
+                    return value.hasOwnProperty('dustForecast');
+                });
+                self._insertDailyPollutants(req.airInfo, dailyList, airUnit);
+            }
+        }
+        catch (err) {
+            log.error(err);
+        }
+        next();
+        return this;
+    };
+
     this.AirkoreaForecast = function (req, res, next){
         var meta = {};
 
@@ -665,44 +914,60 @@ function ControllerTown24h() {
         meta.city = cityName;
         meta.town = townName;
 
-        if(global.airkoreaDustImageMgr){
-            if(req.geocode){
-                global.airkoreaDustImageMgr.getDustInfo(req.geocode.lat, req.geocode.lon, 'PM10', req.query.airUnit, function(err, pm10){
-                    if(err){
-                        log.info('Fail to get PM 10 info');
-                        return next();
-                    }
-                    req.air_forecast = [];
-                    var pm10Forecast = {
-                        source: 'airkorea',
-                        code: 'PM10',
-                        pubDate: pm10.pubDate,
-                        hourly: pm10.hourly
-                    };
+        if (global.airkoreaDustImageMgr == undefined || req.geocode == undefined) {
+            log.error("Fail to find airkoreaDustImageMgr or req.geocode");
+            next();
+            return this;
+        }
 
-                    req.air_forecast.push(pm10Forecast);
-
+        async.applyEachSeries([
+                function (callback) {
+                    airkoreaDustImageMgr.getDustInfo(req.geocode.lat, req.geocode.lon, 'PM10', req.query.airUnit, function(err, pm10) {
+                        if (err) {
+                            log.info('Fail to get PM 10 info');
+                            log.error(err);
+                            return callback();
+                        }
+                        var pm10Forecast = {
+                            source: 'airkorea',
+                            code: 'pm10',
+                            pubDate: pm10.pubDate,
+                            hourly: pm10.hourly
+                        };
+                        callback(null, pm10Forecast);
+                    });
+                },
+                function (callback) {
                     airkoreaDustImageMgr.getDustInfo(req.geocode.lat, req.geocode.lon, 'PM25', req.query.airUnit, function(err, pm25){
                         if(err){
                             log.info('Fail to get PM 25 info');
-                            return next();
+                            log.error(err);
+                            return callback();
                         }
                         var pm25Forecast = {
                             source: 'airkorea',
-                            code: 'PM25',
+                            code: 'pm25',
                             pubDate: pm25.pubDate,
                             hourly: pm25.hourly
                         };
-
-                        req.air_forecast.push(pm25Forecast);
-
-                        next();
+                        callback(null, pm25Forecast);
                     });
-                });
-            }
-        }else{
-            next();
-        }
+                }
+            ],
+            function (err, results) {
+                if (results == undefined || results.length <= 0) {
+                    log.warn("Fail to dust forecast");
+                }
+                else {
+                    try {
+                        self._insertForecastPollutants(req, results, req.query.airUnit);
+                    }
+                    catch(err) {
+                        log.error(err);
+                    }
+                }
+                next();
+            });
 
         return this;
     };
@@ -1080,8 +1345,8 @@ function ControllerTown24h() {
             if (req.dailySummary) {
                 result.dailySummary = req.dailySummary;
             }
-            if (req.air_forecast){
-                result.air_forecast = req.air_forecast;
+            if (req.airInfo){
+                result.airInfo = req.airInfo;
             }
             result.source = "KMA";
 
@@ -1191,7 +1456,7 @@ function ControllerTown24h() {
                 self._convertWeatherData(value, req.query);
             });
             if (req.current.hasOwnProperty('arpltn')) {
-                KecoController.recalculateValue(req.current.arpltn, req.query.airUnit, res);
+                KecoController.recalculateValue(req.current.arpltn, req.query.airUnit);
             }
         }
         catch (err) {
@@ -1226,7 +1491,7 @@ ControllerTown24h.prototype._parseSkyState = function (sky, pty, lgt, isNight) {
             skyIconName += "BigCloud"; //Todo need new icon
             break;
         case 4:
-            skyIconName = "Cloud";
+            skyIconName = "Cloud"; //overwrite Moon/Sun
             break;
         default:
             log.error('Fail to parse sky='+sky);
@@ -1307,7 +1572,7 @@ ControllerTown24h.prototype._getWeatherEmoji = function (skyIcon) {
 
 /**
  * temperatureUnit(C,F), windSpeedUnit(mph,km/h,m/s,bft,kr), pressureUnit(mmHg,inHg,hPa,mb),
- * distanceUnit(km,mi), precipitationUnit(mm,in), airUnit(airkorea,airkorea_who,airnow,aircn)
+ * distanceUnit(km,mi), precipitationUnit(mm,in), airUnit(airkorea,airkorea_who,airnow,aqicn)
  * @param wData
  * @param query
  * @returns {ControllerTown24h}

--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -722,7 +722,7 @@ function ControllerTown24h() {
 
                 pollutant.hourly.push(hourlyData);
 
-                var aqiVal = AqiConverter.value2index(airUnit, code, forecast.val)
+                var aqiVal = AqiConverter.value2index(airUnit, code, forecast.val);
                 var aqiData = {date: forecast.date, code: code,
                                 val: aqiVal,
                                 grade: AqiConverter.value2grade(airUnit, 'aqi', aqiVal)};

--- a/server/controllers/worldWeather/controller.ww.units.js
+++ b/server/controllers/worldWeather/controller.ww.units.js
@@ -16,7 +16,7 @@ function ControllerWWUnits() {
         /**
          *
          * temperatureUnit(C,F), windSpeedUnit(mph,km/h,m/s,bft,kr), pressureUnit(mmHg,inHg,hPa,mb),
-         * distanceUnit(km,mi), precipitationUnit(mm,in), airUnit(airkorea,airkorea_who,airnow,aircn)
+         * distanceUnit(km,mi), precipitationUnit(mm,in), airUnit(airkorea,airkorea_who,airnow,aqicn)
          */
         if(!req.hasOwnProperty('query')) {
             req.query = {};

--- a/server/controllers/worldWeather/controllerCollector.js
+++ b/server/controllers/worldWeather/controllerCollector.js
@@ -1432,7 +1432,6 @@ ConCollector.prototype.requestDsfData = function(geocode, From, To, timeOffset, 
                 }
                 requester.getForecast(geocode, date, key, function(err, result){
                     if(err){
-                        print.error('Req Dsf> get fail', geocode, date);
                         log.warn('Req Dsf> get fail', geocode, date);
                         cb(null);
                         return;

--- a/server/controllers/worldWeather/controllerWorldWeather.js
+++ b/server/controllers/worldWeather/controllerWorldWeather.js
@@ -1653,6 +1653,22 @@ function controllerWorldWeather() {
         next();
     };
 
+    self.makeAirInfo = function (req, res, next) {
+        try {
+            var result = req.result;
+            var current = result.thisTime[result.thisTime.length-1];
+            if ( current.hasOwnProperty('arpltn') ) {
+                result.airInfo = {source: "aqicn"};
+                result.airInfo.last = current.arpltn;
+            }
+        }
+        catch (err) {
+            log.error(err);
+        }
+
+        next();
+    };
+
     self.dataSort = function(req, res, next){
         var meta = {};
         meta.sID = req.sessionID;

--- a/server/lib/aqi.converter.js
+++ b/server/lib/aqi.converter.js
@@ -1,0 +1,191 @@
+/**
+ * Created by aleckim on 2018. 1. 22..
+ */
+
+"use strict";
+
+const air_pollutants_breakpoints = {
+    "airkorea" : {
+        "pm25" : [0, 15, 50, 100, 500],     //ug/m3 (avg 24h)
+        "pm10" : [0, 30, 80, 150, 600],     //ug/m3 (avg 24h)
+        "o3" : [0, 0.03, 0.09, 0.15, 0.6],  //ppm   (avg 1h)
+        "no2" : [0, 0.03, 0.06, 0.2, 2],    //ppm   (avg 1h)
+        "co" : [0, 2, 9, 15, 50],           //ppm   (avg 1h)
+        "so2" : [0, 0.02, 0.05, 0.15, 1],   //ppm   (avg 1h)
+        "aqi" : [0, 50, 100, 250, 500]      //index
+    },
+    "airkorea_who" : {
+        "pm25" : [0, 15, 25, 50, 500],      //ug/m3
+        "pm10" : [0, 30, 50, 100, 600],     //ug/m3
+        "o3" : [0, 0.03, 0.09, 0.15, 0.6],  //ppm
+        "no2" : [0, 0.03, 0.06, 0.2, 2],    //ppm
+        "co" : [0, 2, 9, 15, 50],           //ppm
+        "so2" : [0, 0.02, 0.05, 0.15, 1],   //ppm
+        "aqi" : [0, 50, 100, 250, 500]      //ppm
+    },
+    "airnow" : {
+        "pm25" : [0, 12.0, 35.4, 55.4, 150.4, 250.4, 500.4],    //ug/m3 (avg 24h)
+        "pm10" : [0, 54, 154, 254, 354, 424, 604],              //ug/m3 (avg 24h)
+        "o3" : [0, 54, 124, 164, 204, 404, 604],                //ppb (avg 8h, 1h)
+        "no2" : [0, 53, 100, 360, 649, 1249, 2049],             //ppb (avg 1h)
+        "co" : [0, 4.4, 9.4, 12.4, 15.4, 30.4, 50.4],           //ppm (avg 8h)
+        "so2" : [0, 35, 75, 185, 304, 604, 1004],               //ppb (avg 1h, 24h)
+        "aqi" : [0, 50, 100, 150, 200, 300, 500]                //index
+    },
+    "aqicn": {
+        "pm25" : [0, 35, 75, 115, 150, 250, 500],    //ug/m3 (avg 1h)
+        "pm10" : [0, 50, 150, 250, 350, 420, 600],   //ug/m3 (avg 1h)
+        "o3" : [0, 160, 200, 300, 400, 800, 1200],    //ug/m3 (avg 1h)
+        "no2" : [0, 100, 200, 700, 1200, 2340, 3840], //ug/m3 (avg 1h)
+        "co" : [0, 5, 10, 35, 60, 90, 150],          //ug/m3 (avg 1h)
+        "so2" : [0, 150, 500, 650, 800, 1600, 2620],  //ug/m3
+        "aqi" : [0, 50, 100, 150, 200, 300, 500]
+    }
+};
+
+class AqiConverter {
+    constructor() {
+    }
+
+    /**
+     *
+     * @param airUnit
+     * @param code
+     * @param grade
+     * @returns {{min: *, max: *}}
+     */
+    static grade2minMaxValue(airUnit, code, grade) {
+        let pollutants = air_pollutants_breakpoints[airUnit];
+        return {min: pollutants[code][grade-1], max: pollutants[code][grade]};
+    }
+
+    static ppm2ppb(value) {
+        return value*1000;
+    }
+
+    /**
+     * @param Mal
+     *           so2 분자량 : 15.99 + 15.99 + 32.07 = 64.05
+     *           no2 분자량 : 15.99 + 15.99 + 14.01 = 45.99
+     *           O3 분자량 : 15.99 + 15.99 + 15.99 = 47.97
+     *           CO 분자량 : 15.99 + 12.01 = 28
+     * @param value
+     * @returns {Number}
+     * @private
+     */
+    static ppm2um (Mol, value) {
+        var ppb = parseFloat(this.ppm2ppb(value));
+        var molList = {
+            so2: 64.05,
+            no2: 45.99,
+            o3: 47.97,
+            co: 28.00
+        };
+
+        if (molList[Mol] == undefined) {
+            return -1;
+        }
+        return Math.round(ppb * molList[Mol] / 22.4);
+    }
+
+    static value2grade(airUnit, code, v) {
+        var unit;
+
+        unit = air_pollutants_breakpoints[airUnit][code];
+
+        if (code === 'o3' || code === 'no2' || code === 'so2') {
+            if (airUnit === 'airnow') {
+                v = this.ppm2ppb(v);
+            }
+            else if (airUnit == 'aqicn') {
+                v = this.ppm2um(code, v);
+                if (isNaN(v) || v < 0) {
+                    v = 0;
+                }
+            }
+        }
+        else if (code === 'co') {
+            if (airUnit == 'aqicn') {
+                v = this.ppm2um(code, v);
+                if (isNaN(v) || v < 0) {
+                    v = 0;
+                }
+            }
+        }
+
+        if (unit == undefined) {
+            log.error(airUnit, code, v);
+        }
+
+        if (v < unit[0]) {
+            return -1;
+        }
+        else if (v <= unit[1]) {
+            return 1;
+        }
+        else if (v <= unit[2]) {
+            return 2;
+        }
+        else if (v <= unit[3]) {
+            return 3;
+        }
+        else if (v > unit[3]) {
+            if (unit.length > 4) {
+                if (v <= unit[4]) {
+                    return 4;
+                }
+                else if(v <= unit[5]) {
+                    return 5;
+                }
+                else if(v > unit[5]) {
+                    return 6;
+                }
+            }
+
+            return 4;
+        }
+        return -1;
+    }
+
+    static value2index(airUnit, code, value) {
+        if (code === 'aqi' || code === 'khai') {
+            log.error("You can not calculator about aqi or khai");
+            return value;
+        }
+
+        var unit = air_pollutants_breakpoints[airUnit][code];
+        var aqiUnit = air_pollutants_breakpoints[[airUnit]].aqi;
+
+        // log.info('code: '+code+', unit: '+unit+' value: '+value);
+        // log.info('code: aqi, unit: '+aqiUnit);
+        var grade = this.value2grade(airUnit, code, value);
+        // log.info('code: '+code+', grade:'+grade);
+
+        if (code === 'o3' || code === 'no2' || code === 'so2') {
+            if (airUnit === 'airnow') {
+                value = value * 1000;   // ppm -> ppb
+                log.debug('value: '+value+'ppb');
+            }
+            else if (airUnit == 'aqicn') {
+                value = this.ppm2um(code, value);
+                if (isNaN(value) || value < 0) {
+                    value = 0;
+                }
+                log.debug('value: '+value+'ug/m3');
+            }
+        }
+        else if (code === 'co') {
+            if (airUnit == 'aqicn') {
+                value = this.ppm2um(code, value) * 1000;
+                if (isNaN(value) || value < 0) {
+                    value = 0;
+                }
+                log.debug('value: '+value+'ug/m3');
+            }
+        }
+
+        return Math.round((aqiUnit[grade]-aqiUnit[grade-1])/(unit[grade] - unit[grade-1])*(value - unit[grade-1]) + aqiUnit[grade-1]);
+    }
+}
+
+module.exports = AqiConverter;

--- a/server/lib/kmaTimeLib.js
+++ b/server/lib/kmaTimeLib.js
@@ -224,6 +224,7 @@ kmaTimeLib.convertYYYYoMMoDDoHHoMMtoYYYYoMMoDD_HHoMM = function(dateStr) {
 
 /**
  * for kma scraper
+ * Date -> 2018.12.31.23:00
  * @param date
  * @returns {string}
  */
@@ -239,6 +240,11 @@ kmaTimeLib.convertDateToYYYYoMMoDDoHHoZZ = function (date) {
         ':00';
 };
 
+/**
+ * Date -> 2018.12.31.23:59
+ * @param date
+ * @returns {string}
+ */
 kmaTimeLib.convertDateToYYYYoMMoDDoHHoMM = function (date) {
     if (date == undefined) {
         date = kmaTimeLib.toTimeZone(9);
@@ -251,6 +257,11 @@ kmaTimeLib.convertDateToYYYYoMMoDDoHHoMM = function (date) {
         ':'+manager.leadingZeros(date.getMinutes(), 2);
 };
 
+/**
+ * Date -> 2018.12.31 23:00
+ * @param date
+ * @returns {string}
+ */
 kmaTimeLib.convertDateToYYYYoMMoDD_HHoZZ = function (date) {
     if (date == undefined) {
         date = kmaTimeLib.toTimeZone(9);
@@ -263,6 +274,11 @@ kmaTimeLib.convertDateToYYYYoMMoDD_HHoZZ = function (date) {
         ':00';
 };
 
+/**
+ * Date -> 2018.12.31 23:59
+ * @param date
+ * @returns {string}
+ */
 kmaTimeLib.convertDateToYYYYoMMoDD_HHoMM = function (date) {
     if (date == undefined) {
         date = kmaTimeLib.toTimeZone(9);
@@ -275,6 +291,11 @@ kmaTimeLib.convertDateToYYYYoMMoDD_HHoMM = function (date) {
         ':'+manager.leadingZeros(date.getMinutes(), 2);
 };
 
+/**
+ * Date -> 2018-12-31 23:59
+ * @param date
+ * @returns {string}
+ */
 kmaTimeLib.convertDateToYYYY_MM_DD_HHoMM = function (date) {
     if (date == undefined) {
         date = kmaTimeLib.toTimeZone(9);
@@ -370,11 +391,21 @@ kmaTimeLib.getPast8DaysTime = function(curTime){
     return now;
 };
 
+/**
+ * 201812312300 -> Date(Timezone +9)
+ * @param curTime
+ * @returns {Date}
+ */
 kmaTimeLib.getKoreaDateObj = function(curTime){
     return new Date(curTime.slice(0,4)+ '-' + curTime.slice(4,6) + '-' + curTime.slice(6,8) + 'T' + curTime.slice(8,10) + ':' + curTime.slice(10,12) + ':00+09:00');
 };
 
 
+/**
+ * Date + 9 -> 201812312300
+ * @param curTime
+ * @returns {*}
+ */
 kmaTimeLib.getKoreaTimeString = function(curTime){
     var now = new Date(curTime.getTime());
     var tz = now.getTime() + (9 * 3600000);
@@ -406,6 +437,14 @@ kmaTimeLib.getDiffDays = function(target, current) {
     var targetDay = new Date(target.getFullYear(), target.getMonth(), target.getDate());
     var date = new Date(current.getFullYear(), current.getMonth(), current.getDate());
     return Math.ceil((targetDay - date) / (1000 * 3600 * 24));
+};
+
+/**
+ * 2018-01-21 11시 발표 -> 2018-01-21 11:00
+ * @param str
+ */
+kmaTimeLib.convertYYYY_MM_DD_HHStr2YYYY_MM_DD_HHoZZ = function (str) {
+    return str.substr(0, 13) + ":00";
 };
 
 module.exports = kmaTimeLib;

--- a/server/lib/unitConverter.js
+++ b/server/lib/unitConverter.js
@@ -244,7 +244,7 @@ UnitConverter.prototype.convertUnits = function (from, to, val) {
     var self = this;
 
     if (val == undefined) {
-        log.error('Fail to convert from '+from+" to "+to+" value="+val);
+        log.warn('Fail to convert from '+from+" to "+to+" value="+val);
         return val;
     }
     if (from == to) {

--- a/server/models/modelPush.js
+++ b/server/models/modelPush.js
@@ -23,7 +23,7 @@ var pushSchema = new mongoose.Schema({
         pressureUnit: String,   //hPa, mbar, ..
         distanceUnit: String,   //km, miles
         precipitationUnit: String, //mm, inches
-        airUnit: String //airkorea, airkorea_who, airnow, aircn
+        airUnit: String //airkorea, airkorea_who, airnow, aqicn
     }
 });
 

--- a/server/routes/v000901/route.dsf.coord.js
+++ b/server/routes/v000901/route.dsf.coord.js
@@ -34,6 +34,6 @@ router.get('/:loc', ctrlUnits.checkQueryValidation, convertParamAndQuery,
     worldWeather.queryTwoDaysWeather, worldWeather.convertDsfLocalTime,
     worldWeather.mergeDsfDailyData, worldWeather.mergeDsfCurrentData,
     worldWeather.mergeDsfHourlyData, worldWeather.mergeAqi, worldWeather.dataSort,
-    ctrlUnits.convertUnits, ctrlUnits.makeSummary, worldWeather.sendResult);
+    ctrlUnits.convertUnits, worldWeather.makeAirInfo, ctrlUnits.makeSummary, worldWeather.sendResult);
 
 module.exports = router;

--- a/server/routes/v000901/route.kma.addr.js
+++ b/server/routes/v000901/route.kma.addr.js
@@ -55,7 +55,7 @@ var routerList = [cTown.checkQueryValidation, cTown.checkParamValidation, cTown.
     cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather, cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
     cTown.mergeByShortest, cTown.adjustShort, cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo,
     cTown.getPastMid, cTown.mergeMidWithShort, cTown.updateMidTempMaxMin, cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco,
-    cTown.getKecoDustForecast, cTown.getRiseSetInfo, cTown.insertIndex, cTown.AirkoreaForecast, cTown.insertSkyIcon,
+    cTown.getKecoDustForecast, cTown.getRiseSetInfo, cTown.insertIndex, cTown.makeAirInfo, cTown.AirkoreaForecast, cTown.insertSkyIcon,
     cTown.setYesterday, cTown.convertUnits, cTown.insertStrForData, cTown.getSummaryAfterUnitConverter,
     cTown.makeResult, cTown.sendResult];
 

--- a/server/test/test.aqi.converter.js
+++ b/server/test/test.aqi.converter.js
@@ -1,0 +1,55 @@
+/**
+ * Created by aleckim on 18. 1. 23..
+ */
+
+"use strict";
+
+var Logger = require('../lib/log');
+global.log  = new Logger(__dirname + "/debug.log");
+
+var assert  = require('assert');
+
+var AqiConverter = require('../lib/aqi.converter');
+
+describe('unit test - aqi converter', function() {
+    var testData = { "stationName" : "상대원동", "pm25Grade" : -1, "pm10Grade" : 2,
+        "no2Grade" : 3, "o3Grade" : 1, "coGrade" : 1, "so2Grade" : 1,
+        "khaiGrade" : -1, "khaiValue" : -1, "pm25Value" : 80,
+        "pm10Value" : 80, "no2Value" : 0.064, "o3Value" : 0.003,
+        "coValue" : 0.9, "so2Value" : 0.005, "dataTime" : "2017-12-22 20:00" };
+
+    it('test getting aqi index', function(){
+        var index = AqiConverter.value2index('airkorea', 'pm10', testData.pm10Value);
+        assert.equal(index, 100);
+
+        index = AqiConverter.value2index('airkorea_who', 'pm10', testData.pm10Value);
+        assert.equal(index, 190);
+
+        index = AqiConverter.value2index('airnow', 'pm10', testData.pm10Value);
+        assert.equal(index, 63);
+
+        index = AqiConverter.value2index('aqicn', 'pm10', testData.pm10Value);
+        assert.equal(index, 65);
+
+        index = AqiConverter.value2index('airnow', 'o3', testData.o3Value);
+        assert.equal(index, 3);
+
+        index = AqiConverter.value2index('aqicn', 'so2', testData.so2Value);
+        assert.equal(index, 5);
+
+        var airkorea = { "stationName" : "강남구", "pm25Grade" : 2,
+            "pm25Grade24" : 2, "pm10Grade" : 2, "pm10Grade24" : 2, "no2Grade" : 2, "o3Grade" : 1,
+            "coGrade" : 1, "so2Grade" : 1, "khaiGrade" : 2, "khaiValue" : 97, "pm25Value24" : 31,
+            "pm25Value" : 40, "pm10Value24" : 51, "pm10Value" : 46, "no2Value" : 0.058, "o3Value" : 0.003,
+            "coValue" : 0.7, "so2Value" : 0.005, "dataTime" : "2018-01-22 18:00", "mangName" : "도시대기" };
+        var aqicn = {
+            "pm25": 112, "pm10": 43, "o3": 3, "no2": 55, "so2": 7, "co": 8, "aqi":112
+        };
+        ['pm25', 'pm10', 'o3', 'no2', 'so2', 'co'].forEach(function (name) {
+            index = AqiConverter.value2index('airnow', name, airkorea[name+'Value']);
+            //console.log({name: name, value: airkorea[name+'Value'], aqiCNIndex: index});
+            assert.equal(index, aqicn[name]);
+        });
+    });
+});
+

--- a/server/test/testKecoController.js
+++ b/server/test/testKecoController.js
@@ -113,9 +113,9 @@ describe('unit test - keco controller', function() {
                         "coValue" : 0.9, "so2Value" : 0.005, "dataTime" : "2017-12-22 20:00" };
 
         kecoController.recalculateValue(testData, 'airkorea');
-        assert.equal(testData.pm25Grade, 3);
-        assert.equal(testData.khaiGrade, undefined);
         log.info('airkorea : ', testData);
+        assert.equal(testData.pm25Grade, 3);
+        assert.equal(testData.aqiGrade, 3);
     });
 });
 


### PR DESCRIPTION
#2082
- aircn -> aqicn으로 통일(aqicn.org에서 가져온 이름임)
  - client도 조정함
- aqiUnit, airUnit -> airUnit으로 통일
- air_forecast -> airInfo
  - last라고 가장 최근 측정값 추가
  - pollutants에 오염물질별 hourly(과거,예보), daily(예보) 정보 추가
  - 오염물질의 예보 val은 간격값 중에 큰값임
  - daily는 범위값을 가짐
  - 일별예보도 airUnit에 따라 변환함
- new aqi.converter.js
   - aqi 관련 수치, 변환함수는 여기로 정리
- khaValue(aqiValue)가 없는 경우 계산 시도함