### PR TITLE
airinfo string 변환 오류 수정

### DIFF
--- a/server/.jshintrc
+++ b/server/.jshintrc
@@ -36,7 +36,8 @@
     "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
     "eqnull"        : false,     // true: Tolerate use of `== null`
     "es5"           : true,      // true: Allow ES5 syntax (ex: getters and setters)
-    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "esnext"        : true,      // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "esversion"     : 6,
     "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
     "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
     "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -2781,12 +2781,7 @@ function ControllerTown() {
                         if (pollutant.hourly) {
                             pollutant.hourly.forEach(function (item) {
                                 if (item.hasOwnProperty('grade')) {
-                                    if (airUnit === 'airnow' || airUnit === 'aqicn') {
-                                        item.str = UnitConverter.airGrade2str(item.grade, pollutant.code, res);
-                                    }
-                                    else {
-                                        item.str = UnitConverter.airkoreaGrade2str(item.grade, pollutant.code, res);
-                                    }
+                                    item.str = UnitConverter.airGrade2Str(airUnit, item.grade, res);
                                 }
                             });
                         }
@@ -2794,10 +2789,10 @@ function ControllerTown() {
                         if (pollutant.daily) {
                             pollutant.daily.forEach(function (item) {
                                 if (item.hasOwnProperty('minGrade')) {
-                                    item.minStr = UnitConverter.airkoreaGrade2str(item.minGrade, pollutant.code, res);
+                                    item.minStr = UnitConverter.airGrade2Str(airUnit, item.minGrade, res);
                                 }
                                 if (item.hasOwnProperty('maxGrade')) {
-                                    item.maxStr = UnitConverter.airkoreaGrade2str(item.maxGrade, pollutant.code, res);
+                                    item.maxStr = UnitConverter.airGrade2Str(airUnit, item.maxGrade, res);
                                 }
                             });
                         }
@@ -3165,51 +3160,29 @@ ControllerTown.prototype._convertKmaRxxToStr = function(pty, rXX) {
  * @private
  */
 ControllerTown.prototype._makeArpltnStr = function (arpltn, airUnit, ts) {
-    if (airUnit === 'airnow' || airUnit === 'aqicn') {
-        if (arpltn.hasOwnProperty('pm10Grade')) {
-            arpltn.pm10Str = UnitConverter.airGrade2str(arpltn.pm10Grade, "pm10", ts);
-        }
-        if (arpltn.hasOwnProperty('pm25Grade')) {
-            arpltn.pm25Str = UnitConverter.airGrade2str(arpltn.pm25Grade, "pm25", ts);
-        }
-        if (arpltn.hasOwnProperty('o3Grade')) {
-            arpltn.o3Str = UnitConverter.airGrade2str(arpltn.o3Grade, "o3", ts);
-        }
-        if (arpltn.hasOwnProperty('no2Grade')) {
-            arpltn.no2Str = UnitConverter.airGrade2str(arpltn.no2Grade, "no2", ts);
-        }
-        if (arpltn.hasOwnProperty('coGrade')) {
-            arpltn.coStr = UnitConverter.airGrade2str(arpltn.coGrade, "co", ts);
-        }
-        if (arpltn.hasOwnProperty('so2Grade')) {
-            arpltn.so2Str = UnitConverter.airGrade2str(arpltn.so2Grade, "so2", ts);
-        }
-        if (arpltn.hasOwnProperty('khaiGrade')) {
-            arpltn.khaiStr = UnitConverter.airGrade2str(arpltn.khaiGrade, "khai", ts);
-        }
+    if (arpltn.hasOwnProperty('pm10Grade')) {
+        arpltn.pm10Str = UnitConverter.airGrade2Str(airUnit, arpltn.pm10Grade, ts);
     }
-    else if (airUnit === 'airkorea' || airUnit === 'airkorea_who' || airUnit == undefined) {
-        if (arpltn.hasOwnProperty('pm10Grade')) {
-            arpltn.pm10Str = UnitConverter.airkoreaGrade2str(arpltn.pm10Grade, "pm10", ts);
-        }
-        if (arpltn.hasOwnProperty('pm25Grade')) {
-            arpltn.pm25Str = UnitConverter.airkoreaGrade2str(arpltn.pm25Grade, "pm25", ts);
-        }
-        if (arpltn.hasOwnProperty('o3Grade')) {
-            arpltn.o3Str = UnitConverter.airkoreaGrade2str(arpltn.o3Grade, "o3", ts);
-        }
-        if (arpltn.hasOwnProperty('no2Grade')) {
-            arpltn.no2Str = UnitConverter.airkoreaGrade2str(arpltn.no2Grade, "no2", ts);
-        }
-        if (arpltn.hasOwnProperty('coGrade')) {
-            arpltn.coStr = UnitConverter.airkoreaGrade2str(arpltn.coGrade, "co", ts);
-        }
-        if (arpltn.hasOwnProperty('so2Grade')) {
-            arpltn.so2Str = UnitConverter.airkoreaGrade2str(arpltn.so2Grade, "so2", ts);
-        }
-        if (arpltn.hasOwnProperty('khaiGrade')) {
-            arpltn.khaiStr = UnitConverter.airkoreaGrade2str(arpltn.khaiGrade, "khai", ts);
-        }
+    if (arpltn.hasOwnProperty('pm25Grade')) {
+        arpltn.pm25Str = UnitConverter.airGrade2Str(airUnit, arpltn.pm25Grade, ts);
+    }
+    if (arpltn.hasOwnProperty('o3Grade')) {
+        arpltn.o3Str = UnitConverter.airGrade2Str(airUnit, arpltn.o3Grade, ts);
+    }
+    if (arpltn.hasOwnProperty('no2Grade')) {
+        arpltn.no2Str = UnitConverter.airGrade2Str(airUnit, arpltn.no2Grade, ts);
+    }
+    if (arpltn.hasOwnProperty('coGrade')) {
+        arpltn.coStr = UnitConverter.airGrade2Str(airUnit, arpltn.coGrade, ts);
+    }
+    if (arpltn.hasOwnProperty('so2Grade')) {
+        arpltn.so2Str = UnitConverter.airGrade2Str(airUnit, arpltn.so2Grade, ts);
+    }
+    if (arpltn.hasOwnProperty('khaiGrade')) {
+        arpltn.khaiStr = UnitConverter.airGrade2Str(airUnit, arpltn.khaiGrade, ts);
+    }
+    if (arpltn.hasOwnProperty('aqiGrade')) {
+        arpltn.aqiStr = UnitConverter.airGrade2Str(airUnit, arpltn.aqiGrade, ts);
     }
 
     return this;

--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -1469,6 +1469,17 @@ function ControllerTown24h() {
             if (req.current.hasOwnProperty('arpltn')) {
                 KecoController.recalculateValue(req.current.arpltn, req.query.airUnit);
             }
+            if (req.hasOwnProperty('airInfo') && req.airInfo.hasOwnProperty('pollutants')) {
+                var pollutants = req.airInfo.pollutants;
+                for (var pollutantName in pollutants) {
+                    if (pollutants[pollutantName].hasOwnProperty('daily')) {
+                        pollutants[pollutantName].daily.forEach(function (value) {
+                            value.fromToday = kmaTimeLib.getDiffDays(value.date, currentDate);
+                            value.dayOfWeek = (new Date(value.date)).getDay();
+                        });
+                    }
+                }
+            }
         }
         catch (err) {
             log.error(err);

--- a/server/controllers/worldWeather/controllerWorldWeather.js
+++ b/server/controllers/worldWeather/controllerWorldWeather.js
@@ -1571,24 +1571,14 @@ function controllerWorldWeather() {
                         thisTime.h = aqiItem.h;
                         thisTime.p = aqiItem.p;
 
-                        // string
-                        if(req.query.aqi != undefined && (req.query.aqi == 'airkorea' || req.query.aqi == 'airkorea_who')) {
-                            thisTime.aqiStr = UnitConverter.airkoreaGrade2str(thisTime.aqiGrade, 'aqi', res);
-                            thisTime.coStr = UnitConverter.airkoreaGrade2str(thisTime.coGrade, 'co2', res);
-                            thisTime.no2Str = UnitConverter.airkoreaGrade2str(thisTime.no2Grade, 'no2', res);
-                            thisTime.o3Str = UnitConverter.airkoreaGrade2str(thisTime.o3Grade, 'o3', res);
-                            thisTime.pm10Str = UnitConverter.airkoreaGrade2str(thisTime.pm10Grade, 'pm10', res);
-                            thisTime.pm25Str = UnitConverter.airkoreaGrade2str(thisTime.pm25Grade, 'pm25', res);
-                            thisTime.so2Str = UnitConverter.airkoreaGrade2str(thisTime.so2Grade, 'so2', res);
-                        }else{
-                            thisTime.aqiStr = UnitConverter.airGrade2str(thisTime.aqiGrade, 'aqi', res);
-                            thisTime.coStr = UnitConverter.airGrade2str(thisTime.coGrade, 'co', res);
-                            thisTime.no2Str = UnitConverter.airGrade2str(thisTime.no2Grade, 'no2', res);
-                            thisTime.o3Str = UnitConverter.airGrade2str(thisTime.o3Grade, 'o3', res);
-                            thisTime.pm10Str = UnitConverter.airGrade2str(thisTime.pm10Grade, 'pm10', res);
-                            thisTime.pm25Str = UnitConverter.airGrade2str(thisTime.pm25Grade, 'pm25', res);
-                            thisTime.so2Str = UnitConverter.airGrade2str(thisTime.so2Grade, 'so2', res);
-                        }
+                        var airUnit = req.query.aqi;
+                        thisTime.aqiStr = UnitConverter.airGrade2Str(airUnit, thisTime.aqiGrade, res);
+                        thisTime.coStr = UnitConverter.airGrade2Str(airUnit, thisTime.coGrade, res);
+                        thisTime.no2Str = UnitConverter.airGrade2Str(airUnit, thisTime.no2Grade, res);
+                        thisTime.o3Str = UnitConverter.airGrade2Str(airUnit, thisTime.o3Grade, res);
+                        thisTime.pm10Str = UnitConverter.airGrade2Str(airUnit, thisTime.pm10Grade, res);
+                        thisTime.pm25Str = UnitConverter.airGrade2Str(airUnit, thisTime.pm25Grade, res);
+                        thisTime.so2Str = UnitConverter.airGrade2Str(airUnit, thisTime.so2Grade, res);
 
                         // unit conversion
                         thisTime.coValue = self._convertUmtoPpm('co', thisTime.coValue);

--- a/server/lib/aqi.converter.js
+++ b/server/lib/aqi.converter.js
@@ -56,7 +56,36 @@ class AqiConverter {
      */
     static grade2minMaxValue(airUnit, code, grade) {
         let pollutants = air_pollutants_breakpoints[airUnit];
-        return {min: pollutants[code][grade-1], max: pollutants[code][grade]};
+        var min = pollutants[code][grade-1];
+        if (code === 'aqi') {
+            min += 1;
+        }
+        else if (airUnit === 'aqicn') {
+            min += 0.1;
+        }
+        else if (airUnit === 'airkorea' || airUnit === 'airkorea_who') {
+            if (code === 'pm10' || code === 'pm25' || code === 'co') {
+                min += 0.1;
+            }
+            else if (code === 'o3' || code === 'no2' || code === 'so2') {
+                min += 0.001;
+            }
+            else {
+                log.error('Unknown code:'+code, ' unit:'+airUnit);
+            }
+        }
+        else if (airUnit === 'airnow') {
+            if (code === 'co' || code === 'pm25')  {
+                min += 0.01;
+            }
+            else {
+                min += 0.1;
+            }
+        }
+        else {
+            log.error('Unknown code:'+code, ' unit:'+airUnit);
+        }
+        return {min: min, max: pollutants[code][grade]};
     }
 
     static ppm2ppb(value) {

--- a/server/lib/unitConverter.js
+++ b/server/lib/unitConverter.js
@@ -322,7 +322,7 @@ UnitConverter.airkoreaGrade2str = function (grade, type, translate) {
  * @param translate
  * @returns {*}
  */
-UnitConverter.airGrade2str = function (grade, type, translate) {
+UnitConverter.airnowGrade2str = function (grade, type, translate) {
     var ts = translate == undefined?global:translate;
 
     switch (grade) {
@@ -342,6 +342,15 @@ UnitConverter.airGrade2str = function (grade, type, translate) {
             log.warn("Unknown airnow grade="+grade+" type="+type);
     }
     return "";
+};
+
+UnitConverter.airGrade2Str = function (airUnit, grade, translate) {
+    if (airUnit === 'airnow' || airUnit === 'aqicn') {
+        return this.airnowGrade2str(grade, undefined, translate);
+    }
+    else {
+        return this.airkoreaGrade2str(grade, undefined, translate);
+    }
 };
 
 module.exports = UnitConverter;


### PR DESCRIPTION
#2082 #2092
- airGrade2Str에 airUnit받아서 분리하게 수정
- add fromToday, dayOfWeek to airInfo.pollutants[pm25|pm10|o3|aqi].daily
- min값은 이전 breakpoint + 1point(0.1 or 0.01 or 0.001)하여 이전 grade에 포함되지 않게 수정
- server/.jshintrc
  - es6지원으로 변경