### PR TITLE
#1846

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -468,6 +468,15 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   background: transparent;
 }
 
+.short-forecast .air-info-box {
+  margin: 0;
+  padding: 0;
+}
+
+.short-forecast .air-info-box hr {
+  margin: 0; border: 0; border-top:1px solid rgba(255,255,255,0.6);
+}
+
 .start-content .item-input {
   padding-right: 16px;
   display: flex !important;
@@ -597,6 +606,10 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   font-size: 17px;
 }
 
+.air-content .card {
+  margin: 0 0 9px 0;
+}
+
 .air-content [md-page-header] {
   color: #444;
 }
@@ -606,26 +619,35 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   margin: auto;
 }
 
-.air-content .main-icon i {
+.air-content .main-text {
+  margin: -2px 0;
   font-size: 64px;
 }
 
-.air-content .main-text {
-  margin: -2px 0;
-  font-weight:300;
-  font-size: 64px;
-  line-height: 64px;
+.air-content .main-text span {
+  font-size: 32px;
+}
+
+.air-content [md-page-header] i {
+  font-size: 24px;
+  vertical-align: bottom;
 }
 
 .air-content [md-page-header] .textFont {
   margin: 0;
-  font-size: 20px;
+  font-size: 24px;
+  line-height: 24px;
 }
 
 .air-content .button {
   color: #444;
   font-size: 17px;
   line-height: initial;
+}
+
+.air-std-table {
+  position: relative;
+  margin: 0 4px;
 }
 
 .air-label {
@@ -696,7 +718,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   margin: auto;
 }
 
-.air-hourly .body1 {
+.air-hourly .hourly-box .body1 {
   margin: 0;
 }
 
@@ -728,6 +750,10 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 .air-daily .daily-box {
   text-align: center;
   margin: auto;
+}
+
+.air-daily .daily-box a {
+  color: inherit;
 }
 
 .air-daily .daily-border {
@@ -783,7 +809,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 }
 
 .card {
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
   margin: 5px 10px;
 }
 

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -1505,7 +1505,7 @@ angular.module('starter', [
                 }
             })
             .state('tab.air', {
-                url: '/air?fav',
+                url: '/air?fav&code',
                 cache: false,
                 views: {
                     'tab-air': {

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -466,6 +466,20 @@ angular.module('controller.forecastctrl', [])
                 $scope.dayWidth = colWidth * dayTable.length;
 
                 $scope.currentWeather = cityData.currentWeather;
+                if (cityData.airInfo
+                    && cityData.airInfo.pollutants
+                    && cityData.airInfo.pollutants.aqi) {
+
+                    var latestAirInfo =  cityData.airInfo.last || cityData.currentWeather.arpltn;
+                    if (cityData.airInfo.pollutants.aqi.hourly) {
+                        $scope.hourlyAqiForecast = cityData.airInfo.pollutants.aqi.hourly.filter(function (obj) {
+                            return obj.date >= latestAirInfo.dataTime;
+                        }).slice(0, 4);
+                    }
+                    if (cityData.airInfo.pollutants.aqi.daily) {
+                        $scope.dailyAqiForecast = cityData.airInfo.pollutants.aqi.daily;
+                    }
+                }
 
                 $scope.currentPosition = cityData.currentPosition;
 

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -618,7 +618,7 @@ angular.module('controller.tabctrl', [])
 
         $scope.convertMMDD = function (value) {
             if (typeof value == 'string') {
-                return value.substr(4,2)+'/'+value.substr(6,2);
+                return value.substr(5,2)+'/'+value.substr(8,2);
             }
             return value;
         };
@@ -994,6 +994,15 @@ angular.module('controller.tabctrl', [])
         $scope.$on('$destroy',function(){
             clearTimeout(refreshTimer);
         });
+
+        $scope.goAirInfoPage = function(code) {
+            console.log('go air info page code='+code);
+            var path = '/tab/air';
+            if (code) {
+               path += '?code='+code;
+            }
+            $location.url(path);
+        };
 
         var strOkay = "OK";
         var strCancel = "Cancel";

--- a/client/www/js/service.weatherinfo.js
+++ b/client/www/js/service.weatherinfo.js
@@ -218,8 +218,8 @@ angular.module('service.weatherinfo', [])
             if (newCityInfo.source) {
                 city.source = newCityInfo.source;
             }
-            if (newCityInfo.air_forecast) {
-                city.air_forecast = newCityInfo.air_forecast;
+            if (newCityInfo.airInfo) {
+                city.airInfo = newCityInfo.airInfo;
             }
 
             if (city.currentPosition == true) {

--- a/client/www/js/service.weatherutil.js
+++ b/client/www/js/service.weatherutil.js
@@ -96,7 +96,7 @@ angular.module('service.weatherutil', [])
          */
         function _makeQueryUrlWithLocation (location, funcName) {
             var url = twClientConfig.serverUrl;
-            url += '/'+funcName+'/coord/'+ location.lat + ','+location.long;
+            url += '/'+funcName+'/v000901'+'/coord/'+ location.lat + ','+location.long;
             if (funcName === 'weather') {
                 url += _getUnitsParams();
             }
@@ -112,7 +112,7 @@ angular.module('service.weatherutil', [])
          */
         function _makeQueryUrlWithAddr (addr, funcName) {
             var url = twClientConfig.serverUrl;
-            url += '/'+funcName+'/addr/'+ addr;
+            url += '/'+funcName+'/v000901'+'/addr/'+ addr;
             if (funcName === 'weather') {
                 url += _getUnitsParams();
             }
@@ -455,8 +455,8 @@ angular.module('service.weatherutil', [])
                     temp: currentForecast.t1h,
                     displayItemCount: midTownWeather.displayItemCount
                 }];
-                if (weatherData.air_forecast) {
-                    data.air_forecast = weatherData.air_forecast;
+                if (weatherData.airInfo) {
+                    data.airInfo = weatherData.airInfo;
                 }
                 data.source = "KMA";
             }
@@ -614,6 +614,10 @@ angular.module('service.weatherutil', [])
                     if (weatherData.pubDate.hasOwnProperty('DSF')) {
                        data.source = "DSF";
                     }
+                }
+
+                if (weatherData.airInfo) {
+                    data.airInfo = weatherData.airInfo;
                 }
             }
             catch (err) {

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -25,26 +25,28 @@
                     <div class="air-outline" ng-style="{'border-color': grade2Color(airCodeGrade)}">
                         {{airCodeName|translate}}
                     </div>
-                    <div class="row row-no-padding" style="margin-top: 8px">
+                    <div class="row row-no-padding">
+                        <div style="margin: auto">
+                            <p class="main-text">{{airCodeValue}}<span>{{getAirCodeUnit(aqiCode)}}</span></p>
+                        </div>
+                    </div>
+                    <div class="row row-no-padding">
                         <div style="margin: auto">
                             <div class="row row-no-padding">
-                                <div class="main-icon">
-                                    <i class="material-icons" ng-bind-html="getSentimentIcon(airCodeGrade)">
-                                    </i>
-                                </div>
-                                <p class="main-text">{{airCodeValue}}
+                                <p class="textFont">
+                                    {{airCodeStr}}
+                                    <i class="material-icons" ng-bind-html="getSentimentIcon(airCodeGrade)"></i>
+                                    <span ng-if="airCodeActionGuide">{{airCodeActionGuide}}</span>
                                 </p>
                             </div>
                         </div>
                     </div>
-                    <p class="textFont">
-                        {{airCodeStr}}<span ng-if="airCodeActionGuide">:{{airCodeActionGuide}}</span></p>
                 </div>
                 <div class="cityArrow" ng-click="onSwipeLeft()" ng-if="cityCount > 1">
                     <span class="icon-right ion-chevron-right"></span>
                 </div>
             </div>
-            <div style="position: relative">
+            <div class="air-std-table">
                 <div class="air-label"
                      ng-style="{'left':getLabelPosition(airCodeGrade, airCodeValue)+'px'}">
                     <div class="outline"
@@ -66,38 +68,33 @@
                 </div>
             </div>
         </div>
-        <div class="list card air-hourly" ng-if="hourlyForecast && hourlyForecast.length">
-            <p class="body1">{{'LOC_HOURLY_AQI_FORECAST'|translate}}</p>
+        <div class="list card air-hourly" ng-if="hourlyForecast && hourlyForecast.length > 1">
+            <p class="body1">{{'LOC_HOURLY_AQI_FORECAST'|translate}} (beta)</p>
             <div>
                 <table ng-style="{'width':hourlyForecast.length*48+'px'}">
                     <tr>
-                        <td class="hourly-box" ng-repeat="obj in hourlyForecast" ng-style="{'color': grade2Color(obj.grade)}">
-                            <p class="body1">{{obj.time}}{{'LOC_HOUR'|translate}}</p>
-                            <p class="display1">
+                        <td class="hourly-box" ng-repeat="obj in hourlyForecast">
+                            <p class="body1">{{obj.date.substr(11,2)}}{{'LOC_HOUR'|translate}}</p>
+                            <p class="display1" ng-style="{'color': mainGrade2Color(obj.grade)}">
                                 <i class="material-icons" ng-bind-html="getSentimentIcon(obj.grade)"></i>
                             </p>
-                            <span class="body2">{{obj.value}}</span>
+                            <span class="body2" ng-style="{'color': mainGrade2Color(obj.grade)}">{{obj.val == undefined?"-":obj.val}}</span>
                         </td>
                     </tr>
                 </table>
             </div>
         </div>
         <div class="list card air-daily" ng-if="dayForecast && dayForecast.length">
-            <p class="body1">{{"LOC_DAILY_AQI_FORECAST"|translate}} ({{getForecastAirUnitStr()|translate}})</p>
+            <p class="body1">{{"LOC_DAILY_AQI_FORECAST"|translate}}</p>
             <table>
                 <tr>
                     <td class="daily-box" ng-repeat="day in dayForecast">
-                        <div class="air-outline"
-                             ng-style="{'border-color': airkoreaGrade2Color(day.grade), 'color': airkoreaGrade2Color(day.grade)}">
-                            <a class="icon ion-calendar"
-                               ng-style="{'color': airkoreaGrade2Color(day.grade)}"
-                            >{{convertMMDD(day.date)}} {{day.fromToday==0?getDayString(day.fromToday):dayToString(day.dayOfWeek)|translate}}</a>
-                            <div class="daily-border">
-                                <p class="display1">
-                                    <i class="material-icons" ng-bind-html="getSentimentIcon(day.grade)"></i>
-                                </p>
-                                <p class="body2">{{day.str}}</p>
-                            </div>
+                        <p class="body1">{{convertMMDD(day.date)}} {{day.fromToday==0?getDayString(day.fromToday):dayToString(day.dayOfWeek)|translate}}</p>
+                        <div class="daily-border" ng-style="{'color': grade2Color(day.maxGrade)}">
+                            <p class="display1">
+                                <i class="material-icons" ng-bind-html="getSentimentIcon(day.maxGrade)"></i>
+                            </p>
+                            <p class="body2">{{day.maxStr}}</p>
                         </div>
                     </td>
                 </tr>
@@ -107,13 +104,14 @@
             <p class="body1">{{"LOC_DETAIL_AQI"|translate}}</p>
             <div ng-if="aqiList.length > 1">
                 <div class="row" ng-style="{'width':aqiList.length*110+'px'}">
-                    <button class="button button-outline button-dark item-center"
-                            ng-style="{'border-color': grade2Color(obj.grade), 'color': grade2Color(obj.grade)}"
+                    <button class="button button-stable item-center"
                             ng-click="setMainAqiCode(obj.code)"
-                            ng-repeat="obj in aqiList">
-                        <span>{{obj.name|translate}}</span><br>
-                        <i class="material-icons" ng-bind-html="getSentimentIcon(obj.grade)"></i><br>
-                        {{obj.value}}
+                            ng-repeat="obj in aqiList" style="background-color: #f4f4f4">
+                        <span style="font-weight: normal">{{obj.name|translate}}</span><br>
+                        <div ng-style="{'color': mainGrade2Color(obj.grade)}">
+                            <i class="material-icons" ng-bind-html="getSentimentIcon(obj.grade)"></i><br>
+                            {{obj.value}}
+                        </div>
                     </button>
                 </div>
             </div>

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -58,8 +58,22 @@
                 </div>
                 <div class="col" style="margin: 0; padding: 0">
                    <hr ng-if="hasDustForecast()" style="margin: 5px; border: 0; border-top:1px solid rgba(254,254,254,0.6);">
-                   <p ng-if="hasDustForecast()" class="caption" style="margin: 5px;">{{"LOC_DAILY_AQI_FORECAST"|translate}} ({{getForecastAirUnitStr()|translate}})</p>
-                   <table style="width: 100%">
+                   <p ng-if="hasDustForecast()" class="caption" style="margin: 5px;">{{"LOC_DAILY_AQI_FORECAST"|translate}}</p>
+
+                    <table style="width: 100%" ng-if="dailyAqiForecast && dailyAqiForecast.length" ng-click="goAirInfoPage('aqi')">
+                        <tr>
+                            <td style="text-align: center; margin: auto" ng-repeat="day in dailyAqiForecast">
+                                <p class="body1" style="margin: 0;">{{convertMMDD(day.date)}} {{day.fromToday==0?getDayString(day.fromToday):dayToString(day.dayOfWeek)|translate}}</p>
+                                <p class="display1" style="margin: 0; opacity: 1">
+                                    <i class="material-icons" style="font-size: 32px;"
+                                       ng-bind-html="getSentimentIcon(day.maxGrade)">
+                                    </i>
+                                </p>
+                                <p class="body2" style="margin: 0;">{{day.maxStr}}</p>
+                            </td>
+                        </tr>
+                    </table>
+                    <table style="width: 100%" ng-if="dailyAqiForecast == undefined && dayChart[0].values">
                        <tr ng-if="($index == 7 || $index == 8) && day.dustForecast"
                            ng-repeat="day in dayChart[0].values">
                            <td style="text-align: center; margin: auto">
@@ -69,7 +83,7 @@
                                    <p class="body2" style="margin: 0 0 5px;">{{getDayString(day.fromToday)|translate}}</p>
                                </div>
                            </td>
-                           <td style="text-align: center; margin: auto">
+                           <td style="text-align: center; margin: auto" ng-click="goAirInfoPage('pm25')">
                                <p class="body1" style="margin: 0;">{{"LOC_PM25"|translate}}</p>
                                <p class="display1" style="margin: 0; opacity: 1">
                                    <i class="material-icons" style="font-size: 32px"
@@ -79,7 +93,7 @@
                                <p class="body2"
                                   style="margin: 0 0 5px;">{{day.dustForecast.pm25Str}}</p>
                            </td>
-                           <td style="text-align: center; margin: auto">
+                           <td style="text-align: center; margin: auto" ng-click="goAirInfoPage('pm10')">
                                <p class="body1" style="margin: 0;">{{"LOC_PM10"|translate}}</p>
                                <p class="display1" style="margin: 0; opacity: 1">
                                    <i class="material-icons" style="font-size: 32px;"
@@ -88,7 +102,7 @@
                                <p class="body2"
                                   style="margin: 0 0 5px;">{{day.dustForecast.pm10Str}}</p>
                            </td>
-                           <td style="text-align: center; margin: auto" ng-if="day.dustForecast.o3Grade != undefined">
+                           <td style="text-align: center; margin: auto" ng-if="day.dustForecast.o3Grade != undefined" ng-click="goAirInfoPage('o3')">
                                <p class="body1" style="margin: 0;">{{"LOC_O3"|translate}}</p>
                                <p class="display1" style="margin: 0; opacity: 1">
                                    <i class="material-icons" style="font-size: 32px"
@@ -107,7 +121,7 @@
                        <div class="row" style="margin: auto;">
                            <div style="margin: 0 auto; min-width: 132px" ng-if="checkDailyDetailWeather(day)" ng-repeat="day in dayChart[0].values">
                                <div class="row" style="margin: 0">
-                                   <a class="icon ion-calendar" style="color: white; margin: 0 12px; min-width: 90px"> {{convertMMDD(day.date)}} {{day.fromToday==0?getDayString(day.fromToday):dayToString(day.dayOfWeek)|translate}}</a>
+                                   <a class="icon ion-calendar" style="color: white; margin: 0 12px; min-width: 90px"> {{convertMMDD(day.dateObj)}} {{day.fromToday==0?getDayString(day.fromToday):dayToString(day.dayOfWeek)|translate}}</a>
                                </div>
                                <div class="row" style="margin: 0" ng-if="day.reh">
                                    <img ng-src="img/Humidity-{{day.reh?day.reh - day.reh%10:'00'}}.png" style="height: 24px; margin: auto 0;">

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -68,10 +68,20 @@
                         <div class="label-today"></div> <span>{{"LOC_THIS_DAY_TEMP"|translate}}</span>
                     </div>
                 </div>
-                <div class="col" style="margin: 0;padding: 0" ng-if="showDetailWeather">
-                    <hr ng-if="currentWeather.arpltn" style="margin: 0; border: 0; border-top:1px solid rgba(255,255,255,0.6);">
-                    <div ng-if="currentWeather.arpltn" class="row row-no-padding" style="margin-top: 16px">
-                        <div class="col" style="text-align: center" ng-if="currentWeather.arpltn.pm25Value">
+                <div class="col air-info-box" ng-if="showDetailWeather">
+                    <hr ng-if="currentWeather.arpltn">
+                    <p ng-if="hourlyAqiForecast && hourlyAqiForecast.length" class="caption">{{'LOC_HOURLY_AQI_FORECAST'|translate}} (beta)</p>
+                    <div ng-if="hourlyAqiForecast && hourlyAqiForecast.length" class="row row-no-padding" ng-click="goAirInfoPage('aqi')">
+                        <div class="col" style="text-align: center" ng-repeat="obj in hourlyAqiForecast">
+                            <p class="body1" style="margin: 0 0 5px;">{{obj.date.substr(11,2)}}{{'LOC_HOUR'|translate}}</p>
+                            <i class="material-icons" style="font-size: 32px"
+                               ng-bind-html="getSentimentIcon(obj.grade)">
+                            </i>
+                            <p class="body2" style="margin: 0 0 2px;">{{obj.str == undefined?"-":obj.str}}</p>
+                        </div>
+                    </div>
+                    <div ng-if="hourlyAqiForecast == undefined && currentWeather.arpltn" class="row row-no-padding" style="margin-top: 8px">
+                        <div class="col" style="text-align: center" ng-if="currentWeather.arpltn.pm25Value" ng-click="goAirInfoPage('pm25')">
                             <p class="body1" style="margin: 0 0 5px;">{{"LOC_PM25"|translate}}</p>
                             <i class="material-icons" style="font-size: 32px"
                                ng-bind-html="getSentimentIcon(currentWeather.arpltn.pm25Grade)">
@@ -79,7 +89,7 @@
                             <p class="body2" style="margin: 0 0 2px;">{{currentWeather.arpltn.pm25Str}}</p>
                             <p class="caption" style="margin: 0 0 5px;">{{currentWeather.arpltn.pm25Value.toFixed(0)}}<small>㎍/㎥</small></p>
                         </div>
-                        <div class="col" style="text-align: center" ng-if="currentWeather.arpltn.pm10Value">
+                        <div class="col" style="text-align: center" ng-if="currentWeather.arpltn.pm10Value" ng-click="goAirInfoPage('pm10')">
                             <p class="body1" style="margin: 0 0 5px;">{{"LOC_PM10"|translate}}</p>
                             <i class="material-icons" style="font-size: 32px"
                                ng-bind-html="getSentimentIcon(currentWeather.arpltn.pm10Grade)">
@@ -87,7 +97,7 @@
                             <p class="body2" style="margin: 0 0 2px;">{{currentWeather.arpltn.pm10Str}}</p>
                             <p class="caption" style="margin: 0 0 5px;">{{currentWeather.arpltn.pm10Value.toFixed(0)}}<small>㎍/㎥</small></p>
                         </div>
-                        <div class="col" style="text-align: center" ng-if="currentWeather.arpltn.aqiValue">
+                        <div class="col" style="text-align: center" ng-if="currentWeather.arpltn.aqiValue" ng-click="goAirInfoPage('aqi')">
                             <p class="body1" style="margin: 0 0 5px;">{{"LOC_AQI"|translate}}</p>
                             <i class="material-icons" style="font-size: 32px"
                                ng-bind-html="getSentimentIcon(currentWeather.arpltn.aqiGrade)">
@@ -157,7 +167,7 @@
                     <hr ng-if="currentWeather.arpltn" style="margin: 0; border: 0; border-top:1px solid rgba(254,254,254,0.6);">
                     <div ng-if="currentWeather.arpltn" class="row caption" style="padding: 3px">{{"LOC_DETAIL_AQI"|translate}}</div>
                     <table ng-if="currentWeather.arpltn" border="0" class="subheading" style="margin: 0 auto;">
-                        <tr ng-if="currentWeather.arpltn.pm25Value">
+                        <tr ng-if="currentWeather.arpltn.pm25Value" ng-click="goAirInfoPage('pm25')">
                             <td>{{"LOC_PM25"|translate}}</td>
                             <td>
                                 <i class="material-icons img-detail-aqi" ng-bind-html="getSentimentIcon(currentWeather.arpltn.pm25Grade)">
@@ -165,7 +175,7 @@
                                 {{currentWeather.arpltn.pm25Str}}<span class="caption">({{currentWeather.arpltn.pm25Value.toFixed(0)}}㎍/㎥{{currentWeather.arpltn.pm25StationName?" "+currentWeather.arpltn.pm25StationName:""}})</span>
                             </td>
                         </tr>
-                        <tr ng-if="currentWeather.arpltn.pm10Value">
+                        <tr ng-if="currentWeather.arpltn.pm10Value" ng-click="goAirInfoPage('pm10')">
                             <td>{{"LOC_PM10"|translate}}</td>
                             <td>
                                 <i class="material-icons img-detail-aqi" ng-bind-html="getSentimentIcon(currentWeather.arpltn.pm10Grade)">
@@ -173,7 +183,7 @@
                                 {{currentWeather.arpltn.pm10Str}}<span class="caption">({{currentWeather.arpltn.pm10Value.toFixed(0)}}㎍/㎥{{currentWeather.arpltn.pm10StationName?" "+currentWeather.arpltn.pm10StationName:""}})</span>
                             </td>
                         </tr>
-                        <tr ng-if="currentWeather.arpltn.o3Value">
+                        <tr ng-if="currentWeather.arpltn.o3Value" ng-click="goAirInfoPage('o3')">
                             <td>{{"LOC_O3"|translate}}</td>
                             <td>
                                 <i class="material-icons img-detail-aqi" ng-bind-html="getSentimentIcon(currentWeather.arpltn.o3Grade)">
@@ -181,7 +191,7 @@
                                 {{currentWeather.arpltn.o3Str}}<span class="caption">({{currentWeather.arpltn.o3Value.toFixed(3)}}ppm{{currentWeather.arpltn.o3StationName?" "+currentWeather.arpltn.o3StationName:""}})</span>
                             </td>
                         </tr>
-                        <tr ng-if="currentWeather.arpltn.no2Value">
+                        <tr ng-if="currentWeather.arpltn.no2Value" ng-click="goAirInfoPage('no2')">
                             <td>{{"LOC_NO2"|translate}}</td>
                             <td>
                                 <i class="material-icons img-detail-aqi" ng-bind-html="getSentimentIcon(currentWeather.arpltn.no2Grade)">
@@ -189,7 +199,7 @@
                                 {{currentWeather.arpltn.no2Str}}<span class="caption">({{currentWeather.arpltn.no2Value.toFixed(3)}}ppm{{currentWeather.arpltn.no2StationName?" "+currentWeather.arpltn.no2StationName:""}})</span>
                             </td>
                         </tr>
-                        <tr ng-if="currentWeather.arpltn.coValue">
+                        <tr ng-if="currentWeather.arpltn.coValue" ng-click="goAirInfoPage('co')">
                             <td>{{"LOC_CO"|translate}}</td>
                             <td>
                                 <i class="material-icons img-detail-aqi" ng-bind-html="getSentimentIcon(currentWeather.arpltn.coGrade)">
@@ -197,7 +207,7 @@
                                 {{currentWeather.arpltn.coStr}}<span class="caption">({{currentWeather.arpltn.coValue.toFixed(3)}}ppm{{currentWeather.arpltn.coStationName?" "+currentWeather.arpltn.coStationName:""}})</span>
                             </td>
                         </tr>
-                        <tr ng-if="currentWeather.arpltn.so2Value">
+                        <tr ng-if="currentWeather.arpltn.so2Value" ng-click="goAirInfoPage('so2')">
                             <td>{{"LOC_SO2"|translate}}</td>
                             <td>
                                 <i class="material-icons img-detail-aqi" ng-bind-html="getSentimentIcon(currentWeather.arpltn.so2Grade)">
@@ -205,7 +215,7 @@
                                 {{currentWeather.arpltn.so2Str}}<span class="caption">({{currentWeather.arpltn.so2Value.toFixed(3)}}ppm{{currentWeather.arpltn.so2StationName?" "+currentWeather.arpltn.so2StationName:""}})</span>
                             </td>
                         </tr>
-                        <tr ng-if="currentWeather.arpltn.aqiValue">
+                        <tr ng-if="currentWeather.arpltn.aqiValue" ng-click="goAirInfoPage('aqi')">
                             <td>{{"LOC_AQI"|translate}}</td>
                             <td>
                                 <i class="material-icons img-detail-aqi" ng-bind-html="getSentimentIcon(currentWeather.arpltn.aqiGrade)">


### PR DESCRIPTION
- css 조정
  - box-show alpha 0.3 -> 0.1
- data
  - air_forecast -> airInfo 변경됨
  - {weather|geocode}/{version}/{coord|addr} rest api path 변경됨
- air info page
  - css 조정
  - code query 지원
  - aqi grade color n사에 맞춤
  - 마지막 측정 정보가 없더라도, 과거와 예보데이터가 있으면 오염물질 선택 버튼 표시
  - 기본 code를 aqi로 변경
  - code(오염물질 항목) 변경시에 스크롤 상단으로 이동
- 시간별날씨
  - 시간별 대기예보가 있으면, 실시간 통합대기, 미세, 초미세먼지 대신 표시
  - 미세먼지 정보 클릭시에 미세먼지 페이지로 이동
- 일별날씨
  - 대기 예보 클릭시 대기정보 페이지로 이동