### PR TITLE
kma life index 개선

### DIFF
--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -2349,21 +2349,6 @@ Manager.prototype.startManager = function(){
                 }
                 callback();
             });
-        },
-        function (callback) {
-            taskKmaIndexService.loadAreaList(function () {
-                log.info('KmaIndex> complete loadAreaList for KMA Index.');
-                callback();
-            });
-        },
-        function (callback) {
-            taskKmaIndexService.updateLifeIndexDbFromTowns(function (err) {
-                if (err) {
-                    log.error(err);
-                }
-                log.info('Finish updating life index db from towns');
-                callback();
-            });
         }
     ], function () {
 

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -2079,6 +2079,7 @@ function ControllerTown() {
                     current.fsnGrade = dailyData[i].fsnGrade;
                     current.fsnStr = dailyData[i].fsnStr;
                 }
+                break;
             }
         }
     };

--- a/server/models/kma/kma.lifeindex.model.js
+++ b/server/models/kma/kma.lifeindex.model.js
@@ -1,0 +1,19 @@
+/**
+ * Created by aleckim on 2018. 2. 1..
+ */
+
+var mongoose = require('mongoose');
+
+var lifeIndexSchema = new mongoose.Schema({
+    areaNo: Number,             ///< 지역 코드
+    date: Date,               ///< 날짜
+    indexType: String,          ///< 지수 종류 "fsn, ultrv"
+    index: Number,               ///< 지수
+    lastUpdateDate: String
+});
+
+lifeIndexSchema.index({areaNo: 1});
+lifeIndexSchema.index({date: 1});
+lifeIndexSchema.index({indexType: 'text'});
+
+module.exports = mongoose.model('lifeIndexKma2', lifeIndexSchema);

--- a/server/test/e2e_local/test.e2e.lifeindex.kma.requester.js
+++ b/server/test/e2e_local/test.e2e.lifeindex.kma.requester.js
@@ -1,0 +1,62 @@
+/**
+ * Created by aleckim on 2018. 2. 1..
+ */
+
+"use strict";
+
+var Logger = require('../../lib/log');
+global.log  = new Logger(__dirname + "/debug.log");
+
+var controllerManager = require('../../controllers/controllerManager');
+global.manager = new controllerManager();
+
+var assert  = require('assert');
+var config = require('../../config/config');
+var LifeIndexKmaRequester  = require('../../lib/lifeIndexKmaRequester');
+
+describe('unit test - requester of kma index service class', function() {
+    var reqLifeIndex = new LifeIndexKmaRequester();
+
+    reqLifeIndex.setServiceKey(config.keyString.cert_key, config.keyString);
+
+    it ('get fsn life index', function (done) {
+        reqLifeIndex.getLifeIndex2('fsn', function (err, body) {
+            assert.equal(body.Response.header.successYN, 'Y', '');
+            done();
+        });
+    });
+
+    // it ('get ultrv life index', function (done) {
+    //     co.getLifeIndex('ultrv', '1100000000', function (err, body) {
+    //         assert.equal(body.Response.header.successYN, 'Y', '');
+    //         done();
+    //     });
+    // });
+
+    it('update Life Index Db From Towns', function (done) {
+        this.timeout(30*1000);
+        var mongoose = require('mongoose');
+        mongoose.connect('localhost/todayweather', function(err) {
+            if (err) {
+                console.error('Could not connect to MongoDB!');
+                console.log(err);
+                done();
+            }
+        });
+        mongoose.connection.on('error', function(err) {
+            console.error('MongoDB connection error: ' + err);
+        });
+
+        reqLifeIndex.setNextGetTime('fsn', new Date());
+        reqLifeIndex.taskLifeIndex2('fsn', function (err, result) {
+            if (err) {
+                log.error(err.toString());
+                return done();
+            }
+            log.info(result);
+            done();
+        });
+    });
+});
+
+

--- a/server/test/testLifeIndexKmaRequester.js
+++ b/server/test/testLifeIndexKmaRequester.js
@@ -168,6 +168,23 @@ describe('unit test - requester of kma index service class', function() {
         assert.equal(result.data.ultrv.data[0].date, '20151029', '');
     });
 
+    it ('parse daily life index 2', function () {
+        var data = {"Response": {
+            "header": {"successYN":"Y","returnCode":"00","errMsg":""},
+            "body":{
+                "indexModels":[
+                    {"code":"A01_2","areaNo":"1100000000","date":"2018020106",
+                        "today":"56","tomorrow":"53","theDayAfterTomorrow":"55"},
+                    {"code":"A01_2","areaNo":"1111000000","date":"2018020106",
+                        "today":"56","tomorrow":"53","theDayAfterTomorrow":"55"},
+                    {"code":"A01_2","areaNo":"1111051500","date":"2018020106",
+                        "today":"56","tomorrow":"53","theDayAfterTomorrow":"55"},
+                    {"code":"A01_2","areaNo":"5019099000","date":"2018020106",
+                        "today":"58","tomorrow":"57","theDayAfterTomorrow":"55"}]}}};
+        var results = reqLifeIndex.parseLifeIndex2('fsn', data);
+        console.log(JSON.stringify(results));
+    });
+
     it ('update or add life index', function () {
         var ultraIndex = { lastUpdateDate: '2015102819', data: []};
         var data = { data: [{ date: '20151029', value: 2}, { date: '20151030', value: 3}],


### PR DESCRIPTION
#1511
- appendData2 추가
  - client에 데이터 전달할때, LifeIndexKma2에 데이터가 없으면 기존 collections에서 전달
- taskLifeIndex2 생성
  - kma.lifeindex.model 생성
  - area no 없이 쿼리
- _appendLifeIndexToCurrent
  - 데이터 찾으면 for문 정지