### PR TITLE
데이터나 현재위치 업데이트 중에는 도시명 옆에 spinner 표시

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -604,6 +604,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 .air-content {
   color: #444;
   font-size: 17px;
+  width: 100%;
 }
 
 .air-content .card {
@@ -704,11 +705,16 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   height: 2px;
 }
 
+.air-hourly {
+  width: 100%;
+}
+
 .air-hourly p {
   margin: 5px;
 }
 
-.air-hourly div {
+.air-hourly #hourlyBox {
+  width: 100%;
   overflow: auto;
   white-space: nowrap;
 }
@@ -777,7 +783,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   width: 100%;
 }
 
-.air-items div {
+.air-items #itemsBox {
   overflow: auto;
   white-space: nowrap;
 }
@@ -892,6 +898,22 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 .bar.bar-search .dailyforecast-header,
 .bar.bar-dailyforecast .search-header {
   display: none !important;
+}
+
+.dailyforecast-header span,
+.forecast-header span {
+  vertical-align: middle;
+}
+
+.dailyforecast-header i,
+.forecast-header i {
+  font-size: 100%;
+  vertical-align: middle;
+}
+
+.dailyforecast-header ion-spinner,
+.forecast-header ion-spinner {
+  vertical-align: middle;
 }
 
 .menu-content.overflow-scroll {
@@ -1146,6 +1168,13 @@ p small {
 
 .nation-label span {
   font-size:12px;
+}
+
+.spinner svg {
+  width: 14px;
+  height: 14px;
+  stroke: #fff;
+  fill: #fff;
 }
 
 //iphone 4

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -488,8 +488,6 @@ angular.module('controller.forecastctrl', [])
                     }
                 }
 
-                $scope.currentPosition = cityData.currentPosition;
-
                 $scope.updateTime = (function () {
                     try {
                         if (cityData.currentWeather) {
@@ -740,10 +738,6 @@ angular.module('controller.forecastctrl', [])
             else {
                 return temp;
             }
-        };
-
-        $scope.isLocationEnabled = function () {
-            return Util.isLocationEnabled();
         };
 
         $scope.switchToLocationSettings = function () {

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -1,7 +1,6 @@
 angular.module('controller.tabctrl', [])
     .controller('TabCtrl', function($scope, $ionicPopup, $interval, WeatherInfo, WeatherUtil,
-                                     $location, TwAds, $rootScope, Util, $translate, TwStorage, $sce, Units,
-                                    $ionicLoading, $q) {
+                                     $location, TwAds, $rootScope, Util, $translate, TwStorage, $sce, Units, $q) {
         var currentTime;
 
         $scope.data = { 'autoSearch': false };
@@ -27,6 +26,8 @@ angular.module('controller.tabctrl', [])
             //}, 1000);
 
             TwAds.init();
+
+            $scope.$broadcast('reloadEvent', 'init');
         }
 
         var lastClickTime = 0;
@@ -695,16 +696,19 @@ angular.module('controller.tabctrl', [])
                     return;
                 }
 
+                $scope.currentPosition = weatherInfo.currentPosition;
+
                 showLoadingIndicator();
                 updateWeatherData(weatherInfo).then(function () {
                     $scope.$broadcast('applyEvent', 'updateWeatherData');
                     //data cache된 경우에라도, Loading했다는 느낌을 주기 위해서 최소 지연 시간 설정
-                    setTimeout(function () {
-                        console.info('hide loading indicator after update wData');
+                    if (!weatherInfo.currentPosition) {
                         hideLoadingIndicator();
-                    }, 500);
+                    }
                 }, function (msg) {
-                    hideLoadingIndicator();
+                    if (!weatherInfo.currentPosition) {
+                        hideLoadingIndicator();
+                    }
                     $scope.showRetryConfirm(strError, msg, 'weather');
                 });
 
@@ -713,6 +717,7 @@ angular.module('controller.tabctrl', [])
                      * one more update when finished position is updated
                      */
                     updateCurrentPosition(weatherInfo).then(function(geoInfo) {
+                        hideLoadingIndicator();
                         if (geoInfo) {
                             console.log("current position is updated !!");
                             try {
@@ -756,6 +761,7 @@ angular.module('controller.tabctrl', [])
                             Util.ga.trackEvent('position', 'error', 'failToGetCurrentPosition');
                         }
                     }, function(msg) {
+                        hideLoadingIndicator();
                         if (msg) {
                             $scope.showRetryConfirm(strError, msg, 'forecast');
                         }
@@ -772,23 +778,12 @@ angular.module('controller.tabctrl', [])
             }
         }
 
-        // retry popup이 없는 경우 항상 undefined여야 함.
-        var isLoadingIndicator = false;
-
         function showLoadingIndicator() {
-            $ionicLoading.show().then(function() {
-                // retry 시에 show 후에 바로 hide를 할 때 hide의 resolve가 먼저 처리되어 LoadingIndicator가 보여지는 경우가 있음
-                // 실제로 show가 되면 상태를 체크하여 hide를 다시 요청함
-                if (isLoadingIndicator == false) {
-                    $ionicLoading.hide();
-                }
-            });
-            isLoadingIndicator = true;
+            $scope.showLoadingIndicator = true;
         }
 
         function hideLoadingIndicator() {
-            $ionicLoading.hide();
-            isLoadingIndicator = false;
+            $scope.showLoadingIndicator = false;
         }
 
         var refreshTimer = null;
@@ -1002,6 +997,10 @@ angular.module('controller.tabctrl', [])
                path += '?code='+code;
             }
             $location.url(path);
+        };
+
+        $scope.isLocationEnabled = function () {
+            return Util.isLocationEnabled();
         };
 
         var strOkay = "OK";

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -4,10 +4,10 @@
     </ion-nav-buttons>
     <ion-nav-title>
         <p class="title forecast-header">
-            <span style="vertical-align: middle">{{address}}</span>
-            <!--location_on, location_off-->
-            <i ng-if="currentPosition" class="material-icons" style="vertical-align: middle; font-size: 100%"
+            <span>{{address}}</span>
+            <i ng-if="currentPosition && showLoadingIndicator != true" class="material-icons"
                ng-click="switchToLocationSettings()">{{isLocationEnabled()?'&#xE0C8;':'&#xE0C7;'}}</i>
+            <ion-spinner ng-if="showLoadingIndicator" icon="bubbles"></ion-spinner>
         </p>
     </ion-nav-title>
     <ion-nav-buttons side="right">
@@ -70,7 +70,7 @@
         </div>
         <div class="list card air-hourly" ng-if="hourlyForecast && hourlyForecast.length > 1">
             <p class="body1">{{'LOC_HOURLY_AQI_FORECAST'|translate}} (beta)</p>
-            <div>
+            <div id="hourlyBox">
                 <table ng-style="{'width':hourlyForecast.length*48+'px'}">
                     <tr>
                         <td class="hourly-box" ng-repeat="obj in hourlyForecast">
@@ -102,7 +102,7 @@
         </div>
         <div class="list card air-items" ng-if="aqiList.length>1">
             <p class="body1">{{"LOC_DETAIL_AQI"|translate}}</p>
-            <div ng-if="aqiList.length > 1">
+            <div id="itemsBox" ng-if="aqiList.length > 1">
                 <div class="row" ng-style="{'width':aqiList.length*110+'px'}">
                     <button class="button button-stable item-center"
                             ng-click="setMainAqiCode(obj.code)"

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -4,10 +4,10 @@
     </ion-nav-buttons>
     <ion-nav-title>
         <p class="title dailyforecast-header">
-            <span style="vertical-align: middle">{{address}}</span>
-            <!--location_on, location_off-->
-            <i ng-if="currentPosition" class="material-icons" style="vertical-align: middle; font-size: 100%"
+            <span>{{address}}</span>
+            <i ng-if="currentPosition && showLoadingIndicator != true" class="material-icons"
                ng-click="switchToLocationSettings()">{{isLocationEnabled()?'&#xE0C8;':'&#xE0C7;'}}</i>
+            <ion-spinner ng-if="showLoadingIndicator" icon="bubbles"></ion-spinner>
         </p>
     </ion-nav-title>
     <ion-nav-buttons side="right">

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -4,10 +4,10 @@
     </ion-nav-buttons>
     <ion-nav-title>
         <p class="title forecast-header">
-            <span style="vertical-align: middle">{{address}}</span>
-            <!--location_on, location_off-->
-            <i ng-if="currentPosition" class="material-icons" style="vertical-align: middle; font-size: 100%"
+            <span>{{address}}</span>
+            <i ng-if="currentPosition && showLoadingIndicator != true" class="material-icons"
                ng-click="switchToLocationSettings()">{{isLocationEnabled()?'&#xE0C8;':'&#xE0C7;'}}</i>
+            <ion-spinner ng-if="showLoadingIndicator" icon="bubbles"></ion-spinner>
         </p>
     </ion-nav-title>
     <ion-nav-buttons side="right">


### PR DESCRIPTION
#2121
- spinner 추가
  - forecast-header, dailyforecast-header 내에서 vertical-align을 middle에 맞춤
  - $ionicLoading을 사용하지 않고, 로딩중에는 ion-spinner만 표시
#1846
- $scope.currentPosition, isLocationEnabled을 forecastrCtrl -> tabCtrl
- tablCtrl.init시에 realod event 생성
- scroll에 대한 css 차일드 전달되는 문제 수정