### PR TITLE
#1425 가독성 위해 색 조정(배경색 흰색적용)

### DIFF
--- a/client/www/img/weather_old/moon_lightning.png
+++ b/client/www/img/weather_old/moon_lightning.png
@@ -1,1 +1,0 @@
-MoonSmallCloudLightning.png

--- a/client/www/img/weather_old/moon_rain.png
+++ b/client/www/img/weather_old/moon_rain.png
@@ -1,1 +1,0 @@
-MoonSmallCloudRain.png

--- a/client/www/img/weather_old/moon_rain_lightning.png
+++ b/client/www/img/weather_old/moon_rain_lightning.png
@@ -1,1 +1,0 @@
-MoonSmallCloudRainLightning.png

--- a/client/www/img/weather_old/moon_rainsnow.png
+++ b/client/www/img/weather_old/moon_rainsnow.png
@@ -1,1 +1,0 @@
-MoonSmallCloudRainSnow.png

--- a/client/www/img/weather_old/moon_rainsnow_lightning.png
+++ b/client/www/img/weather_old/moon_rainsnow_lightning.png
@@ -1,1 +1,0 @@
-MoonSmallCloudRainSnowLightning.png

--- a/client/www/img/weather_old/moon_snow.png
+++ b/client/www/img/weather_old/moon_snow.png
@@ -1,1 +1,0 @@
-MoonSmallCloudSnow.png

--- a/client/www/img/weather_old/moon_snow_lightning.png
+++ b/client/www/img/weather_old/moon_snow_lightning.png
@@ -1,1 +1,0 @@
-MoonSmallCloudSnowLightning.png

--- a/client/www/img/weather_old/sun_lightning.png
+++ b/client/www/img/weather_old/sun_lightning.png
@@ -1,1 +1,0 @@
-SunSmallCloudLightning.png

--- a/client/www/img/weather_old/sun_rain.png
+++ b/client/www/img/weather_old/sun_rain.png
@@ -1,1 +1,0 @@
-SunSmallCloudRain.png

--- a/client/www/img/weather_old/sun_rain_lightning.png
+++ b/client/www/img/weather_old/sun_rain_lightning.png
@@ -1,1 +1,0 @@
-SunSmallCloudRainLightning.png

--- a/client/www/img/weather_old/sun_rainsnow.png
+++ b/client/www/img/weather_old/sun_rainsnow.png
@@ -1,1 +1,0 @@
-SunSmallCloudRainSnow.png

--- a/client/www/img/weather_old/sun_rainsnow_lightning.png
+++ b/client/www/img/weather_old/sun_rainsnow_lightning.png
@@ -1,1 +1,0 @@
-SunSmallCloudRainSnowLightning.png

--- a/client/www/img/weather_old/sun_snow.png
+++ b/client/www/img/weather_old/sun_snow.png
@@ -1,1 +1,0 @@
-SunSmallCloudSnow.png

--- a/client/www/img/weather_old/sun_snow_lightning.png
+++ b/client/www/img/weather_old/sun_snow_lightning.png
@@ -1,1 +1,0 @@
-SunSmallCloudSnowLightning.png


### PR DESCRIPTION
#1425 가독성 위해 색 조정(배경색 흰색적용)
* weatherIcon2-color -> weather_old로 폴더명 변경 시 link로 걸려있는 이미지의 link가 깨져 에러 발생하는 문제
 - link로 생성된 이미지 제거