### PR TITLE
push alarm, push alert 수정

### DIFF
--- a/server/controllers/alert.push.controller.js
+++ b/server/controllers/alert.push.controller.js
@@ -709,8 +709,8 @@ class AlertPushController {
          * 기준시(time)보다 시작시작인 작아야 하고, 기준시보다 종료가 커야 함.
          * @type {{reverseTime: boolean, startTime: {$lte: *}, endTime: {$gte: *}}}
          */
-        let queryN = {reverseTime: false, startTime: {$lte:time}, endTime: {$gte:time}};
-        let queryR = {reverseTime: true, $or: [{startTime: {$lte:time}}, {endTime: {$gte:time}}]};
+        let queryN = {enable: true, reverseTime: false, startTime: {$lte:time}, endTime: {$gte:time}};
+        let queryR = {enable: true, reverseTime: true, $or: [{startTime: {$lte:time}}, {endTime: {$gte:time}}]};
         let queryList = [];
         queryList.push(queryN);
         queryList.push(queryR);

--- a/server/controllers/controllerPush.js
+++ b/server/controllers/controllerPush.js
@@ -115,8 +115,12 @@ ControllerPush.prototype.updatePushInfo = function (pushInfo, callback) {
         return callback(new Error('invalid info pushInfo:'+JSON.stringify(pushInfo)));
     }
 
+    if (pushInfo.id == undefined) {
+        pushInfo.id = pushInfo.cityIndex;
+    }
+
     PushInfo.update(
-        {registrationId: pushInfo.registrationId, cityIndex: pushInfo.cityIndex},
+        {registrationId: pushInfo.registrationId, id: pushInfo.id},
         pushInfo,
         {upsert : true},
         function (err, result) {
@@ -149,10 +153,17 @@ ControllerPush.prototype.removePushInfo = function (pushInfo, callback) {
 };
 
 ControllerPush.prototype.getPushByTime = function (time, callback) {
-    PushInfo.find({pushTime: time}).lean().exec(function (err, pushList) {
+
+    function enable() {
+        //enable이 없거나, true이면 true
+        return this.enable !== false;
+    }
+
+    PushInfo.find({pushTime: time}).$where(enable).lean().exec(function (err, pushList) {
         if (err) {
             return callback(err);
         }
+
         if (pushList.length == 0) {
             return callback('No push info time='+time);
         }
@@ -868,7 +879,7 @@ ControllerPush.prototype._removeOldList = function (pushList, callback) {
  */
 ControllerPush.prototype._filterByDayOfWeek = function (pushList, current) {
     var filteredList = pushList.filter(function (pushInfo) {
-        if (pushInfo.hasOwnProperty('dayOfWeeks')) {
+        if (pushInfo.dayOfWeek && pushInfo.dayOfWeek.length > 0) {
             if (!pushInfo.hasOwnProperty('timezoneOffset')) {
                 log.error("timezone offset is undefined pushInfo:"+JSON.stringify(pushInfo));
                 return false;
@@ -877,10 +888,7 @@ ControllerPush.prototype._filterByDayOfWeek = function (pushList, current) {
             var localCurrent = kmaTimeLib.toLocalTime(pushInfo.timezoneOffset, current);
             var day = localCurrent.getDay();
 
-            var findIt = pushInfo.dayOfWeeks.find(function (value) {
-                return day === value;
-            });
-            return findIt != undefined;
+            return pushInfo.dayOfWeek[day];
         }
         else {
             return true;
@@ -915,7 +923,7 @@ ControllerPush.prototype.sendPush = function (time, callback) {
                     log.error(err);
                     return callback(err);
                 }
-                callback(filteredList);
+                callback(undefined, filteredList);
             },
             function(pushList, callback) {
                 async.mapSeries(pushList, function (pushInfo, mCallback) {
@@ -942,7 +950,7 @@ ControllerPush.prototype.sendPush = function (time, callback) {
         ],
         function(err, result) {
             if (err) {
-                return log.warn(err);
+                log.warn(err);
             }
             log.info(result);
             if (callback) {

--- a/server/models/alert.push.model.js
+++ b/server/models/alert.push.model.js
@@ -10,8 +10,10 @@ var alertPushSchema = new mongoose.Schema({
     startTime: Number,          //UTChours*60*60 + UTCMinutes*60
     endTime: Number,            //UTChours*60*60 + UTCMinutes*60
     reverseTime: {type: Boolean, default: false}, //true when startTime > endTime
+    id: Number,
     cityIndex: Number, //index of city in client
     type: String, //ios, android, windows, amazon ..
+    enable: {type: Boolean, default: true},
     town: {first: String, second: String, third: String},
     geo: {
         type: [Number],     // [<longitude(dmY)>, <latitude(dmX)>]
@@ -30,7 +32,7 @@ var alertPushSchema = new mongoose.Schema({
     },
     updatedAt: Date,
     timezoneOffset: Number, //mins +9h -> +540 for filtering day of week
-    dayOfWeeks: [Number], // Sunday - Saturday : 0 - 6
+    dayOfWeek: [Boolean], // Sunday - Saturday : 0 - 6 [false, true, true, true, true, true, false]
     airAlertsBreakPoint: Number, //사용자 설정한 기준값 민감군주의, 나쁨, 매우나쁨,...기본 나쁨
     precipAlerts: {
         lastState: Number, //start time에 갱신, 폴링시 체크때마다 갱신

--- a/server/models/modelPush.js
+++ b/server/models/modelPush.js
@@ -7,8 +7,10 @@ var mongoose = require("mongoose");
 var pushSchema = new mongoose.Schema({
     registrationId: String,
     pushTime: Number, //UTChours*60*60 + UTCMinutes*60
+    id: Number,         //이미 등록된 요청은 id가 없음 18.2.14
     cityIndex: Number, //index of city in client
     type: String, //ios, android, windows, amazon ..
+    enable: {type: Boolean, default: true},        //이미 등록된 요청은 없음, 도시가 유지된 채, 알람만 제거하면 false가 됨.
     town: {first: String, second: String, third: String},
     geo: {
         type: [Number],     // [<longitude(dmY)>, <latitude(dmX)>]
@@ -27,7 +29,7 @@ var pushSchema = new mongoose.Schema({
     },
     updatedAt: Date,
     timezoneOffset: Number, //mins +9h -> +540
-    dayOfWeeks: [Number], // Sunday - Saturday : 0 - 6
+    dayOfWeek: [Boolean], // Sunday - Saturday : 0 - 6 [false, true, true, true, true, true, false]
 });
 
 pushSchema.index({alarmTime:1});

--- a/server/routes/v000705/routePushNotification.js
+++ b/server/routes/v000705/routePushNotification.js
@@ -23,8 +23,8 @@ router.post('/', function(req, res) {
 
     //update modelPush
     //return _id
-    var pushInfo = req.body;
-    var language = req.headers['accept-language'];
+
+    var language = req.headers['accept-language'] || req.headers['Accept-Language'];
     if (language == undefined) {
         log.warn("accept-language is undefined");
         language = 'en';
@@ -32,7 +32,13 @@ router.post('/', function(req, res) {
     else {
         language = language.split(',')[0];
         if (language) {
-            language = language.substr(0, language.length-3);
+            if ( language.indexOf('ko') >= 0 ||
+                language.indexOf('en') >= 0 ||
+                language.indexOf('ja') >= 0 ||
+                language.indexOf('de') >= 0 )
+            {
+                language = language.substr(0, 2);
+            }
         }
         else {
             log.error("Fail to parse language="+req.headers['accept-language']);
@@ -40,16 +46,40 @@ router.post('/', function(req, res) {
         }
     }
 
-    pushInfo.lang = language;
-    if (pushInfo.location && pushInfo.location.hasOwnProperty('long') && pushInfo.location.hasOwnProperty('lat')) {
-        pushInfo.geo = [pushInfo.location.long, pushInfo.location.lat];
+    var pushInfo;
+
+    try {
+        pushInfo = req.body;
+
+        if (!pushInfo.hasOwnProperty('registrationId') ||
+            !pushInfo.hasOwnProperty('type') )
+        {
+            throw new Error('invalid push info registrationId/type');
+        }
+        if (pushInfo.registrationId.length === 0 ||
+            pushInfo.type.length === 0)
+        {
+            throw new Error('invalid push info registrationId/type');
+        }
+        if (!pushInfo.hasOwnProperty('location') && !pushInfo.hasOwnProperty('town')) {
+            throw new Error('invalid push info location or town is empty');
+        }
+
+        pushInfo.lang = language;
+        if (pushInfo.location && pushInfo.location.hasOwnProperty('long') && pushInfo.location.hasOwnProperty('lat')) {
+            pushInfo.geo = [pushInfo.location.long, pushInfo.location.lat];
+        }
+
+        if (pushInfo.source == undefined) {
+            pushInfo.source = "KMA"
+        }
+
+        log.info('pushInfo : '+ JSON.stringify(pushInfo));
+    }
+    catch (err) {
+        return res.status(403).send(err.message);
     }
 
-    if (pushInfo.source == undefined) {
-        pushInfo.source = "KMA"
-    }
-
-    log.info('pushInfo : '+ JSON.stringify(pushInfo));
     var co = new ControllerPush();
     co.updatePushInfo(pushInfo, function (err, result) {
         if (err) {

--- a/server/test/e2e_local/test.e2e.alert.push.controller.js
+++ b/server/test/e2e_local/test.e2e.alert.push.controller.js
@@ -54,7 +54,7 @@ describe('unit test - alert push controller', function() {
             precipitationUnit: "mm",
             airUnit: "airkorea"
         },
-        dayOfWeeks: [1,5],
+        dayOfWeek: [false, true, false, false, false, true, false],
         timezoneOffset: 540,
         airAlertsBreakPoint: 2
     };
@@ -77,7 +77,7 @@ describe('unit test - alert push controller', function() {
             distanceUnit: "miles",
             precipitationUnit: "inch"
         },
-        dayOfWeeks: [1,2,3,4,5],
+        dayOfWeek: [false, true, true, true, true, true, false],
         timezoneOffset: 540,
         airAlertsBreakPoint: 2
     };

--- a/server/test/e2e_local/test.e2e.controller.push.js
+++ b/server/test/e2e_local/test.e2e.controller.push.js
@@ -29,23 +29,38 @@ global.i18n = i18n;
 
 describe('e2e local test - controller push', function() {
 
-    var pushInfo1 = { "cityIndex" : 1,
+    var pushInfo1 = { "id":1, "cityIndex" : 1,
         "registrationId" : "3c9b9e4f199b94bbf6a5253860c09a33f2dcabcdb097ec6d3f9a7ab44dba013f",
         "pushTime" : 82800,
+        "enable" : true,
+        "category" : "alarm",
         "type" : "ios", "source" : "KMA", "lang" : "ko",
         "units" : { "temperatureUnit" : "C", "windSpeedUnit" : "m/s",
             "pressureUnit" : "hPa", "distanceUnit" : "km", "precipitationUnit" : "mm" },
         "geo" : [ 127.37, 36.3 ],
-        "name" : "정림동1", "dayOfWeeks":[1,3,5], "timezoneOffset":540 };
+        "name" : "정림동1", "dayOfWeek":[false, true, false, true, false, true, false], "timezoneOffset":540 };
 
-    var pushInfo2 = { "cityIndex" : 2,
+    var pushInfo2 = { "id":2, "cityIndex" : 2,
         "registrationId" : "3c9b9e4f199b94bbf6a5253860c09a33f2dcabcdb097ec6d3f9a7ab44dba013f",
         "town" : { "first" : "대전광역시", "second" : "서구", "third" : "정림동" },
         "pushTime" : 82800,
+        "enable" : true,
+        "category" : "alarm",
         "type" : "ios", "source" : "KMA", "lang" : "ko",
         "units" : { "temperatureUnit" : "C", "windSpeedUnit" : "m/s",
             "pressureUnit" : "hPa", "distanceUnit" : "km", "precipitationUnit" : "mm" },
-        "name" : "정림동2", "dayOfWeeks":[1,3,5], "timezoneOffset":-540};
+        "name" : "정림동2", "dayOfWeek":[false, true, false, true, false, true, false], "timezoneOffset":-540};
+
+    var pushInfo3 = { "id":3, "cityIndex" : 2,
+        "registrationId" : "3c9b9e4f199b94bbf6a5253860c09a33f2dcabcdb097ec6d3f9a7ab44dba013f",
+        "town" : { "first" : "대전광역시", "second" : "서구", "third" : "정림동" },
+        "pushTime" : 82900,
+        "enable" : false,
+        "category" : "alarm",
+        "type" : "ios", "source" : "KMA", "lang" : "ko",
+        "units" : { "temperatureUnit" : "C", "windSpeedUnit" : "m/s",
+            "pressureUnit" : "hPa", "distanceUnit" : "km", "precipitationUnit" : "mm" },
+        "name" : "정림동3", "dayOfWeek":[false, true, false, true, false, true, false], "timezoneOffset":540};
 
     it('test request daily summary without town', function(done) {
         this.timeout(20*1000);
@@ -90,6 +105,7 @@ describe('e2e local test - controller push', function() {
         var pushList = [];
         pushList.push(pushInfo1);
         pushList.push(pushInfo2);
+        pushList.push(pushInfo3);
 
         ctrl._getCurrentTime = function () {
             var current = new Date();
@@ -130,6 +146,17 @@ describe('e2e local test - controller push', function() {
         var co = new ControllerPush();
         var filteredList = co._filterByDayOfWeek(pushList, date);
         console.log(filteredList);
+    });
+
+    it('test get push info by time', function(done) {
+        var co = new ControllerPush();
+        co.getPushByTime(pushInfo3.pushTime, function (err, result) {
+            if (err) {
+                console.error(err);
+            }
+            assert.equal(result, undefined);
+            done();
+        });
     });
 });
 

--- a/server/test/e2e_local/test.e2e.route.push.update.list.js
+++ b/server/test/e2e_local/test.e2e.route.push.update.list.js
@@ -90,7 +90,7 @@ describe('e2e local test - controller push', function() {
             precipitationUnit: "mm",
             airUnit: "airkorea"
         },
-        dayOfWeeks: [1,5],
+        dayOfWeek: [false, true, false, false, false, true, false],
         timezoneOffset: 540,
         airAlertsBreakPoint: 2
     };

--- a/server/test/test.alert.push.controller.js
+++ b/server/test/test.alert.push.controller.js
@@ -34,7 +34,7 @@ describe('unit test - alert push controller', function() {
             precipitationUnit: "mm",
             airUnit: "airkorea"
         },
-        dayOfWeeks: [1,5],
+        dayOfWeek: [false, true, false, false, false, true, false],
         timezoneOffset: 540,
         airAlertsBreakPoint: 2
     };
@@ -57,7 +57,7 @@ describe('unit test - alert push controller', function() {
             distanceUnit: "miles",
             precipitationUnit: "inch"
         },
-        dayOfWeeks: [1,2,3,4,5],
+        dayOfWeek: [false, true, true, true, true, true, false],
         timezoneOffset: 540,
         airAlertsBreakPoint: 2
     };

--- a/server/test/testControllerPush.js
+++ b/server/test/testControllerPush.js
@@ -54,7 +54,7 @@ describe('unit test - controller push', function() {
             precipitationUnit: "mm",
             airUnit: "airkorea"
         },
-        dayOfWeeks: [1,5],
+        dayOfWeek: [false, true, false, false, false, true, false],
         timezoneOffset: 540
     };
 
@@ -102,7 +102,7 @@ describe('unit test - controller push', function() {
            distanceUnit: "miles",
            precipitationUnit: "inch"
        },
-        dayOfWeeks: [1,2,3,4,5],
+        dayOfWeek: [false, true, true, true, true, true, false],
         timezoneOffset: 540
     };
 
@@ -156,18 +156,6 @@ describe('unit test - controller push', function() {
         });
     });
 
-    it('test get push info by time', function(done) {
-        var PushInfo = require('../models/modelPush');
-        PushInfo.find = function(getInfo) {
-            assert.equal(getInfo.pushTime, pushInfo.pushTime, 'error');
-            return {lean: function() { return {exec: function(callback) {return callback(undefined, [pushInfo]);}}}};
-        };
-
-        var co = new ControllerPush();
-        co.getPushByTime(pushInfo.pushTime, function () {
-            done();
-        });
-    });
 });
 
 


### PR DESCRIPTION
#1701 #2130
- modelPush
  - new id, enable
  - rename dayOfWeek, 요일별 boolean 으로 변경
- alert.push.model
  - new id, enable
  - rename dayOfWeek, 요일별 boolean 으로 변경
- alert.push.controller
  - check enable when db.find
- controllerPush
  - id가 없는 경우 cityIndex에서 가져오고, update시 기준을 cityIndex->id로 변경
  - find 시 enable 처리
    - enable 없는 경우에도 true
  - sendPush process 오류 수정
- push language 오류
  - 중국어(간체,번체)는 zh-TW, zh-CN 유지
  - 한국어, 영어, 일본어, 독일어는 shorten name으로 저장
  - registrationId, type이 없거나, 빈문자열이면 403 에러 처리