### PR TITLE
#2118 [0.9.78] crosswalk에서 대기정보페이지 내 스크롤이 동작하지 않음.

### DIFF
--- a/client/www/js/controller.air.js
+++ b/client/www/js/controller.air.js
@@ -1,6 +1,6 @@
 angular.module('controller.air', [])
     .controller('AirCtrl', function ($scope, $stateParams, $sce, WeatherInfo, WeatherUtil, Units, Util,
-                                     $ionicScrollDelegate) {
+                                     $ionicScrollDelegate, $ionicHistory) {
 
         var TABLET_WIDTH = 640;
 
@@ -398,6 +398,8 @@ angular.module('controller.air', [])
         }
 
         function init() {
+            $ionicHistory.clearHistory();
+
             var fav = parseInt($stateParams.fav);
             if (!isNaN(fav)) {
                 if (fav === 0) {


### PR DESCRIPTION
#2118 [0.9.78] crosswalk에서 대기정보페이지 내 스크롤이 동작하지 않음.
* 대기정보페이지에서 back버튼으로 앱이 종료되도록 clearHistory 처리 추가
* clearHistory 추가로 스크롤이 되지 않는 문제도 수정됨