### PR TITLE
pm10 hourly foreacst 수집중에 map이 종료되지 않고 멈춰 있는 문제

### DIFF
--- a/server/controllers/airkorea.dust.image.controller.js
+++ b/server/controllers/airkorea.dust.image.controller.js
@@ -169,9 +169,9 @@ AirkoreaDustImageController.prototype.getDustInfo = function(lat, lon, type, aqi
     var x = parseInt((lon - self.coordinate.top_left.lon) / pixels.map_pixel_distance_width) + pixels.map_area.left;
     var y = parseInt((self.coordinate.top_left.lat - lat) / pixels.map_pixel_distance_height) + pixels.map_area.top;
 
-    log.info('Airkorea Image > lat: ', lat, 'lon: ', lon);
-    log.info('Airkorea Image > ', pixels.map_pixel_distance_width,  pixels.map_pixel_distance_height);
-    log.info('Airkorea Image > x: ', x, 'y: ',y);
+    log.debug('Airkorea Image > lat: ', lat, 'lon: ', lon);
+    log.debug('Airkorea Image > ', pixels.map_pixel_distance_width,  pixels.map_pixel_distance_height);
+    log.debug('Airkorea Image > x: ', x, 'y: ',y);
 
     var result = [];
     var colorTable = self.colorTable_pm10;

--- a/server/controllers/airkorea.hourly.forecast.controller.js
+++ b/server/controllers/airkorea.hourly.forecast.controller.js
@@ -10,7 +10,9 @@
 const async = require('async');
 const ControllerAirkoreaDustImage = require('./airkorea.dust.image.controller');
 const MsrStn = require('../models/modelMsrStnInfo');
+const Frcst = require('../models/modelMinuDustFrcst');
 const ArpltnHourlyForecast = require('../models/arpltn.hourly.forecast');
+const kmaTimeLib = require('../lib/kmaTimeLib');
 
 class AirkoreaHourlyForecastController {
     constructor(imgPaths) {
@@ -98,8 +100,7 @@ class AirkoreaHourlyForecastController {
                             'airkorea',
                             function (err, hourlyForecastObj) {
                                 if(err){
-                                    log.warn('Invalid geocode for dust forecast:', stn.geo[1], stn.geo[0]);
-                                    return callback();
+                                    return callback(err);
                                 }
                                 hourlyForecastObj.stationName = stn.stationName;
                                 hourlyForecastObj.code = code;
@@ -108,13 +109,19 @@ class AirkoreaHourlyForecastController {
                 },
                 (hourlyForecasts, callback) => {
                     if (hourlyForecasts == undefined) {
-                        log.warn('pass update forecast list hourlyForecasts is undefined');
+                        log.error('pass update forecast list hourlyForecasts is undefined');
                         return callback();
                     }
+                    log.debug(JSON.stringify(hourlyForecasts));
                     this._updateForecastList(hourlyForecasts, callback);
                 }
             ],
-            callback);
+            (err)=>{
+                if(err) {
+                    log.warn('Invalid geocode for dust forecast:', stn.geo[1], stn.geo[0]);
+                }
+                callback();
+            });
     }
 
     /**
@@ -125,7 +132,9 @@ class AirkoreaHourlyForecastController {
      * @private
      */
     _updateHourlyForecastEach(stnList, code, callback) {
-        async.map(stnList,
+        log.info('update hourly forecast code:'+code);
+
+        async.mapSeries(stnList,
             (stn, callback) => {
                 this._updateDustInfo(stn, code, callback);
             },
@@ -133,6 +142,8 @@ class AirkoreaHourlyForecastController {
     }
 
     _updateHourlyForecast(stnList, callback) {
+        log.info('update hourly forecast stnList:'+stnList.length);
+
         async.mapSeries(['pm10', 'pm25'],
             (code, callback) => {
                 this._updateHourlyForecastEach(stnList, code, callback);
@@ -151,11 +162,69 @@ class AirkoreaHourlyForecastController {
         });
     }
 
-    do() {
-        async.waterfall([
+    _checkHourlyForecast(dataTime, callback) {
+        let query = {pubDate: dataTime};
+        ArpltnHourlyForecast.find(query).lean().exec((err, list)=>{
+            if (err) {
+                return callback(err);
+            }
+            let pm10List = list.filter((obj)=> {
+                return obj.code === 'pm10';
+            });
+            let pm25List = list.filter((obj)=> {
+                return obj.code === 'pm25';
+            });
+            if (pm10List.length > 0 && pm25List.length > 0) {
+                err = 'skip';
+            }
+            return callback(err, list);
+        });
+    }
+
+    _getImgPaths(dataTime, callback) {
+        Frcst.find({dataTime: dataTime}).lean().exec(function (err, frcstList) {
+            if (err)  {
+                return callback(err);
+            }
+            if (frcstList.length == 0) {
+                err = new Error("Fail to find dataTime:"+dataTime);
+                return callback(err);
+            }
+
+            let imagePaths = {pubDate: kmaTimeLib.convertYYYY_MM_DD_HHStr2YYYY_MM_DD_HHoZZ(frcstList[0].dataTime)};
+            let findCount = 0;
+
+            for (var i=0; i<frcstList.length && findCount<2; i++) {
+                var obj = frcstList[i];
+                if (!imagePaths.hasOwnProperty('pm10') && obj.informCode === 'PM10')  {
+                    imagePaths.pm10 = obj.imageUrl[6];
+                    findCount++;
+                }
+                else if (!imagePaths.hasOwnProperty('pm25') && obj.informCode === 'PM25') {
+                    imagePaths.pm25 = obj.imageUrl[7];
+                    findCount++;
+                }
+            }
+            return callback(err, imagePaths);
+        });
+    }
+
+    do(dataTime) {
+
+        async.waterfall(
+            [
                 (callback) => {
+                    let hourlyForecastDataTime = kmaTimeLib.convertYYYY_MM_DD_HHStr2YYYY_MM_DD_HHoZZ(dataTime);
+                    this._checkHourlyForecast(hourlyForecastDataTime, (err)=> {
+                        callback(err);
+                    });
+                },
+                (callback) => {
+                    this._getImgPaths(dataTime, callback);
+                },
+                (imgPaths, callback) => {
                     this.airkoreaDustImageMgr = new ControllerAirkoreaDustImage();
-                    this.airkoreaDustImageMgr.getDustImage(this.imgPaths, callback);
+                    this.airkoreaDustImageMgr.getDustImage(imgPaths, callback);
                 },
                 (result, callback) => {
                     this._getMsrStn(callback);
@@ -165,7 +234,7 @@ class AirkoreaHourlyForecastController {
                 }
             ],
             (err) => {
-                if (err) {
+                if (err && err !== 'skip') {
                     log.error(err);
                 }
                 log.info("Finish update hourly forecast");

--- a/server/lib/kecoRequester.js
+++ b/server/lib/kecoRequester.js
@@ -779,12 +779,16 @@ Keco.prototype.removeMinuDustFrcst = function (callback) {
 Keco.prototype.getMinuDustFrcstDspth = function(callback) {
     var self = this;
 
+    var dataTime;
+
     async.waterfall([
             function (cb) {
                 self._checkDataTime(function (err, result) {
                     if (err) {
                         return cb(err);
                     }
+                    dataTime = result.dataTime;
+
                     if (result.isLatest) {
                         log.info('minu dust forecast is already latest');
                         return cb('skip');
@@ -808,27 +812,6 @@ Keco.prototype.getMinuDustFrcstDspth = function(callback) {
                 return cb(undefined, parsedList);
             },
             function (parsedFrcstList, cb) {
-                if(parsedFrcstList.length > 0) {
-                    var imagePaths = {pubDate: kmaTimeLib.convertYYYY_MM_DD_HHStr2YYYY_MM_DD_HHoZZ(parsedFrcstList[0].dataTime)};
-                    var findCount = 0;
-
-                    for (var i=0; i<parsedFrcstList.length && findCount<2; i++) {
-                        var obj = parsedFrcstList[i];
-                        if (!imagePaths.hasOwnProperty('pm10') && obj.informCode === 'PM10')  {
-                            imagePaths.pm10 = obj.imageUrl[6];
-                            findCount++;
-                        }
-                        else if (!imagePaths.hasOwnProperty('pm25') && obj.informCode === 'PM25') {
-                            imagePaths.pm25 = obj.imageUrl[7];
-                            findCount++;
-                        }
-                    }
-
-                    (new AirkoreaHourlyForecastCtrl(imagePaths)).do();
-                }
-                return cb(undefined, parsedFrcstList);
-            },
-            function (parsedFrcstList, cb) {
                 self._saveFrcst(parsedFrcstList, function (err, result) {
                     if (err) {
                         return cb(err);
@@ -838,6 +821,7 @@ Keco.prototype.getMinuDustFrcstDspth = function(callback) {
             }
         ],
         function (err, result) {
+            (new AirkoreaHourlyForecastCtrl()).do(dataTime.dataDate+' '+dataTime.dataHours);
             if (err) {
                 return callback(err);
             }


### PR DESCRIPTION
#2152 #2139 #2114
- airkorea.hourly.forecast.controller
  - waterfall에서 callback을 param 없이 넘기면, 받는 곳에서 func이 첫 파람으로 옴
  - map으로 하는 경우 local에서 락걸리는 경우가 있어 mapSeries로 변경
  - image 못 가지고 오거나, 중간에 에러나는 경우 재시도하게 수정
- airkorea.dust.image.controller
  - log level 조정