### PR TITLE
#1425 가독성 위해 색 조정(배경색 흰색적용)

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -230,36 +230,38 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
       color: #666666;
       font-size: 13px;
     }
-    .chart-header {
-      width: 100%;
-      text-align: center;
-      .day-title-list {
-        position: relative;
-        height: 14px;
-        margin-bottom: 5px;
-        .day-title {
-          position: absolute;
-          top: 0;
-          width: 120px;
-          background-color: #F5F5F5;
-          font-size: 13px;
-          font-weight: 400;
+    .chart-scroll {
+      overflow-x: auto;
+      overflow-y: hidden;
+      white-space: nowrap;
+      .chart-header {
+        width: 100%;
+        text-align: center;
+        .day-title-list {
+          position: relative;
+          height: 14px;
+          margin-bottom: 5px;
+          .day-title {
+            position: absolute;
+            font-size: 15px;
+            font-weight: 400;
+            text-align: left;
+          }
+        }
+        .chart-title {
+          width: 100%;
+          padding: 2px;
+          font-size: 17px;
+        }
+        .chart-small-title {
+          width: 100%;
+          padding: 2px;
+          font-size: 15px;
         }
       }
-      .chart-title {
+      .chart-content {
         width: 100%;
-        padding: 2px;
-        font-size: 17px;
       }
-      .chart-small-title {
-        width: 100%;
-        padding: 2px;
-        font-size: 15px;
-      }
-    }
-    .chart-content {
-      width: 100%;
-      margin: 0 0 4px;
     }
     .chart-label {
       background: rgba(0, 0, 0, 0.1);
@@ -314,15 +316,14 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
       max-width: 50%;
       height: 8px;
       border-right: 1px solid #444;
-      display: flex;
+      margin: 0 1px;
     }
   }
   .air-std-box {
     display: flex;
-    margin-top: -2px;
     .air-std {
       flex-basis: 100%;
-      padding: 1px;
+      margin: 0 1px;
       text-overflow:ellipsis;
       overflow:hidden;
       white-space:nowrap;
@@ -352,6 +353,12 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 
 .chart-bar {
   fill: #7aa4d1;
+}
+
+.guide-vivid-line {
+  stroke: #c0d6f0;
+  stroke-width: 1;
+  stroke-opacity: 0.6;
 }
 
 .guide-line {

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -520,7 +520,13 @@ angular.module('starter', [
                             });
 
                         guideLines.enter().append('line')
-                            .attr('class', 'guide-line')
+                            .attr('class', function (d) {
+                                if (d.value.time === 24) {
+                                    return 'guide-vivid-line';
+                                } else {
+                                    return 'guide-line';
+                                }
+                            })
                             .attr('x1', function (d, i) {
                                 return x.rangeBand() * i + x.rangeBand() / 2+0.5;
                             })

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -40,7 +40,7 @@
                     <span class="icon-right ion-chevron-right"></span>
                 </div>
             </div>
-            <div id="chartScroll" class="card-scroll">
+            <div id="chartScroll" class="chart-scroll">
                 <div ng-style="{'width':dayWidth +'px'}">
                     <div class="chart-header" ng-if="dayChart[0].values">
                         <div class="row row-no-padding">

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -41,7 +41,7 @@
                 </div>
             </div>
             <div style="position: relative" ng-if="timeWidth">
-                <div id="chartScroll" class="card-scroll">
+                <div id="chartScroll" class="chart-scroll">
                     <div ng-style="{'width':timeWidth +'px'}">
                         <div class="chart-header" ng-if="timeTable">
                             <div class="row row-no-padding day-title-list">


### PR DESCRIPTION
#1425 가독성 위해 색 조정(배경색 흰색적용)
* 대기정보 기준 그래프의 grade 사이에 1px 여백 표시, 위치 조정
* 시간별/일별 차트에서 세로 스크롤이 되는 문제
    1. chart-content의 하단 마진 제거
    2. overscroll이 auto일 때 컨텐츠의 height이 4px 커지는 문제가 있어 overscroll-y을 hidden으로 처리하여 동일한 height으로 계산되도록 함
* 시간별 차트에서 스타일 수정
    1. 날짜 title의 배경색 제거, 15px, 좌측 정렬
    2. 24시일 때 guide line의 색상을 진하게 표시