### PR TITLE
TW-139 [0.9.81] 4:3 화면비에서 겹치는 문제 #2220

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -61,7 +61,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 @import "www/lib/ionic/scss/ionic";
 
 [md-page-header] {
-  padding: 0;
+  padding: 0 0 5px 0;
   //height: auto;
   color: #444;
   background-color: #fff;

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -203,7 +203,7 @@ angular.module('controller.forecastctrl', [])
             //console.log(headerE);
             //console.log("startHeight=", startHeight);
 
-            headerE.css('height', startHeight+'px');
+            headerE.css('min-height', startHeight+'px');
             //빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
             $scope.headerHeight = startHeight;
 

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -18,7 +18,7 @@
                  has-bouncing="false" tabs-shrink class="main-content">
         <div class="card">
             <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()" class="row row-no-padding"
-                 ng-style="{'height':headerHeight+'px'}">
+                 ng-style="{'min-height':headerHeight+'px'}">
                 <div class="main-box-arrow" ng-click="onSwipeRight()" ng-if="cityCount > 1">
                     <span class="icon-left ion-chevron-left"></span>
                 </div>

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -18,7 +18,7 @@
                  has-bouncing="false" tabs-shrink class="main-content">
         <div class="card">
             <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()" class="row row-no-padding"
-                 ng-style="{'height':headerHeight+'px'}">
+                 ng-style="{'min-height':headerHeight+'px'}">
                 <div class="main-box-arrow" ng-click="onSwipeRight()" ng-if="cityCount > 1">
                     <span class="icon-left ion-chevron-left"></span>
                 </div>

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -18,7 +18,7 @@
                  has-bouncing="false" tabs-shrink class="main-content">
         <div class="card">
             <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()" class="row row-no-padding"
-                 ng-style="{'height':headerHeight+'px'}">
+                 ng-style="{'min-height':headerHeight+'px'}">
                 <div class="main-box-arrow" ng-click="onSwipeRight()" ng-if="cityCount > 1">
                     <span class="icon-left ion-chevron-left"></span>
                 </div>


### PR DESCRIPTION
TW-139 [0.9.81] 4:3 화면비에서 겹치는 문제 #2220
* md-page-header의 height을 controller에서 계산해서 설정하는데 summary가 길어지거나 화면 크기가 작은 경우 header 영역을 벗어나는 문제가 발생함
 - controller에서 계산한 headerHeight를 min-height으로 설정하여 최소 높이만 보장하고 하위 child 크기 만큼 커질 수 있도록 함
* md-page-header와 chart 사이에 여백 추가