### PR TITLE
TW-129 하단 탭과 광고 영역 구분 필요 #2196

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -269,21 +269,18 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
       position: absolute;
       left: 10px;
       bottom: 0px;
-      padding: 5px;
       font-size: 13px;
       .chart-label-today {
-        background-color: #ffffff;
-        width: 13px;
+        margin: 5px;
+        border-left: 13px solid #7aa4d1;
+        padding-left: 5px;
         height: 13px;
-        display: inline-block;
-        vertical-align: bottom;
       }
       .chart-label-yesterday {
-        background-color: #9E9E9E;
-        width: 13px;
+        margin: 5px;
+        border-left: 13px solid #9e9e9e;
+        padding-left: 5px;
         height: 13px;
-        display: inline-block;
-        vertical-align: bottom;
       }
     }
   }

--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -833,6 +833,10 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 }
 
 /* common */
+ion-side-menu-content > ion-nav-view {
+  border-bottom: 1px solid #d2d2d2;
+}
+
 .pane, .view {
   background-color: transparent;
 }

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -62,8 +62,8 @@
                     </div>
                 </div>
                 <div class="chart-label" ng-if="timeChart">
-                    <div class="chart-label-yesterday"></div> <span>{{"LOC_PREVIOUS_DAY_TEMP"|translate}}</span><br/>
-                    <div class="chart-label-today"></div> <span>{{"LOC_THIS_DAY_TEMP"|translate}}</span>
+                    <div class="chart-label-today">{{"LOC_THIS_DAY_TEMP"|translate}}</div>
+                    <div class="chart-label-yesterday">{{"LOC_PREVIOUS_DAY_TEMP"|translate}}</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
TW-129 하단 탭과 광고 영역 구분 필요 #2196
* <ion-side-menu-content> 하위의 <ion-nav-view>의 하단 border 추가하여 모든 page의 하단에 표시됨
* .tabs로 설정된 background-image: linear-gradient(0deg, #b2b2b2, #b2b2b2 50%, transparent 70%);으로 tabs의 상단 border 표시되고 있음