### PR TITLE
TW-174 K Image data를 DB에 저장 및 추출

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -109,7 +109,9 @@ module.exports = {
                 right: (process.env.KAQ_KOREA_IMAGE_MAP_RIGHT || '0'),
                 top: (process.env.KAQ_KOREA_IMAGE_MAP_TOP || '0'),
                 bottom: (process.env.KAQ_KOREA_IMAGE_MAP_BOTTOM || '0')
-            }
+            },
+            region: (process.env.KAQ_KOREA_IMAGE_MAP_REGION || ''),
+            bucketName: (process.env.KAQ_KOREA_IMAGE_MAP_BUCKET_NAME || ''),
         }
     }
 };

--- a/server/controllers/airkorea.hourly.forecast.controller.js
+++ b/server/controllers/airkorea.hourly.forecast.controller.js
@@ -9,78 +9,17 @@
 
 const async = require('async');
 const ControllerAirkoreaDustImage = require('./airkorea.dust.image.controller');
-const MsrStn = require('../models/modelMsrStnInfo');
 const Frcst = require('../models/modelMinuDustFrcst');
 const ArpltnHourlyForecast = require('../models/arpltn.hourly.forecast');
 const kmaTimeLib = require('../lib/kmaTimeLib');
 
-class AirkoreaHourlyForecastController {
+const ImgHourlyForecastController = require('./img.hourly.forecast.controller');
+
+class AirkoreaHourlyForecastController extends ImgHourlyForecastController {
     constructor(imgPaths) {
-        this.imgPaths = imgPaths;
+        // noinspection JSAnnotator
+        super(imgPaths, ArpltnHourlyForecast);
         this.airkoreaDustImageMgr;
-    }
-
-    _getMsrStn(callback) {
-        MsrStn.find().lean().exec(function (err, stnList) {
-            if (err) {
-                return callback(err);
-            }
-            if (stnList.length === 0) {
-                return callback(new Error("airkroea msr stn list length is 0"));
-            }
-            callback(null, stnList);
-        });
-    }
-
-    _updateDb(obj, callback) {
-        ArpltnHourlyForecast.update({stationName: obj.stationName, date: obj.date, code: obj.code},
-            obj,
-            {upsert:true},
-            callback);
-    }
-
-    _makeArpltnHourForecast(stationName, code, pubDate, hourData) {
-        return {
-            stationName: stationName,
-            date: new Date(hourData.date),
-            code: code,
-            val: hourData.val,
-            dataTime: hourData.date,
-            pubDate: pubDate
-        };
-    }
-
-    _updateForecastList(forecastsObj, callback) {
-        async.map(forecastsObj.hourly,
-            (hourData, callback) => {
-                var arpltnHourForecast;
-                try {
-                    if (hourData.val == undefined) {
-                       log.warn("invalid val "+ forecastsObj.stationName+ " "+forecastsObj.code+" "+hourData.date);
-                    }
-                    else {
-                        arpltnHourForecast = this._makeArpltnHourForecast(
-                            forecastsObj.stationName,
-                            forecastsObj.code,
-                            forecastsObj.pubDate,
-                            hourData);
-                    }
-                }
-                catch(err) {
-                    log.error(err);
-                }
-                if (arpltnHourForecast) {
-                    this._updateDb(arpltnHourForecast, function (err) {
-                        if (err)  {
-                            log.error(err);
-                        }
-                        callback();
-                    });
-                }
-                else {
-                    callback();
-                }
-            }, callback);
     }
 
     /**
@@ -122,63 +61,6 @@ class AirkoreaHourlyForecastController {
                 }
                 callback();
             });
-    }
-
-    /**
-     * code(pm10, pm25, o3) 별로 모든 stn의 예보를 업데이트 요청한다.
-     * @param stnList
-     * @param code
-     * @param callback
-     * @private
-     */
-    _updateHourlyForecastEach(stnList, code, callback) {
-        log.info('update hourly forecast code:'+code);
-
-        async.mapSeries(stnList,
-            (stn, callback) => {
-                this._updateDustInfo(stn, code, callback);
-            },
-            callback);
-    }
-
-    _updateHourlyForecast(stnList, callback) {
-        log.info('update hourly forecast stnList:'+stnList.length);
-
-        async.mapSeries(['pm10', 'pm25'],
-            (code, callback) => {
-                this._updateHourlyForecastEach(stnList, code, callback);
-            },
-            callback);
-    }
-
-    _removeOldData() {
-        var removeDate = new Date();
-        removeDate.setDate(removeDate.getDate()-1);
-        ArpltnHourlyForecast.remove({"date": {$lt:removeDate}}, function (err) {
-            log.info('removed airpltn hourly forecast from date : ' + removeDate);
-            if(err) {
-                log.error(err);
-            }
-        });
-    }
-
-    _checkHourlyForecast(dataTime, callback) {
-        let query = {pubDate: dataTime};
-        ArpltnHourlyForecast.find(query).lean().exec((err, list)=>{
-            if (err) {
-                return callback(err);
-            }
-            let pm10List = list.filter((obj)=> {
-                return obj.code === 'pm10';
-            });
-            let pm25List = list.filter((obj)=> {
-                return obj.code === 'pm25';
-            });
-            if (pm10List.length > 0 && pm25List.length > 0) {
-                err = 'skip';
-            }
-            return callback(err, list);
-        });
     }
 
     _getImgPaths(dataTime, callback) {
@@ -237,16 +119,10 @@ class AirkoreaHourlyForecastController {
                 if (err && err !== 'skip') {
                     log.error(err);
                 }
-                log.info("Finish update hourly forecast");
+                log.info("Finish update airkorea hourly forecast");
                 delete this.airkoreaDustImageMgr;
                 this._removeOldData();
             });
-    }
-
-    getForecast(stationName, callback) {
-       ArpltnHourlyForecast.find({stationName: stationName}).lean().sort({date:1}).exec(function (err, forecastList) {
-           callback(err, forecastList);
-       });
     }
 }
 

--- a/server/controllers/controllerManager.js
+++ b/server/controllers/controllerManager.js
@@ -1911,152 +1911,6 @@ Manager.prototype.task = function(callback) {
     });
 };
 
-//It is unused.
-//Manager.prototype.checkTimeAndPushTask = function (putAll) {
-//    var self = this;
-//    var time = (new Date()).getUTCMinutes();
-//
-//    var server_key = config.keyString.cert_key;
-//    var normal_key = config.keyString.normal;
-//
-//    log.info('check time and push task');
-//
-//    if (time === 1 || putAll) {
-//        //short rss
-//        log.info('push short rss');
-//        self.asyncTasks.push(function (callback) {
-//            //need to update sync
-//            townRss.mainTask(function(){
-//                log.info('Rss>complete mainTask for Rss');
-//                callback();
-//            });
-//        //    setTimeout(function () {
-//       //         log.info('Finished ShortRss '+new Date());
-//       //         callback();
-//       //     }, 1000*60); //1min
-//        });
-//        log.info('push mid rss');
-//        self.asyncTasks.push(function (callback) {
-//            midRssKmaRequester.mainProcess(midRssKmaRequester, function (self, err) {
-//                log.info('Finished MidRss '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//    }
-//
-//    if (time === 2 || putAll) {
-//        log.info('push MidTemp');
-//        self.asyncTasks.push(function (callback) {
-//            self.getMidTemp(9, normal_key, function (err) {
-//                log.info('Finished MidTemp '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//        log.info('push MidLand');
-//        self.asyncTasks.push(function (callback) {
-//            self.getMidLand(9, normal_key, function (err) {
-//                log.info('Finished MidLand '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//        log.info('push MidForecast');
-//        self.asyncTasks.push(function (callback) {
-//            self.getMidForecast(9, normal_key, function (err) {
-//                log.info('Finished MidForecast '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//        log.info('push MidSea');
-//        self.asyncTasks.push(function (callback) {
-//            self.getMidSea(9, normal_key, function (err) {
-//                log.info('Finished MidSea '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//    }
-//
-//    if (time === 10 || putAll) {
-//        log.info('push PastConditionGather');
-//        self.asyncTasks.push(function (callback) {
-//            var pastGather = new PastConditionGather();
-//
-//            pastGather.start(1, server_key, function (err) {
-//                log.info('Finished PastConditionGather '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//    }
-//
-//    //1:06분 일부만 업데이트 됨. 20분에 대부분 갱신됨.
-//    if (time === 20 || putAll) {
-//        log.info('push keco main process');
-//        self.asyncTasks.push(function (callback) {
-//            keco.cbKmaIndexProcess(keco, function (err) {
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//    }
-//
-//    if (time === 31 || putAll) {
-//        log.info('push Short');
-//        self.asyncTasks.push(function (callback) {
-//            self.getTownShortData(9, server_key, function (err) {
-//                log.info('Finished Short '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//    }
-//
-//    if (time === 41 || putAll) {
-//        log.info('push Shortest');
-//        self.asyncTasks.push(function (callback) {
-//            self.getTownShortestData(9, server_key, function (err) {
-//                log.info('Finished Shortest '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//        log.info('push Current');
-//        self.asyncTasks.push(function (callback) {
-//            self.getTownCurrentData(9, server_key, function (err) {
-//                log.info('Finished Current '+new Date());
-//                if (err) {
-//                    log.error(err);
-//                }
-//                callback();
-//            });
-//        });
-//    }
-//
-//    log.info('wait '+self.asyncTasks.length+' tasks');
-//};
-
 /**
  *
  * @param items
@@ -2109,6 +1963,20 @@ Manager.prototype.checkTimeAndRequestTask = function (putAll) {
     var hours = (new Date()).getUTCHours();
 
     log.verbose('check time and request task');
+
+    if (time === 5 || putAll) {
+        if (hours === 8 || hours === 20 || putAll) {
+            log.info('push kaq hourly forecast');
+            self.asyncTasks.push(function getKaqHourlyForecast(callback) {
+                var KaqHourlyForecast = require('./kaq.hourly.forecast.controller');
+                var ctrl = new KaqHourlyForecast();
+                ctrl.do(new Date(), err=> {
+                    log.info('kaq hourly forecast done');
+                    callback();
+                });
+            });
+        }
+    }
 
     if (time === 2 || putAll) {
         //spend long time

--- a/server/controllers/controllerTown.js
+++ b/server/controllers/controllerTown.js
@@ -240,17 +240,6 @@ function ControllerTown() {
                                 }
                             );
                         });
-                    },
-                    function (callback) {
-                        var date = self._getCurrentTimeValue(+9).date;
-                        KecoController.getDustFrcst({region:req.params.region, city:req.params.city}, date, function (err, results) {
-                            if (err) {
-                                return callback(err);
-                            }
-                            log.info('K DATA[DustFrcst] sID='+req.sessionID);
-                            req.dustFrcstList = results;
-                            callback();
-                        });
                     }
                     ],
                     function(err){
@@ -2300,6 +2289,13 @@ function ControllerTown() {
         meta.region = req.params.region;
         meta.city = req.params.city;
         meta.town = req.params.town;
+
+        if (req.query.airForecastSource !== 'airkorea') {
+            log.info('>sID=',req.sessionID,
+                'skip get keco dust forecast air forecast source='+req.query.airForecastSource, meta);
+            return next();
+        }
+
         log.info('>sID=',req.sessionID, meta);
 
         if (!req.midData)  {
@@ -2898,6 +2894,9 @@ function ControllerTown() {
 
                         if (pollutant.daily) {
                             pollutant.daily.forEach(function (item) {
+                                if (item.hasOwnProperty('grade')) {
+                                    item.str = UnitConverter.airGrade2Str(airUnit, item.grade, res);
+                                }
                                 if (item.hasOwnProperty('minGrade')) {
                                     item.minStr = UnitConverter.airGrade2Str(airUnit, item.minGrade, res);
                                 }

--- a/server/controllers/img.hourly.forecast.controller.js
+++ b/server/controllers/img.hourly.forecast.controller.js
@@ -1,0 +1,149 @@
+/**
+ * Created by aleckim on 2018. 3. 17.
+ */
+
+"use strict";
+
+const async = require('async');
+const MsrStn = require('../models/modelMsrStnInfo');
+
+class ImgHourlyForecastController {
+    constructor(imgPaths, collection) {
+        this.imgPaths = imgPaths;
+        this.collection = collection
+    }
+
+    _getMsrStn(callback) {
+        MsrStn.find().lean().exec(function (err, stnList) {
+            if (err) {
+                return callback(err);
+            }
+            if (stnList.length === 0) {
+                return callback(new Error("airkroea msr stn list length is 0"));
+            }
+            callback(null, stnList);
+        });
+    }
+
+    _updateDb(obj, callback) {
+        this.collection.update({stationName: obj.stationName, date: obj.date, code: obj.code},
+            obj,
+            {upsert:true},
+            callback);
+    }
+
+    _makeHourForecast(stationName, code, pubDate, hourData) {
+        return {
+            stationName: stationName,
+            date: new Date(hourData.date),
+            code: code,
+            val: hourData.val,
+            dataTime: hourData.date,
+            pubDate: pubDate
+        };
+    }
+
+    _updateForecastList(forecastsObj, callback) {
+        async.map(forecastsObj.hourly,
+            (hourData, callback) => {
+                var hourForecast;
+                try {
+                    if (hourData.val == undefined) {
+                        log.warn("invalid val "+ forecastsObj.stationName+ " "+forecastsObj.code+" "+hourData.date);
+                    }
+                    else {
+                        hourForecast = this._makeHourForecast(
+                            forecastsObj.stationName,
+                            forecastsObj.code,
+                            forecastsObj.pubDate,
+                            hourData);
+                    }
+                }
+                catch(err) {
+                    log.error(err);
+                }
+                if (hourForecast) {
+                    this._updateDb(hourForecast, function (err) {
+                        if (err)  {
+                            log.error(err);
+                        }
+                        callback();
+                    });
+                }
+                else {
+                    callback();
+                }
+            }, callback);
+    }
+
+    _updateDustInfo(stn, code, callback) {
+    }
+
+    /**
+     * code(pm10, pm25, o3) 별로 모든 stn의 예보를 업데이트 요청한다.
+     * @param stnList
+     * @param code
+     * @param callback
+     * @private
+     */
+    _updateHourlyForecastEach(stnList, code, callback) {
+        log.info('update hourly forecast code:'+code);
+
+        async.mapSeries(stnList,
+            (stn, callback) => {
+                this._updateDustInfo(stn, code, callback);
+            },
+            callback);
+    }
+
+    _updateHourlyForecast(stnList, callback) {
+        log.info('update hourly forecast stnList:'+stnList.length);
+
+        async.mapSeries(['pm10', 'pm25'],
+            (code, callback) => {
+                this._updateHourlyForecastEach(stnList, code, callback);
+            },
+            callback);
+    }
+
+    _removeOldData() {
+        var removeDate = new Date();
+        removeDate.setDate(removeDate.getDate()-1);
+        this.collection.remove({"date": {$lt:removeDate}}, function (err) {
+            log.info('removed hourly forecast from date : ' + removeDate);
+            if(err) {
+                log.error(err);
+            }
+        });
+    }
+
+    _checkHourlyForecast(dataTime, callback) {
+        let query = {pubDate: dataTime};
+        this.collection.find(query).lean().exec((err, list)=>{
+            if (err) {
+                return callback(err);
+            }
+            let pm10List = list.filter((obj)=> {
+                return obj.code === 'pm10';
+            });
+            let pm25List = list.filter((obj)=> {
+                return obj.code === 'pm25';
+            });
+            if (pm10List.length > 0 && pm25List.length > 0) {
+                err = 'skip';
+            }
+            return callback(err, list);
+        });
+    }
+
+    do(dataTime) {
+    }
+
+    getForecast(stationName, callback) {
+        this.collection.find({stationName: stationName}).lean().sort({date:1}).exec(function (err, forecastList) {
+            callback(err, forecastList);
+        });
+    }
+}
+
+module.exports = ImgHourlyForecastController;

--- a/server/controllers/kaq.dust.image.controller.js
+++ b/server/controllers/kaq.dust.image.controller.js
@@ -21,8 +21,8 @@ class KaqDustImageController{
             PM25 : [50, 62, 76, 90, 102, 114, 128, 140, 152, 164, 178, 190, 204, 216, 228, 240, 254, 268, 280, 292, 304, 318]
         };
         this.value = {
-            PM10 : [999, 120, 116, 112, 108, 104, 100, 96, 92, 88, 84, 80, 76, 72, 68, 64, 60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4, 0],
-            PM25 : [999, 80, 76, 72, 68, 64, 60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4, 0]
+            PM10 : [150, 120, 116, 112, 108, 104, 100, 96, 92, 88, 84, 80, 76, 72, 68, 64, 60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4, 0],
+            PM25 : [100, 80, 76, 72, 68, 64, 60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4, 0]
         };
         this.parser = new libKaqImageParser();
         this.imagePixels = {};
@@ -376,11 +376,12 @@ class KaqDustImageController{
      */
     getDustImage(imgPaths, callback) {
         log.info('KAQ Image > get dust image -----------');
-        async.applyEach(
+        async.waterfall(
             [
                 (cb)=>{
                     if (imgPaths.pm10 == undefined) {
-                        return cb();
+                        log.error('KAQ PM10 Image > image path is undefined');
+                        return cb(null);
                     }
                     log.info("KAQ Image > pm10 path: "+imgPaths.pm10);
                     this.parseMapImage(imgPaths.pm10, 'image/gif', (err, pixelMap)=>{
@@ -392,22 +393,27 @@ class KaqDustImageController{
                         this.imagePixels.PM10 = {};
                         this.imagePixels.PM10.pubDate = imgPaths.pubDate;
                         this.imagePixels.PM10.data = pixelMap;
-                        return cb();
+                        return cb(null, pixelMap);
                     });
                 },
                 (pixelMap, cb)=>{
+                    if (pixelMap  == undefined) {
+                        log.error('KAQ PM10 Image > pixelMap is undefined');
+                        return cb(null);
+                    }
                     this.makeColorTable('PM10', pixelMap, (err)=>{
                         if(err){
-                            log.error('KAQ Image > Failed to get Grade Table');
+                            log.error('KAQ PM10 Image > Failed to get Grade Table');
                             return cb(err);
                         }
 
-                        return cb();
+                        return cb(null);
                     });
                 },
                 (cb)=>{
                     if (imgPaths.pm25 == undefined) {
-                        return cb();
+                        log.error('KAQ PM25 Image > image path is undefined');
+                        return cb(null);
                     }
                     log.info("KAQ Image > pm25 path: "+imgPaths.pm25);
                     this.parseMapImage(imgPaths.pm25, 'image/gif', (err, pixelMap)=>{
@@ -418,17 +424,21 @@ class KaqDustImageController{
                         this.imagePixels.PM25 = {};
                         this.imagePixels.PM25.pubDate = imgPaths.pubDate;
                         this.imagePixels.PM25.data = pixelMap;
-                        return cb();
+                        return cb(null, pixelMap);
                     });
                 },
                 (pixelMap, cb)=>{
+                    if (pixelMap  == undefined) {
+                        log.error('KAQ PM25 Image > pixelMap is undefined');
+                        return cb(null);
+                    }
                     this.makeColorTable('PM25', pixelMap, (err)=>{
                         if(err){
                             log.error('KAQ Image > Failed to get PM25 Grade Table');
                             return cb(err);
                         }
 
-                        return cb();
+                        return cb(null);
                     });
                 }
             ],

--- a/server/controllers/kaq.hourly.forecast.controller.js
+++ b/server/controllers/kaq.hourly.forecast.controller.js
@@ -1,0 +1,127 @@
+/**
+ * Created by aleckim on 2018. 3. 17.
+ */
+
+"use strict";
+
+const async = require('async');
+
+const kmaTimeLib = require('../lib/kmaTimeLib');
+const config = require('../config/config');
+
+const DustImageController = require('./kaq.dust.image.controller');
+const ModelHourlyForecast = require('../models/kaq.hourly.forecast.model');
+const S3 = require('../s3/controller.s3');
+
+const ImgHourlyForecastController = require('./img.hourly.forecast.controller');
+
+class KaqHourlyForecastController extends ImgHourlyForecastController {
+    constructor(imgPaths) {
+        super(imgPaths, ModelHourlyForecast);
+        this.dustImageMgr;
+        this.region = config.image.kaq_korea_image.region;
+        this.bucketName = config.image.kaq_korea_image.bucketName;
+        this.s3 = new S3(this.region, this.bucketName);
+        this.s3Url = 'https://s3.'+this.region+'.amazonaws.com/'+this.bucketName+'/';
+    }
+
+    _updateDustInfo(stn, code, callback) {
+        async.waterfall([
+                (callback) => {
+                    this.dustImageMgr
+                        .getDustInfo(stn.geo[1],
+                            stn.geo[0],
+                            code.toUpperCase(),
+                            'airkorea',
+                            function (err, hourlyForecastObj) {
+                                if(err){
+                                    return callback(err);
+                                }
+                                hourlyForecastObj.stationName = stn.stationName;
+                                hourlyForecastObj.code = code;
+                                callback(err, hourlyForecastObj);
+                            });
+                },
+                (hourlyForecasts, callback) => {
+                    if (hourlyForecasts == undefined) {
+                        log.error('pass update forecast list hourlyForecasts is undefined');
+                        return callback();
+                    }
+                    log.debug(JSON.stringify(hourlyForecasts));
+                    this._updateForecastList(hourlyForecasts, callback);
+                }
+            ],
+            (err)=>{
+                if(err) {
+                    log.warn('Invalid geocode for dust forecast:', stn.geo[1], stn.geo[0]);
+                }
+                callback();
+            });
+    }
+
+    _getPubdate(folderName) {
+       let date = new Date(folderName);
+       date.setHours(date.getHours()+20);
+       return kmaTimeLib.convertDateToYYYY_MM_DD_HHoMM(date);
+    }
+
+    _getImgPaths(dataTime, callback) {
+        this.s3.ls()
+            .then(results => {
+                log.debug(JSON.stringify({'s3list':results}));
+
+                let imgPaths = {};
+                let folderList = results.CommonPrefixes.map(obj => {
+                    return obj.Prefix;
+                });
+                let folderName = folderList[folderList.length-1];
+                ['pm10', 'pm25'].forEach(value => {
+                    let name = value.toUpperCase();
+                    name = name === 'PM25'?'PM2_5':name;
+                    imgPaths[value] = this.s3Url+folderName+name+'.09km.animation.gif';
+                });
+
+                imgPaths.pubDate = this._getPubdate(folderName.slice(0, folderName.length-6));
+
+                callback(null, imgPaths);
+            })
+            .catch(err => {
+                log.error(err);
+                callback(err);
+            });
+    }
+
+    do(dataTime, callback) {
+        async.waterfall(
+            [
+                callback => {
+                    this._getImgPaths(dataTime, callback);
+                },
+                (imgPaths, callback) => {
+                    log.info(JSON.stringify({imagePaths: imgPaths}));
+                    this.dustImageMgr = new DustImageController();
+                    this.dustImageMgr.getDustImage(imgPaths, callback);
+                },
+                (result, callback) => {
+                    this._getMsrStn(callback);
+                },
+                (stnList, callback) => {
+                    this._updateHourlyForecast(stnList, callback);
+                }
+            ],
+            err => {
+                log.info("Finish update kaq hourly forecast");
+                delete this.dustImageMgr;
+                this._removeOldData();
+                if (callback) {
+                    return callback(err);
+                }
+                else if (err && err !== 'skip') {
+                    log.error(err);
+                }
+            }
+        );
+    }
+}
+
+module.exports = KaqHourlyForecastController;

--- a/server/models/kaq.hourly.forecast.model.js
+++ b/server/models/kaq.hourly.forecast.model.js
@@ -1,0 +1,21 @@
+/**
+ * Created by aleckim on 2018. 1. 24..
+ */
+
+'use strict';
+
+var mongoose = require('mongoose');
+
+var kaqHourlyForecastSchema = new mongoose.Schema({
+    stationName: String, //unique
+    date: Date,
+    code: String, //'pm10', 'pm25', 'o3', 'no2', 'co', 'so2'
+    val: Number, //
+    dataTime: String,
+    pubDate: String,
+});
+
+kaqHourlyForecastSchema.index({stationName: 'hashed'});
+kaqHourlyForecastSchema.index({date: 1});
+
+module.exports = mongoose.model('KaqHourlyForecast', kaqHourlyForecastSchema);

--- a/server/routes/v000901/route.kma.addr.js
+++ b/server/routes/v000901/route.kma.addr.js
@@ -55,7 +55,7 @@ var routerList = [cTown.checkQueryValidation, cTown.checkParamValidation, cTown.
     cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather, cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
     cTown.mergeByShortest, cTown.adjustShort, cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo,
     cTown.getPastMid, cTown.mergeMidWithShort, cTown.updateMidTempMaxMin, cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco,
-    cTown.getKecoDustForecast, cTown.getRiseSetInfo, cTown.insertIndex, cTown.makeAirInfo, cTown.AirkoreaForecast, cTown.insertSkyIcon,
+    cTown.getKecoDustForecast, cTown.getRiseSetInfo, cTown.insertIndex, cTown.makeAirInfo, cTown.AirForecast, cTown.insertSkyIcon,
     cTown.setYesterday, cTown.convertUnits, cTown.insertStrForData, cTown.getSummaryAfterUnitConverter,
     cTown.makeResult, cTown.sendResult];
 

--- a/server/routes/v000902/route.kma.v000902.js
+++ b/server/routes/v000902/route.kma.v000902.js
@@ -55,7 +55,7 @@ var routerList = [cTown.checkQueryValidation, cTown.checkParamValidation, cTown.
     cTown.mergeCurrentByStnHourly, cTown.getKmaStnMinuteWeather, cTown.convert0Hto24H, cTown.mergeShortWithCurrentList,
     cTown.mergeByShortest, cTown.adjustShort, cTown.getMid, cTown.getMidRss, cTown.convertMidKorStrToSkyInfo,
     cTown.getPastMid, cTown.mergeMidWithShort, cTown.updateMidTempMaxMin, cTown.getLifeIndexKma, cTown.getHealthDay, cTown.getKeco,
-    cTown.getKecoDustForecast, cTown.getRiseSetInfo, cTown.insertIndex, cTown.makeAirInfo, cTown.AirkoreaForecast, cTown.insertSkyIconLowCase,
+    cTown.getKecoDustForecast, cTown.getRiseSetInfo, cTown.insertIndex, cTown.makeAirInfo, cTown.AirForecast, cTown.insertSkyIconLowCase,
     cTown.setYesterday, cTown.convertUnits, cTown.insertStrForData, cTown.getSummaryAfterUnitConverter,
     cTown.makeResult, cTown.sendResult];
 

--- a/server/s3/controller.s3.js
+++ b/server/s3/controller.s3.js
@@ -1,0 +1,76 @@
+/**
+ * Created by dhkim2 on 2018-03-11.
+ */
+
+"use strict";
+
+const https = require('https');
+const http = require('http');
+const request = require('request');
+const AWS = require('aws-sdk');
+
+class ControllerS3 {
+    constructor(region, bucketName) {
+        //AWS.config.region = 'ap-northeast-2';
+        AWS.config.region = region;
+        this.s3 = new AWS.S3({params: {Bucket: bucketName}});
+    }
+
+    /**
+     *
+     * @param folderName it has '/' at last of string
+     * @returns {Promise<PromiseResult<S3.ListObjectsV2Output, AWSError>>}
+     */
+    ls(folderName) {
+        let opts = {
+            MaxKeys: 2147483647, // Maximum allowed by S3 API
+            Delimiter: '/'
+        };
+        if (folderName && folderName.length > 0) {
+            opts.Prefix = folderName;
+        }
+        return this.s3.listObjectsV2(opts).promise();
+    }
+
+    get(key) {
+        return this.s3.getObject({Key: key}).promise();
+    }
+
+    upload(url, s3Path) {
+        let key = s3Path;
+        console.info({url:url, s3Path: s3Path});
+
+        let self = this;
+
+        return new Promise((resolve, reject) => {
+            request({
+                method: 'GET',
+                url: url,
+                encoding: null // returns body as Buffer
+            }, (e, res, body) => {
+                if (e) {
+                    return reject(e);
+                } // something went wrong during fetch
+                if (res.statusCode.toString().slice(0, 1) !== '2') { // server respond with unexpected status code
+                    return reject(new Error(`Unexpected status code ${res.statusCode}`));
+                }
+
+                self.s3.upload({
+                    // Bucket: process.env.S3_BUCKET,
+                    Key: key,
+                    ContentType: res.headers['content-type'] || 'application/octet-stream',
+                    ACL: 'public-read',
+                    Body: body
+                }, (e, data) => {
+                    if (e) {
+                        return reject(e);
+                    }
+
+                    resolve(data);
+                });
+            });
+        });
+    }
+}
+
+module.exports = ControllerS3;

--- a/server/s3/controller.s3.js
+++ b/server/s3/controller.s3.js
@@ -11,7 +11,6 @@ const AWS = require('aws-sdk');
 
 class ControllerS3 {
     constructor(region, bucketName) {
-        //AWS.config.region = 'ap-northeast-2';
         AWS.config.region = region;
         this.s3 = new AWS.S3({params: {Bucket: bucketName}});
     }

--- a/server/test/e2e_local/test.e2e.kaq.hourly.forecast.controller.js
+++ b/server/test/e2e_local/test.e2e.kaq.hourly.forecast.controller.js
@@ -1,0 +1,48 @@
+/**
+ * Created by aleckim on 18. 3. 20..
+ */
+
+"use strict";
+
+const Logger = require('../../lib/log');
+global.log  = new Logger(__dirname + "/debug.log");
+
+const controllerManager = require('../../controllers/controllerManager');
+global.manager = new controllerManager();
+
+const assert  = require('assert');
+const mongoose = require('mongoose');
+
+const KaqHourlyForecastController = require('../../controllers/kaq.hourly.forecast.controller');
+
+
+describe('e2e test - kaq hourly forecast controller', function() {
+    before(function (done) {
+        this.timeout(10*1000);
+        mongoose.Promise = global.Promise;
+        mongoose.connect('mongodb://localhost/todayweather', function(err) {
+            if (err) {
+                console.error('Could not connect to MongoDB!');
+            }
+            done();
+        });
+        mongoose.connection.on('error', function(err) {
+            if (err) {
+                console.error('MongoDB connection error: ' + err);
+                done();
+            }
+        });
+    });
+
+    it('test kaq hourly forecast do', function (done) {
+        this.timeout(10*60*1000);
+        let ctrl = new KaqHourlyForecastController();
+        ctrl.do(new Date(), err=> {
+            if (err) {
+                console.error(err);
+            }
+            done();
+        });
+    });
+});
+


### PR DESCRIPTION
- AirkoreaHourlyForecastController
  - ImgHourlyForecastController라는 부모 클래스 생성하고, Kaq와 같이 사용
- controllerManager
  - 사용하지 않는 checkTimeAndPushTask 제거
  - _requestApi에서 결과 응답을 받지 못하여 KaqHourlyForecast를 direct call하게 구현
- controllerTown, controllerTown24
  - request query에 airForecastSource 값에 따라 airkorea, kaq 사용하게 구현
  - KecoController.getDustFrcst를 airForecastSource query에 따라 사용되게 변경
  - 시간별 예보는 24시간만 전달
  - pollutant.daily에 val(평균값) 추가
  - rename AirkoreaForecast -> AirForecast
- KaqDustImageController
  - value max 조정