### PR TITLE
TW-95 미세먼지 페이지에서 시간별 예보 표시 #1849

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -421,13 +421,16 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   visibility: hidden;
 }
 
-.axis .minor line {
-  stroke: #777;
-  stroke-dasharray: 2,2;
-}
-
-.x.axis line {
-  stroke: #fff;
+.x-axis {
+  path, line {
+    stroke: #666666;
+    shape-rendering: crispEdges;
+  }
+  text {
+    stroke-width: 0px;
+    fill: #444;
+    font-size: 13px;
+  }
 }
 
 /* tabs */

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -1315,6 +1315,164 @@ angular.module('starter', [
             };
         });
 
+        $compileProvider.directive('ngAirChart', function() {
+            return {
+                restrict: 'A',
+                transclude: true,
+                link: function (scope, iElement) {
+                    var margin = {top: -5, right: 5, bottom: 35, left: 5};
+                    var width, height, x, y;
+                    var svg;
+
+                    function initSvg() {
+                        x = d3.scale.ordinal().rangeBands([margin.left, width - margin.right]);
+                        y = d3.scale.linear().range([height - margin.bottom, margin.top]);
+
+                        if (svg != undefined) {
+                            svg.selectAll("*").remove();
+                            svg.attr('width', width)
+                                .attr('height', height);
+                        }
+                        else {
+                            svg = d3.select(iElement[0]).append('svg')
+                                .attr('width', width)
+                                .attr('height', height);
+                        }
+                    }
+
+                    scope.$watch(function () {
+                        return iElement[0].getBoundingClientRect().height;
+                    }, function(newValue) {
+                        if (newValue === 0 || height === newValue) {
+                            return;
+                        }
+                        width = iElement[0].getBoundingClientRect().width;
+                        height = iElement[0].getBoundingClientRect().height;
+
+                        console.log("air scope watch");
+
+                        if (!(scope.airChart == undefined)) {
+                            initSvg();
+                            chart();
+                        }
+                    });
+
+                    var chart = function () {
+                        var data = scope.airChart;
+                        if (x == undefined || y == undefined || svg == undefined || data == undefined) {
+                            return;
+                        }
+
+                        // min과 max의 중간값이 chart의 중간에 위치하도록 조정
+                        var minValue = d3.min(data, function (d) { return d.val; });
+                        var maxValue = d3.max(data, function (d) { return d.val; });
+                        if (minValue === maxValue) {
+                            maxValue = minValue * 2;
+                            minValue = 0;
+                        }
+                        else {
+                            minValue = Math.max(0, minValue - (maxValue - minValue) / 3);
+                        }
+                        x.domain(data.map(function(d) { return d.date; }));
+                        y.domain([0, maxValue - minValue]).nice();
+
+                        var xAxis = d3.svg.axis()
+                            .tickFormat(function(d, i) {
+                                var hour = parseInt(d.substr(11,2));
+                                if (hour === 0 || hour % 3 === 0) {
+                                    return hour + scope.strHour;
+                                }
+                                return "";
+                            })
+                            .outerTickSize(0)
+                            .scale(x)
+                            .orient('bottom');
+
+                        d3.svg.axis()
+                            .scale(y)
+                            .orient('left');
+
+                        var bottom = height - margin.bottom;
+                        var x_axis = svg.append('g')
+                            .attr('class', 'x-axis')
+                            .attr('transform', 'translate(0,' + bottom + ')')
+                            .call(xAxis);
+
+                        x_axis.selectAll('.x-axis .tick text')
+                            .call(function(t) {
+                                t.each(function (d) {
+                                    var hour = parseInt(d.substr(11,2));
+                                    if (hour === 0) {
+                                        var self = d3.select(this);
+                                        self.append('tspan')
+                                            .attr('x', function (d, i) {
+                                                return x.rangeBand() * i;
+                                            })
+                                            .attr('dy', parseFloat(self.attr('dy')) * 1.5 + 'em')
+                                            .text(d.substr(5,2)+'.'+d.substr(8,2));
+                                    }
+                                })
+                            });
+
+                        var rects = svg.selectAll('.rect')
+                            .data(data);
+
+                        rects.enter().append('rect')
+                            .attr('class', 'chart-bar');
+
+                        rects.exit().remove();
+
+                        rects.attr('x', function (d, i) {
+                                return x.rangeBand() * i + x.rangeBand() / 2 - 1;
+                            })
+                            .attr('width', x.rangeBand() - 2)
+                            .attr('y', 0)
+                            .attr('height', 0)
+                            .style('fill', function (d) {
+                                return scope.grade2Color(d.grade);
+                            })
+                            .style('fill-opacity', function (d, i) {
+                                if (i === 12) {
+                                    return 1.0;
+                                }
+                                return 0.6;
+                            })
+                            .attr('y', function (d) {
+                                if (d.val == undefined) {
+                                    return y(0);
+                                }
+                                return y(d.val-minValue);
+                            })
+                            .attr('height', function (d) {
+                                if (d.val == undefined) {
+                                    return 0;
+                                }
+                                return y(0) - y(d.val-minValue);
+                            });
+                    };
+
+                    scope.$watch('airWidth', function(newValue) {
+                        if (newValue == undefined || newValue == width) {
+                            console.log('new value is undefined or already set same width='+width);
+                            return;
+                        }
+                        console.log('update airWidth='+newValue);
+                        width = newValue;
+                        return;
+                    });
+
+                    scope.$watch('airChart', function (newVal) {
+                        if (newVal == undefined) {
+                            return;
+                        }
+                        console.log("update airChart");
+                        initSvg();
+                        chart();
+                    });
+                }
+            };
+        });
+
         $compileProvider.directive('tabsShrink', function($document) {
             return {
                 restrict: 'A',

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -73,18 +73,10 @@
                 </div>
             </div>
         </div>
-        <div class="card" ng-if="hourlyForecast && hourlyForecast.length > 1">
+        <div class="card" ng-if="airChart && airChart.length > 1">
             <div class="card-title">{{'LOC_HOURLY_AQI_FORECAST'|translate}} (beta)</div>
-            <div class="card-scroll">
-                <table class="rowgroup-vspacing-aqi-box">
-                    <tr>
-                        <td ng-repeat="obj in hourlyForecast" style="min-width: 48px;">
-                            <p>{{obj.date.substr(11,2)}}{{'LOC_HOUR'|translate}}</p>
-                            <i ng-bind-html="getSentimentIcon(obj.grade)" class="material-icons" ng-style="{'color': grade2Color(obj.grade)}"></i><br>
-                            <span ng-style="{'color': grade2Color(obj.grade)}">{{obj.val == undefined?"-":obj.val}}</span>
-                        </td>
-                    </tr>
-                </table>
+            <div id="chartScroll" class="chart-scroll">
+                <div ng-air-chart class="chart-content" ng-style="{'height':chartAirHeight+'px'}"></div>
             </div>
         </div>
         <div class="card" ng-if="dayForecast && dayForecast.length">


### PR DESCRIPTION
TW-95 미세먼지 페이지에서 시간별 예보 표시 #1849
* 상세대기정보에서 통합대기를 맨 앞에 표시
* 시간별대기예보를 차트로 표시하도록 지원
 - airInfo.pollutant.hourly 중에서 과거 11개 + 현재 + 미래 12개의 데이터로 표시
 - 예보 데이터가 없는 경우에는 미래 12개의 데이터를 none 값으로 처리
 - min과 max의 중간값이 차트 높이의 중간에 위치하도록 보정
 - 현재 데이터의 경우 다른 시간 데이터와 구분하기 위해 opacity를 1로 설정해서 진하게 표시