### PR TITLE
TW-95 미세먼지 페이지에서 시간별 예보 표시 #1849

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -1358,23 +1358,16 @@ angular.module('starter', [
                     });
 
                     var chart = function () {
-                        var data = scope.airChart;
+                        var data = scope.airChart.data;
                         if (x == undefined || y == undefined || svg == undefined || data == undefined) {
                             return;
                         }
 
-                        // min과 max의 중간값이 chart의 중간에 위치하도록 조정
-                        var minValue = d3.min(data, function (d) { return d.val; });
+                        // aqiStandard의 max와 data의 (max+여백) 중 큰 값으로 사용
                         var maxValue = d3.max(data, function (d) { return d.val; });
-                        if (minValue === maxValue) {
-                            maxValue = minValue * 2;
-                            minValue = 0;
-                        }
-                        else {
-                            minValue = Math.max(0, minValue - (maxValue - minValue) / 3);
-                        }
+                        maxValue = Math.max(scope.airChart.maxValue, maxValue + maxValue/10);
                         x.domain(data.map(function(d) { return d.date; }));
-                        y.domain([0, maxValue - minValue]).nice();
+                        y.domain([0, maxValue]).nice();
 
                         var xAxis = d3.svg.axis()
                             .tickFormat(function(d, i) {
@@ -1389,6 +1382,7 @@ angular.module('starter', [
                             .orient('bottom');
 
                         d3.svg.axis()
+                            .outerTickSize(0)
                             .scale(y)
                             .orient('left');
 
@@ -1398,6 +1392,17 @@ angular.module('starter', [
                             .attr('transform', 'translate(0,' + bottom + ')')
                             .call(xAxis);
 
+                        x_axis.selectAll('.x-axis .tick line')
+                            .call(function(t) {
+                                t.each(function (d, i) {
+                                    if (i === 12) {
+                                        var self = d3.select(this);
+                                        self.attr('y1', -bottom)
+                                            .attr('stroke', '#000')
+                                            .attr('stroke-width', '2px');
+                                    }
+                                })
+                            });
                         x_axis.selectAll('.x-axis .tick text')
                             .call(function(t) {
                                 t.each(function (d) {
@@ -1441,13 +1446,13 @@ angular.module('starter', [
                                 if (d.val == undefined) {
                                     return y(0);
                                 }
-                                return y(d.val-minValue);
+                                return y(d.val);
                             })
                             .attr('height', function (d) {
                                 if (d.val == undefined) {
                                     return 0;
                                 }
-                                return y(0) - y(d.val-minValue);
+                                return y(0) - y(d.val);
                             });
                     };
 

--- a/client/www/js/controller.air.js
+++ b/client/www/js/controller.air.js
@@ -222,10 +222,13 @@ angular.module('controller.air', [])
                             });
 
                             // 과거 11개 + 현재 + 미래 12개 표시
-                            $scope.airChart = new Array(24);
+                            $scope.airChart = {
+                                data: new Array(24),
+                                maxValue: $scope.aqiMaxValue[aqiCode]
+                            };
                             for (var i = 0; i < 24; i++) {
-                                $scope.airChart[i] = pollutant.hourly[index - 12 + i];
-                                if ($scope.airChart[i] == undefined) {
+                                $scope.airChart.data[i] = pollutant.hourly[index - 12 + i];
+                                if ($scope.airChart.data[i] == undefined) {
                                     var date = new Date(pollutant.hourly[index].date);
                                     date.setHours(date.getHours() - 12 + i);
                                     var pad = function(num) {
@@ -233,7 +236,7 @@ angular.module('controller.air', [])
                                         return s.substr(s.length - 2);
                                     };
 
-                                    $scope.airChart[i] = new Object({
+                                    $scope.airChart.data[i] = new Object({
                                         date: [date.getFullYear(), pad(date.getMonth() + 1), pad(date.getDate())].join('-') + ' '
                                                 + [pad(date.getHours()), pad(date.getMinutes())].join(':')
                                     });

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -20,6 +20,15 @@ angular.module('controller.tabctrl', [])
                     "co" : [0, 2, 9, 15, 50],           //ppm   (avg 1h)
                     "so2" : [0, 0.02, 0.05, 0.15, 1],   //ppm   (avg 1h)
                     "aqi" : [0, 50, 100, 250, 500]      //index
+                },
+                "maxValue": {
+                    "pm25" : 100,
+                    "pm10" : 150,
+                    "o3" : 0.15,
+                    "no2" : 0.2,
+                    "co" : 15,
+                    "so2" : 0.15,
+                    "aqi" : 250
                 }
             },
             "airkorea_who": {
@@ -33,6 +42,15 @@ angular.module('controller.tabctrl', [])
                     "co" : [0, 2, 9, 15, 50],           //ppm
                     "so2" : [0, 0.02, 0.05, 0.15, 1],   //ppm
                     "aqi" : [0, 50, 100, 250, 500]      //ppm
+                },
+                "maxValue": {
+                    "pm25" : 50,
+                    "pm10" : 100,
+                    "o3" : 0.15,
+                    "no2" : 0.2,
+                    "co" : 15,
+                    "so2" : 0.15,
+                    "aqi" : 250
                 }
             },
             "airnow": {
@@ -52,6 +70,15 @@ angular.module('controller.tabctrl', [])
                     //"o3" : [0, 54, 124, 164, 204, 404, 604],              //ppb (avg 8h, 1h)
                     //"no2" : [0, 53, 100, 360, 649, 1249, 2049],           //ppb (avg 1h)
                     //"so2" : [0, 35, 75, 185, 304, 604, 1004],             //ppb (avg 1h, 24h)
+                },
+                "maxValue": {
+                    "pm25" : 250.4,
+                    "pm10" : 424,
+                    "o3" : 0.404,
+                    "no2" : 1.249,
+                    "co" : 30.4,
+                    "so2" : 0.604,
+                    "aqi" : 300
                 }
             },
             "aqicn": {
@@ -63,7 +90,7 @@ angular.module('controller.tabctrl', [])
                 "value": {
                     "pm25" : [0, 35, 75, 115, 150, 250, 500],               //ug/m3 (avg 1h)
                     "pm10" : [0, 50, 150, 250, 350, 420, 600],              //ug/m3 (avg 1h)
-                    "o3" : [0, 0.075, 0.093, 0.14, 0.187, 0.374 ,0.56],     //ppm (avg 1h)
+                    "o3" : [0, 0.075, 0.093, 0.14, 0.187, 0.374, 0.56],     //ppm (avg 1h)
                     "no2" : [0, 0.049, 0.097, 0.341, 0.584, 1.14, 1.87],    //ppm (avg 1h)
                     "co" : [0, 4, 8, 28, 48, 72, 120],                      //ppm (avg 1h)
                     "so2":[0, 0.052, 0.175, 0.227, 0.28, 0.56, 0.916],      //ppm (avg 1h)
@@ -72,6 +99,15 @@ angular.module('controller.tabctrl', [])
                     // "no2" : [0, 100, 200, 700, 1200, 2340, 3840], //ug/m3 (avg 1h)
                     // "co" : [0, 5, 10, 35, 60, 90, 150],          //mg/m3 (avg 1h)
                     // "so2" : [0, 150, 500, 650, 800, 1600, 2620],  //ug/m3
+                },
+                "maxValue": {
+                    "pm25" : 250,
+                    "pm10" : 420,
+                    "o3" : 0.374,
+                    "no2" : 1.14,
+                    "co" : 72,
+                    "so2" : 0.56,
+                    "aqi" : 300
                 }
             }
         };
@@ -1188,6 +1224,7 @@ angular.module('controller.tabctrl', [])
                 }
 
                 $scope.aqiStandard = list;
+                $scope.aqiMaxValue = aqiStandard[airUnit].maxValue;
                 console.info($scope.aqiStandard);
             }
             catch (err) {

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -73,7 +73,7 @@
                 </div>
             </div>
         </div>
-        <div class="card" ng-if="airChart && airChart.length > 1">
+        <div class="card" ng-if="airChart && airChart.data && airChart.data.length > 1">
             <div class="card-title">{{'LOC_HOURLY_AQI_FORECAST'|translate}} (beta)</div>
             <div id="chartScroll" class="chart-scroll">
                 <div ng-air-chart class="chart-content" ng-style="{'height':chartAirHeight+'px'}"></div>


### PR DESCRIPTION
TW-95 미세먼지 페이지에서 시간별 예보 표시 #1849
* 차트의 최대값 기준 변경
 - aqiStandard의 max와 data의 (max+여백) 중 큰 값으로 사용
* 차트에서 현재 데이터의 경우 rect 위쪽에 line으로 표시