### PR TITLE
TW-163 대기정보가 없는 경우 페이지 개선

### DIFF
--- a/client/www/js/controller.air.js
+++ b/client/www/js/controller.air.js
@@ -181,8 +181,9 @@ angular.module('controller.air', [])
                 var cityData = WeatherInfo.getCityOfIndex(cityIndex);
 
                 Util.ga.trackEvent('air', 'applyWeatherData');
-                var latestAirInfo =  cityData.airInfo.last || cityData.currentWeather.arpltn;
-                if (latestAirInfo[aqiCode+'Value'] == undefined && cityData.airInfo.pollutants[aqiCode] == undefined) {
+                var latestAirInfo = cityData.airInfo.last || cityData.currentWeather.arpltn;
+                if ((latestAirInfo.hasOwnProperty(aqiCode+'Value') && latestAirInfo[aqiCode+'Value'] == undefined)
+                    && (cityData.airInfo.hasOwnProperty('pollutants') && cityData.airInfo.pollutants[aqiCode] == undefined)) {
                     //skip current aqicode
                     var newAqiCode = ['pm25', 'pm10', 'o3', 'no2', 'co', 'so2', 'aqi'].find(function (propertyName) {
                         return (latestAirInfo[propertyName+'Value'] != undefined ||

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -39,7 +39,7 @@
                     <span class="icon-left ion-chevron-left"></span>
                 </div>
                 <div class="main-box" ng-if="airInfo" ng-style="{'color': grade2Color(airCodeGrade)}">
-                    <div class="main-box-air-title" ng-style="{'border-color': grade2Color(airCodeGrade, 'white')}">
+                    <div class="main-box-air-title" ng-style="{'border-color': grade2Color(airCodeGrade)}">
                         {{airCodeName|translate}}
                     </div>
                     <div class="main-box-air-content">
@@ -106,7 +106,7 @@
                 </table>
             </div>
         </div>
-        <div class="card" ng-if="airInfo">
+        <div class="card" ng-if="airInfo && airInfo.length > 0">
             <table class="colgroup-box">
                 <tr ng-if="airInfo.stationName">
                     <td>

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -95,7 +95,7 @@
                 </tr>
             </table>
         </div>
-        <div class="card" ng-if="showDetailWeather && !showHourlyAqiForecast() && currentWeather.arpltn">
+        <div class="card" ng-if="showDetailWeather && !showHourlyAqiForecast() && currentWeather.arpltn && currentWeather.arpltn.length > 0">
             <table class="rowgroup-vspacing-aqi-box">
                 <tr>
                     <td ng-if="currentWeather.arpltn.pm25Value" ng-click="goAirInfoPage('pm25')">
@@ -198,7 +198,7 @@
                 </tr>
             </table>
         </div>
-        <div class="card" ng-if="showDetailWeather && currentWeather.arpltn">
+        <div class="card" ng-if="showDetailWeather && currentWeather.arpltn && currentWeather.arpltn.length > 0">
             <div class="card-title">{{"LOC_DETAIL_AQI"|translate}}</div>
             <table class="colgroup-box">
                 <tr ng-if="currentWeather.arpltn.pm25Value != undefined">


### PR DESCRIPTION
TW-163 대기정보가 없는 경우 페이지 개선
* cityData.airInfo.last, cityData.currentWeather.arpltn가 비어있거나, cityData.airInfo.pollutants가 정의되어 있지 않은 경우 예외처리 추가
- 대기정보 페이지에서는 측정값이 없는 상태로 표시, 측정소 정보 숨김 처리
- 시간별날씨 페이지에서는 현재 대기정보, 상세 대기정보 숨김 처리