### PR TITLE
TW178-- loadWeatherData에서 NSLog disable

### DIFF
--- a/ios/widget/TodayViewController.m
+++ b/ios/widget/TodayViewController.m
@@ -450,7 +450,9 @@ static TodayViewController *todayVC = nil;
     tmpDataWD = [nssWeatherList dataUsingEncoding:NSUTF8StringEncoding];
     if(tmpDataWD)
         jsonDictWD = [NSJSONSerialization JSONObjectWithData:(NSData*)tmpDataWD options:0 error:&errorWD];
-    NSLog(@"User Default WD: %@", jsonDictWD);
+    
+    // Too many data causes crash, just use debug	
+    //NSLog(@"User Default WD: %@", jsonDictWD);
     
     mWeatherDataList    = [NSMutableArray array];
     
@@ -475,8 +477,8 @@ static TodayViewController *todayVC = nil;
             [mWeatherDataList addObject:nsdTmpDict];
         }
     }
-    
-    NSLog(@"[loadWeatherData] mWeatherDataList : %@", mWeatherDataList);
+    // Too many data causes crash, just use debug
+    //NSLog(@"[loadWeatherData] mWeatherDataList : %@", mWeatherDataList);
 }
 
 /********************************************************************


### PR DESCRIPTION
+ 	#TW-178 iOS Widget "로드할 수 없음"으로 표시됨
  - loadWeatherData에서 Dictionary 출력시 너무 많은 데이터는 buffer overflow를 유발함