### PR TITLE
TW-95 뉴욕지역 시간별날씨에서 대기정보 안보이는 문제, 대기오염물질이 0인경우 오류

### DIFF
--- a/client/www/js/controller.air.js
+++ b/client/www/js/controller.air.js
@@ -204,14 +204,19 @@ angular.module('controller.air', [])
                 $scope.currentPosition = cityData.currentPosition;
                 $scope.airInfo = latestAirInfo;
                 $scope.airCodeGrade = latestAirInfo[aqiCode+'Grade'];
-                $scope.airCodeValue = latestAirInfo[aqiCode+'Value'] || '-';
+                $scope.airCodeValue = (function() {
+                    if (latestAirInfo[aqiCode+'Value'] == undefined) {
+                        return '-';
+                    }
+                    return latestAirInfo[aqiCode+'Value'];
+                })();
                 $scope.airCodeStr = latestAirInfo[aqiCode+'Str'];
                 if (aqiCode === 'aqi') {
                     $scope.mainInfo = $scope.airCodeStr || '-';
                     $scope.airCodeStr = '';
                 }
                 else {
-                    $scope.mainInfo = $scope.airCodeValue || '-';
+                    $scope.mainInfo = $scope.airCodeValue;
                 }
 
                 $scope.airCodeActionGuide = latestAirInfo[aqiCode+'ActionGuide'];

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -95,7 +95,7 @@
                 </tr>
             </table>
         </div>
-        <div class="card" ng-if="showDetailWeather && !showHourlyAqiForecast() && currentWeather.arpltn && currentWeather.arpltn.date">
+        <div class="card" ng-if="showDetailWeather && !showHourlyAqiForecast() && currentWeather.arpltn && currentWeather.arpltn.dataTime">
             <table class="rowgroup-vspacing-aqi-box">
                 <tr>
                     <td ng-if="currentWeather.arpltn.pm25Value" ng-click="goAirInfoPage('pm25')">
@@ -198,7 +198,7 @@
                 </tr>
             </table>
         </div>
-        <div class="card" ng-if="showDetailWeather && currentWeather.arpltn && currentWeather.arpltn.date">
+        <div class="card" ng-if="showDetailWeather && currentWeather.arpltn && currentWeather.arpltn.dataTime">
             <div class="card-title">{{"LOC_DETAIL_AQI"|translate}}</div>
             <table class="colgroup-box">
                 <tr ng-if="currentWeather.arpltn.pm25Value != undefined">


### PR DESCRIPTION
#2274
- current.arpltn의 validation 체크를 date에서 dataTime으로 변경
  - 원래 dataTime으로 했어야 함
- 오염물질 측정치가 0인경우 '-'로 표시되는 문제 수정
  - ||가 아니라 undefined로 체크