### PR TITLE
TW-202 설정 화면에서 메뉴 리스트의 크기가 다른 문제

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -539,15 +539,6 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   left: 0px;
 }
 
-.menu-left .menu-content i {
-  padding-right: 16px;
-  padding-top: 10px;
-  position: absolute;
-  right: 0;
-  color: #333;
-  font-size: 14px;
-}
-
 /* start page */
 .start-content .item-input {
   padding-right: 16px;


### PR DESCRIPTION
TW-202 설정 화면에서 메뉴 리스트의 크기가 다른 문제
* 다음 depth가 있는 경우와 없는 경우 구분하지 않고 동일한 스타일로 변경
 - scss 파일 수정