### PR TITLE
TW-212 current data가 소실되면서 "Fail to parse sky=-1"가 발생하는 문제

### DIFF
--- a/server/controllers/kma/kma.town.current.controller.js
+++ b/server/controllers/kma/kma.town.current.controller.js
@@ -25,7 +25,7 @@ kmaTownCurrentController.prototype.saveCurrent = function(newData, callback){
 
     var pubDate = kmaTimelib.getKoreaDateObj(newData[0].pubDate);
 
-    log.info('KMA Town C> pubDate :', pubDate.toString());
+    log.debug('KMA Town C> pubDate :', pubDate.toString());
     //log.info('KMA Town C> db find :', coord);
 
     try{
@@ -33,7 +33,7 @@ kmaTownCurrentController.prototype.saveCurrent = function(newData, callback){
             function(item, cb){
                 var fcsDate = kmaTimelib.getKoreaDateObj(item.date + item.time);
                 var newItem = {mCoord: coord, pubDate: pubDate, fcsDate: fcsDate, currentData: item};
-                log.info('KMA Town C> item : ', JSON.stringify(newItem));
+                log.debug('KMA Town C> item : ', JSON.stringify(newItem));
 
                 modelKmaTownCurrent.update({mCoord: coord, fcsDate: fcsDate}, newItem, {upsert:true}, function(err){
                     if(err){
@@ -46,7 +46,7 @@ kmaTownCurrentController.prototype.saveCurrent = function(newData, callback){
                 });
             },
             function(err){
-                log.info('KMA Town C> finished to save town.current data');
+                log.debug('KMA Town C> finished to save town.current data');
                 callback(err);
             }
         );
@@ -177,7 +177,7 @@ kmaTownCurrentController.prototype.checkPubDate = function(model, srcList, dateS
 kmaTownCurrentController.prototype.remove = function (pubDate) {
     var limitedTime = kmaTimelib.getPast8DaysTime(pubDate);
     log.info('KMA Town C> remove item if it is before : ', limitedTime.toString());
-    modelKmaTownCurrent.remove({"pubDate": {$lte:limitedTime}}).exec();
+    modelKmaTownCurrent.remove({"fcsDate": {$lte:limitedTime}}).exec();
 };
 
 module.exports = kmaTownCurrentController;

--- a/server/controllers/kma/kma.town.mid.controller.js
+++ b/server/controllers/kma/kma.town.mid.controller.js
@@ -77,7 +77,7 @@ kmaTownMidController.prototype.saveMid = function(type, newData, overwrite, call
             }],
             function(err){
                 var limitedTime = kmaTimelib.getPast8DaysTime(pubDate);
-                log.info('KMA Town M> finished to save town.mid : ', type);
+                log.debug('KMA Town M> finished to save town.mid : ', type);
                 if(overwrite){
                     log.info('KMA Town M> remove all item before pubData: ', pubDate.toString());
                     db.remove({regId: regId, "fcsDate": {$lt:pubDate}}).exec();

--- a/server/controllers/kma/kma.town.short.controller.js
+++ b/server/controllers/kma/kma.town.short.controller.js
@@ -27,7 +27,7 @@ kmaTownShortController.prototype.saveShort = function(newData, callback){
             function(item, cb){
                 var fcsDate = kmaTimelib.getKoreaDateObj(item.date + item.time);
                 var newItem = {mCoord: coord, pubDate: pubDate, fcsDate: fcsDate, shortData: item};
-                log.info('KMA Town S> item : ', JSON.stringify(newItem));
+                log.debug('KMA Town S> item : ', JSON.stringify(newItem));
 
                 modelKmaTownShort.update({mCoord: coord, fcsDate: fcsDate}, newItem, {upsert:true}, function(err){
                     if(err){
@@ -40,7 +40,7 @@ kmaTownShortController.prototype.saveShort = function(newData, callback){
                 });
             },
             function(err){
-                log.info('KMA Town S> finished to save town.short data');
+                log.debug('KMA Town S> finished to save town.short data');
                 callback(err);
             }
         );

--- a/server/controllers/kma/kma.town.short.rss.controller.js
+++ b/server/controllers/kma/kma.town.short.rss.controller.js
@@ -489,7 +489,7 @@ TownRss.prototype.saveShortRssNewForm = function(index, newData, callback){
             function(item, cb){
                 var fcsDate = kmaTimelib.getKoreaDateObj(item.date);
                 var newItem = {mCoord: newData.mCoord, pubDate: pubDate, fcsDate: fcsDate, shortData: item};
-                log.info('KMA Town S-RSS> item : ', JSON.stringify(newItem));
+                log.debug('KMA Town S-RSS> item : ', JSON.stringify(newItem));
 
                 modelKmaTownShortRss.update({mCoord: newData.mCoord, fcsDate: fcsDate}, newItem, {upsert:true}, function(err){
                     if(err){
@@ -502,7 +502,7 @@ TownRss.prototype.saveShortRssNewForm = function(index, newData, callback){
                 });
             },
             function(err){
-                log.info('KMA Town S-RSS> finished to save town.short.rss data');
+                log.debug('KMA Town S-RSS> finished to save town.short.rss data');
                 callback(err);
             }
         );
@@ -766,7 +766,7 @@ TownRss.prototype.mainTask = function(completionCallback){
                         function(cb) {
                             self.checkPubDate(item, lastestPubDate, index, function(err, type){
                                 if(err){
-                                    log.info('shortRss : already latest data');
+                                    log.debug('shortRss : already latest data');
                                     return cb(err, undefined);
                                 }
                                 index++;

--- a/server/controllers/kma/kma.town.shortest.controller.js
+++ b/server/controllers/kma/kma.town.shortest.controller.js
@@ -18,7 +18,7 @@ kmaTownShortestController.prototype.saveShortest = function(newData, callback){
     };
 
     var pubDate = kmaTimelib.getKoreaDateObj(newData[0].pubDate);
-    log.info('KMA Town ST> pubDate :', pubDate.toString());
+    log.debug('KMA Town ST> pubDate :', pubDate.toString());
     //log.info('KMA Town ST> db find :', coord);
 
     try{
@@ -26,7 +26,7 @@ kmaTownShortestController.prototype.saveShortest = function(newData, callback){
             function(item, cb){
                 var fcsDate = kmaTimelib.getKoreaDateObj(item.date + item.time);
                 var newItem = {mCoord: coord, pubDate: pubDate, fcsDate: fcsDate, shortestData: item};
-                log.info('KMA Town ST> item : ', JSON.stringify(newItem));
+                log.debug('KMA Town ST> item : ', JSON.stringify(newItem));
 
                 modelKmaTownShortest.update({mCoord: coord, fcsDate: fcsDate}, newItem, {upsert:true}, function(err){
                     if(err){
@@ -39,7 +39,7 @@ kmaTownShortestController.prototype.saveShortest = function(newData, callback){
                 });
             },
             function(err){
-                log.info('KMA Town ST> finished to save town.short data');
+                log.debug('KMA Town ST> finished to save town.short data');
                 callback(err);
             }
         );

--- a/server/lib/collectTownForecast.js
+++ b/server/lib/collectTownForecast.js
@@ -330,11 +330,11 @@ CollectData.prototype.getData = function(index, dataType, url, options, callback
 
     req.get(url, {timeout: 1000*10}, function(err, response, body){
         if(err) {
-            if (err.code == "ETIMEDOUT") {
+            if (err.code === "ETIMEDOUT" || err.code === "ESOCKETTIMEDOUT" || err.code === "ECONNRESET") {
                 log.debug(err);
             }
             else {
-                log.warn(err);
+                log.warn(`err.code=${err.code}`);
             }
             //log.error('#', meta);
 


### PR DESCRIPTION
- kma.town.current.controller
  - 삭제시 기준을 fcsDate로 변경
- collectTownForecast
  - network에 나올 수 있는 오류는 로그 레벨 낮게 조정
- PastGather
  - db 2.0에 맞게 빠진 데이터 찾는 _checkBaseTimeByCoord2 만듬