### PR TITLE
TW-214 비오는데 "weather type is undefined" 인 경우

### DIFF
--- a/server/controllers/controllerKmaStnWeather.js
+++ b/server/controllers/controllerKmaStnWeather.js
@@ -23,7 +23,8 @@ function controllerKmaStnWeather() {
 controllerKmaStnWeather.updateWeather = function (current) {
     if (current.pty >= 1) {
         if (current.weatherType == undefined) {
-            log.error('weather type is undefined');
+            log.warn('weather type is undefined so set by pty');
+            current.weatherType = 0;
         }
 
         switch (current.weatherType) {


### PR DESCRIPTION
- 원인 : rns에 의해 강수가 결정되면 발생
- weatherType을 0으로 설정하여 pty에 따라 변경되게 함