### PR TITLE
TW-216 과거 일별 대기 정보 안 나오게 변경

### DIFF
--- a/server/controllers/controllerTown24h.js
+++ b/server/controllers/controllerTown24h.js
@@ -837,8 +837,12 @@ function ControllerTown24h() {
                 dayForecast[forecast.code].hourly.push(forecast.val);
             });
 
-            //remove first and last it does not have full time
-            dailyArray = dailyArray.slice(1, dailyArray.length-1);
+            //remove old data and last it does not have full time
+            let strToday = latestPastDate.slice(0, 10);
+            dailyArray = dailyArray.filter(obj => {
+               return obj.date >= strToday;
+            });
+            dailyArray.pop();
 
             dailyArray.forEach(function (dayForecast) {
                 var date = dayForecast.date;

--- a/server/controllers/kaq.hourly.forecast.controller.js
+++ b/server/controllers/kaq.hourly.forecast.controller.js
@@ -281,10 +281,12 @@ class KaqHourlyForecastController extends ImgHourlyForecastController {
      */
     _getForecastByModelList(stationName, mapCaseList) {
         let forecastList;
+        let date = new Date();
+        date = date.setDate(date.getDate()-1);
         return new Promise((resolve, reject) => {
             async.someSeries(mapCaseList,
                 (mapCase, callback) => {
-                    let query = {stationName: stationName, mapCase: mapCase, date: {$gt: new Date()}};
+                    let query = {stationName: stationName, mapCase: mapCase, date: {$gt: date}};
                     // let query = {stationName: stationName, mapCase: mapCase};
                     this.collection.find(query)
                         .lean()


### PR DESCRIPTION
- controllerTown24h
  - 최종 측정 시간보다 늦을 날짜 데이터는 제외
  - 마지막 일별 데이터도 제외(24개가 안됨)
- kaq.hourly.forecast
  - 오늘날짜 예보를 완성하기위해 하루전부터 데이터를 꺼냄