### PR TITLE
TW-211 fix wrong param of callback

### DIFF
--- a/server/lib/midRssKmaRequester.js
+++ b/server/lib/midRssKmaRequester.js
@@ -350,7 +350,7 @@ MidRssKmaRequester.prototype.processGetMidRss = function (stnId, callback) {
                 log.info("succeed getting MID RSS KMA "+result);
                 self.setNextGetTime();
             }
-            callback(self, err);
+            callback(err);
         });
 
     return this;


### PR DESCRIPTION
- 잘못된 파라미터 전달로 불필요한 error log 출력