### PR TITLE
TW-217 페이지 히스토리 없이 종료에 대한 개선 요청

### DIFF
--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -1,7 +1,6 @@
 angular.module('controller.tabctrl', [])
-    .controller('TabCtrl', function($scope, $ionicPopup, $interval, WeatherInfo, WeatherUtil,
-                                     $location, TwAds, $rootScope, Util, $translate, TwStorage, $sce,
-                                    Push, Units, $q) {
+    .controller('TabCtrl', function($scope, $ionicPlatform, $ionicHistory, $ionicPopup, $interval, WeatherInfo, WeatherUtil,
+                                    $location, TwAds, $rootScope, Util, $translate, TwStorage, $sce, Push, Units, $q) {
         var currentTime;
         var lastClickTime = 0;
         var refreshTimer = null;
@@ -133,6 +132,34 @@ angular.module('controller.tabctrl', [])
             //        $scope.currentTimeString = WeatherUtil.convertTimeString(currentTime);
             //    }
             //}, 1000);
+
+            if (ionic.Platform.isAndroid()) {
+                $ionicPlatform.registerBackButtonAction(function (event) {
+                    if ($location.path() === '/tab/search'
+                        || $location.path() === '/tab/dailyforecast'
+                        || $location.path() === '/tab/forecast'
+                        || $location.path() === '/tab/air'
+                        || $location.path() === '/tab/weather'
+                    ) {
+                        $ionicPopup.show({
+                            template: strDoYouWantToExit,
+                            buttons: [
+                                {
+                                    text: strCancel
+                                },
+                                {
+                                    text: strOkay,
+                                    onTap: function() {
+                                        ionic.Platform.exitApp();
+                                    }
+                                }
+                            ]
+                        });
+                    } else {
+                        $ionicHistory.goBack();
+                    }
+                }, 100);
+            }
 
             setAirUnit();
             TwAds.init();
@@ -1422,11 +1449,13 @@ angular.module('controller.tabctrl', [])
         var strFailToGetCurrentPosition = "Fail to find your current location";
         var strFailToGetWeatherInfo = "Fail to get weather info.";
         var strPleaseTurnOnLocationWiFi = "Please turn on location and Wi-FI";
+        var strDoYouWantToExit = "Do you want to exit?";
         $scope.strHour = "h";
 
         $translate(['LOC_ERROR', 'LOC_ADD_LOCATIONS', 'LOC_HOUR', 'LOC_CLOSE', 'LOC_RETRY',
             'LOC_FAIL_TO_GET_LOCATION_INFORMATION', 'LOC_FAIL_TO_FIND_YOUR_CURRENT_LOCATION',
-            'LOC_FAIL_TO_GET_WEATHER_INFO', 'LOC_PLEASE_TURN_ON_LOCATION_AND_WIFI', 'LOC_OK', 'LOC_CANCEL', 'LOC_WEATHER'])
+            'LOC_FAIL_TO_GET_WEATHER_INFO', 'LOC_PLEASE_TURN_ON_LOCATION_AND_WIFI', 'LOC_OK', 'LOC_CANCEL',
+            'LOC_WEATHER', 'LOC_DO_YOU_WANT_TO_EXIT'])
             .then(function (translations) {
                     strError = translations.LOC_ERROR;
                     strAddLocation = translations.LOC_ADD_LOCATIONS;
@@ -1439,6 +1468,7 @@ angular.module('controller.tabctrl', [])
                     strOkay = translations.LOC_OK;
                     strCancel = translations.LOC_CANCEL;
                     strWeather = translations.LOC_WEATHER;
+                    strDoYouWantToExit = translations.LOC_DO_YOU_WANT_TO_EXIT;
                     $scope.strHour = translations.LOC_HOUR;
                 },
                 function (translationIds) {

--- a/client/www/locales/de.json
+++ b/client/www/locales/de.json
@@ -305,5 +305,6 @@
   "LOC_OFF": "aus",
   "LOC_ON": "auf",
   "LOC_AIR_QUALITY_IS_GOOD" : "Die Luftqualität wird als gut bewertet",
-  "LOC_AIR_QUALITY_IS_MODERATE" : "Die Luftqualität wird als befriedigend bewertet"
+  "LOC_AIR_QUALITY_IS_MODERATE" : "Die Luftqualität wird als befriedigend bewertet",
+  "LOC_DO_YOU_WANT_TO_EXIT": "Do you want to exit?"
 }

--- a/client/www/locales/en.json
+++ b/client/www/locales/en.json
@@ -305,5 +305,6 @@
   "LOC_OFF": "Off",
   "LOC_ON": "On",
   "LOC_AIR_QUALITY_IS_GOOD" : "Air quality is good",
-  "LOC_AIR_QUALITY_IS_MODERATE" : "Air quality is moderate"
+  "LOC_AIR_QUALITY_IS_MODERATE" : "Air quality is moderate",
+  "LOC_DO_YOU_WANT_TO_EXIT": "Do you want to exit?"
 }

--- a/client/www/locales/ja.json
+++ b/client/www/locales/ja.json
@@ -305,5 +305,6 @@
   "LOC_OFF": "オフ",
   "LOC_ON": "に",
   "LOC_AIR_QUALITY_IS_GOOD" : "大気の状態が良いです",
-  "LOC_AIR_QUALITY_IS_MODERATE" : "大気の状態は普通です"
+  "LOC_AIR_QUALITY_IS_MODERATE" : "大気の状態は普通です",
+  "LOC_DO_YOU_WANT_TO_EXIT": "Do you want to exit?"
 }

--- a/client/www/locales/ko.json
+++ b/client/www/locales/ko.json
@@ -305,5 +305,6 @@
   "LOC_OFF": "끄기",
   "LOC_ON": "켜기",
   "LOC_AIR_QUALITY_IS_GOOD" : "대기상태가 좋아요",
-  "LOC_AIR_QUALITY_IS_MODERATE" : "대기상태는 보통입니다"
+  "LOC_AIR_QUALITY_IS_MODERATE" : "대기상태는 보통입니다",
+  "LOC_DO_YOU_WANT_TO_EXIT": "종료하시겠습니까?"
 }

--- a/client/www/locales/zh-CN.json
+++ b/client/www/locales/zh-CN.json
@@ -305,5 +305,6 @@
   "LOC_OFF": "离",
   "LOC_ON": "上",
   "LOC_AIR_QUALITY_IS_GOOD" : "空气状况好",
-  "LOC_AIR_QUALITY_IS_MODERATE" : "空气状况一般"
+  "LOC_AIR_QUALITY_IS_MODERATE" : "空气状况一般",
+  "LOC_DO_YOU_WANT_TO_EXIT": "Do you want to exit?"
 }

--- a/client/www/locales/zh-TW.json
+++ b/client/www/locales/zh-TW.json
@@ -305,6 +305,7 @@
   "LOC_OFF": "離",
   "LOC_ON": "上",
   "LOC_AIR_QUALITY_IS_GOOD" : "空氣狀況好",
-  "LOC_AIR_QUALITY_IS_MODERATE" : "空氣狀況一般"
+  "LOC_AIR_QUALITY_IS_MODERATE" : "空氣狀況一般",
+  "LOC_DO_YOU_WANT_TO_EXIT": "Do you want to exit?"
 }
 


### PR DESCRIPTION
* 안드로이드일 때 즐겨찾기, 시간별날씨, 일별날씨, 대기정보, 날씨 페이지에서 back 버튼을 누르면 '종료하시겠습니까?' 팝업을 띄우도록 처리
 - 앱 실행 후 터치없이 back 버튼을 누른 경우 바로 종료됨(이벤트가 발생하지 않음)