### PR TITLE
TW-145 날씨 사진 테마 지원 #1855

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -60,84 +60,74 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
 // Include all of Ionic
 @import "www/lib/ionic/scss/ionic";
 
-[md-page-header] {
-  padding: 44px 0 5px 0;
-  margin: 0 auto 5px auto;
-  position: relative;
-
-  &.photo {
-    color: white;
-    text-shadow: -0.5px -0.5px 0 #8f8f8f, 0.5px -0.5px 0 #8f8f8f, -0.5px 0.5px 0 #8f8f8f, 0.5px 0.5px 0 #8f8f8f;
-    padding: 44px 0 22px 0;
-    background-color: #fff;
-  }
-  &.no-photo {
-    color: #444;
-    background-color: #fff;
-  }
-  .photo-box {
-    background-repeat: no-repeat;
-    background-size: cover;
-    opacity: 0.8;
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 0;
-  }
-  .main-box {
-    width: 80%;
-    margin: auto;
-    text-align: center;
-    z-index: 1;
-    .main-box-forecast-content {
-      margin: auto;
-      font-weight: 300;
-      display: inline-flex;
-      span {
-        vertical-align: super;
-      }
-    }
-    .main-box-air-title {
-      margin: auto;
-      padding: 0 12px;
-      font-size:17px;
-      font-weight: 500;
-      border-radius: 4px;
-      border: 1px solid #444;
-      display: inline-flex;;
-    }
-    .main-box-air-content {
-      margin: auto;
-      font-size: 64px;
-      i, span {
-        font-size: 32px;
-      }
-    }
-    .main-box-summary {
-      font-size: 21px;
-      line-height: 21px;
-      i {
-        font-size: 24px;
-        vertical-align: bottom;
-      }
-    }
-  }
-  .main-box-arrow {
-    width: 10%;
-    padding-bottom: 7%;
-    padding-top: 7%;
-    margin: auto;
-    text-align: center;
-    z-index: 1;
-  }
-}
-
 .main-content {
   color: #000;
   width: 100%;
   top: 0;
+  [md-page-header] {
+    color: #444;
+    background-color: #fff;
+    padding: 44px 0 5px 0;
+    margin: 0 auto 5px auto;
+    position: relative;
+    .photo-box {
+      background-repeat: no-repeat;
+      background-size: cover;
+      opacity: 0.8;
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
+    }
+    .main-box {
+      width: 80%;
+      margin: auto;
+      text-align: center;
+      z-index: 1;
+      .main-box-forecast-content {
+        margin: auto;
+        font-weight: 300;
+        display: inline-flex;
+        span {
+          vertical-align: super;
+        }
+      }
+      .main-box-air-title {
+        margin: auto;
+        padding: 0 12px;
+        font-size:17px;
+        font-weight: 500;
+        border-radius: 4px;
+        border: 1px solid #444;
+        display: inline-flex;;
+      }
+      .main-box-air-content {
+        margin: auto;
+        font-size: 64px;
+        i, span {
+          font-size: 32px;
+        }
+      }
+      .main-box-summary {
+        font-size: 21px;
+        line-height: 21px;
+        i {
+          font-size: 24px;
+          vertical-align: bottom;
+        }
+      }
+    }
+    .main-box-arrow {
+      width: 10%;
+      padding-bottom: 7%;
+      padding-top: 7%;
+      margin: auto;
+      text-align: center;
+      z-index: 1;
+    }
+  }
   .card {
     background-color: #fff;
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
@@ -268,6 +258,92 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
       }
       .chart-content {
         width: 100%;
+        .chart-text {
+          fill: #444;
+          font-size: 15px;
+          text-anchor: middle;
+        }
+        .chart-sub-text {
+          fill: #444;
+          font-size: 13px;
+          text-anchor: middle;
+          letter-spacing: 0px;
+        }
+        .chart-unit-text {
+          fill: #444;
+          font-size: 10px;
+        }
+        .chart-bar {
+          fill: #7aa4d1;
+        }
+        .guide-vivid-line {
+          stroke: #c0d6f0;
+          stroke-width: 1;
+          stroke-opacity: 0.6;
+        }
+        .guide-line {
+          stroke: #d9e5f2;
+          stroke-width: 1;
+          stroke-opacity: 0.4;
+        }
+        .current-rect {
+          stroke: #d9e5f2;
+          fill: #d9e5f2;
+        }
+        .line-today {
+          stroke: #7aa4d1;
+          stroke-width: 2px;
+          fill: none;
+        }
+        .line-yesterday {
+          stroke: #9e9e9e;
+          stroke-width: 1px;
+          fill: none;
+        }
+        .circle-today {
+          stroke: #7aa4d1;
+          stroke-width: 1px;
+          fill: #7aa4d1;
+        }
+        .circle-yesterday {
+          stroke: #9e9e9e;
+          stroke-width: 1px;
+          fill: #9e9e9e;
+        }
+        .circle-today-current {
+          stroke: #FF5252;
+          stroke-width: 2px;
+          fill: #FF5252;
+        }
+        .circle-yesterday-current {
+          stroke: #9e9e9e;
+          stroke-width: 2px;
+          fill: #9e9e9e;
+        }
+        .text-today {
+          fill: #ffffff;
+          font-size: 15px;
+          text-anchor: middle;
+        }
+        .text-yesterday {
+          fill: #ffffff;
+          font-size: 15px;
+          text-anchor: middle;
+        }
+        .circle-hidden, .text-hidden {
+          visibility: hidden;
+        }
+        .x-axis {
+          path, line {
+            stroke: #666666;
+            shape-rendering: crispEdges;
+          }
+          text {
+            stroke-width: 0px;
+            fill: #444;
+            font-size: 13px;
+          }
+        }
       }
     }
     .chart-label {
@@ -290,6 +366,37 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
         height: 13px;
       }
     }
+    .air-std-table {
+      margin: 0 4px;
+      font-size: 15px;
+      .air-label {
+        position: relative;
+        display: inline-block;
+        .outline {
+          border-radius: 4px;
+          border: 1px solid #444;
+          font-weight: 700;
+          padding: 0 10px;
+        }
+        .line {
+          max-width: 50%;
+          height: 8px;
+          border-right: 1px solid #444;
+          margin: 0 1px;
+        }
+      }
+      .air-std-box {
+        display: flex;
+        .air-std {
+          flex-basis: 100%;
+          margin: 0 1px;
+          text-overflow:ellipsis;
+          overflow:hidden;
+          white-space:nowrap;
+          border-top: 2px solid #444;
+        }
+      }
+    }
   }
   .card:first-child {
     padding: 0 0 10px 0;
@@ -306,140 +413,25 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   }
 }
 
-/* air standard table */
-.air-std-table {
-  margin: 0 4px;
-  font-size: 15px;
-  .air-label {
-    position: relative;
-    display: inline-block;
-    .outline {
-      border-radius: 4px;
-      border: 1px solid #444;
-      font-weight: 700;
-      padding: 0 10px;
-    }
-    .line {
-      max-width: 50%;
-      height: 8px;
-      border-right: 1px solid #444;
-      margin: 0 1px;
-    }
-  }
-  .air-std-box {
-    display: flex;
-    .air-std {
-      flex-basis: 100%;
-      margin: 0 1px;
-      text-overflow:ellipsis;
-      overflow:hidden;
-      white-space:nowrap;
-      border-top: 2px solid #444;
-    }
+.main-content.photo {
+  [md-page-header] {
+    color: #fff;
+    text-shadow: -0.5px -0.5px 0 #8f8f8f, 0.5px -0.5px 0 #8f8f8f, -0.5px 0.5px 0 #8f8f8f, 0.5px 0.5px 0 #8f8f8f;
+    padding: 44px 0 22px 0;
   }
 }
 
-/* chart style */
-.chart-text {
-  fill: #444;
-  font-size: 15px;
-  text-anchor: middle;
-}
-
-.chart-sub-text {
-  fill: #444;
-  font-size: 13px;
-  text-anchor: middle;
-  letter-spacing: 0px;
-}
-
-.chart-unit-text {
-  fill: #444;
-  font-size: 10px;
-}
-
-.chart-bar {
-  fill: #7aa4d1;
-}
-
-.guide-vivid-line {
-  stroke: #c0d6f0;
-  stroke-width: 1;
-  stroke-opacity: 0.6;
-}
-
-.guide-line {
-  stroke: #d9e5f2;
-  stroke-width: 1;
-  stroke-opacity: 0.4;
-}
-
-.current-rect {
-  stroke: #d9e5f2;
-  fill: #d9e5f2;
-}
-
-.line-today {
-  stroke: #7aa4d1;
-  stroke-width: 2px;
-  fill: none;
-}
-
-.line-yesterday {
-  stroke: #9e9e9e;
-  stroke-width: 1px;
-  fill: none;
-}
-
-.circle-today {
-  stroke: #7aa4d1;
-  stroke-width: 1px;
-  fill: #7aa4d1;
-}
-
-.circle-yesterday {
-  stroke: #9e9e9e;
-  stroke-width: 1px;
-  fill: #9e9e9e;
-}
-
-.circle-today-current {
-  stroke: #FF5252;
-  stroke-width: 2px;
-  fill: #FF5252;
-}
-
-.circle-yesterday-current {
-  stroke: #9e9e9e;
-  stroke-width: 2px;
-  fill: #9e9e9e;
-}
-
-.text-today {
-  fill: #ffffff;
-  font-size: 15px;
-  text-anchor: middle;
-}
-
-.text-yesterday {
-  fill: #ffffff;
-  font-size: 15px;
-  text-anchor: middle;
-}
-
-.circle-hidden, .text-hidden {
-  visibility: hidden;
-}
-
-.x-axis {
-  path, line {
-    stroke: #666666;
-    shape-rendering: crispEdges;
+.platform-ios.platform-cordova {
+  .main-content {
+    top: 0 !important;
+    [md-page-header] {
+      padding: 64px 0 5px 0;
+    }
   }
-  text {
-    stroke-width: 0px;
-    fill: #444;
-    font-size: 13px;
+  .main-content.photo {
+    [md-page-header] {
+      padding: 64px 0 22px 0;
+    }
   }
 }
 
@@ -666,11 +658,11 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
   top: auto;
   bottom: auto;
   margin-top: -3px;
-  background-color: white;
+  background-color: #fff;
 }
 
 .toggle.toggle-search input:checked + .track .handle {
-  background-color: white;
+  background-color: #fff;
   left: auto;
   right: 25px;
 }
@@ -940,7 +932,7 @@ ion-side-menu-content > ion-nav-view {
 }
 
 .setting-push button {
-  color: white;
+  color: #fff;
 }
 
 //iphone 4

--- a/client/www/data/theme.js
+++ b/client/www/data/theme.js
@@ -1,4 +1,10 @@
 window.theme = {
-    icons: 'img/icons_default',
-    weather: 'img/weather_default'
+    'photo': {
+        icons: 'img/icons_default',
+        weather: 'img/weather_default'
+    },
+    'light': {
+        icons: 'img/icons_default',
+        weather: 'img/weather_default'
+    }
 };

--- a/client/www/index.html
+++ b/client/www/index.html
@@ -103,9 +103,9 @@
                     {{'LOC_REFRESH_INTERVAL'|translate}}
                     <span style="float: right">{{getRefreshIntervalValueStr(settingsInfo.refreshInterval)|translate}}</span>
                 </label>
-                <label class="item" ng-click="settingRadio('showWeatherPhotos')" ng-if="clientConfig.package === 'todayWeather'">
-                    {{'LOC_SHOW_WEATHER_PHOTOS'|translate}}
-                    <span style="float: right">{{getShowWeatherPhotosValueStr(settingsInfo.showWeatherPhotos)|translate}}</span>
+                <label class="item" ng-click="settingRadio('theme')">
+                    {{'LOC_THEME_SETTING'|translate}}
+                    <span style="float: right">{{getThemeValueStr(settingsInfo.theme)|translate}}</span>
                 </label>
                 <label class="item" ng-click="clickMenu('purchase')" ng-if="hasInAppPurchase()">
                     {{'LOC_REMOVE_ADS'|translate}}

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -239,6 +239,9 @@ angular.module('starter', [
                 headerbars[i].style.backgroundImage = "";
             }
 
+            var contents = angular.element(document.querySelectorAll('ion-content'));
+            contents.removeClass('photo');
+
             if (toState.name === 'tab.search') {
                 $rootScope.viewColor = '#F5F5F5';
                 headerbars.addClass('bar-search');
@@ -246,7 +249,7 @@ angular.module('starter', [
             } else if (toState.name === 'tab.forecast') {
                 $rootScope.viewColor = '#F5F5F5';
                 headerbars.addClass('bar-forecast');
-                if ($rootScope.settingsInfo.showWeatherPhotos === '1') {
+                if ($rootScope.settingsInfo.theme === 'photo') {
                     headerbars.addClass('bar-clear');
                 } else {
                     headerbars.addClass('bar-dark');
@@ -254,7 +257,7 @@ angular.module('starter', [
             } else if (toState.name === 'tab.dailyforecast') {
                 $rootScope.viewColor = '#F5F5F5';
                 headerbars.addClass('bar-dailyforecast');
-                if ($rootScope.settingsInfo.showWeatherPhotos === '1') {
+                if ($rootScope.settingsInfo.theme === 'photo') {
                     headerbars.addClass('bar-clear');
                 } else {
                     headerbars.addClass('bar-dark');
@@ -303,12 +306,14 @@ angular.module('starter', [
         }
 
         TwStorage.init().finally(function() {
-            return WeatherUtil.loadWeatherPhotos();
-        }).finally(function () {
-            $rootScope.iconsImgPath = window.theme.icons;
-            $rootScope.weatherImgPath = window.theme.weather;
+            $rootScope.iconsImgPath = window.theme[$rootScope.settingsInfo.theme].icons;
+            $rootScope.weatherImgPath = window.theme[$rootScope.settingsInfo.theme].weather;
 
             WeatherInfo.loadCities();
+            WeatherUtil.loadWeatherPhotos().finally(function () {
+                WeatherInfo.updatePhotos();
+                $rootScope.$broadcast('loadWeatherPhotosEvent');
+            });
             if (Push.init() === true) {
                 //show notify alert info popup
                 setTimeout(function () {
@@ -331,37 +336,25 @@ angular.module('starter', [
                 return;
             }
 
-            var startupPage;
-            var settingsInfo = TwStorage.get("settingsInfo");
-            if (settingsInfo !== null) {
-                startupPage = settingsInfo.startupPage;
-            }
-
+            var startupPage = $rootScope.settingsInfo.startupPage;
             Util.ga.trackEvent('app', 'startupPage', startupPage);
 
-            if (clientConfig.package === 'todayWeather') {
-                if (startupPage === "0") { //일별날씨
-                    $state.go('tab.forecast');
-                } else if (startupPage === "1") { //일별날씨
-                    $state.go('tab.dailyforecast');
-                } else if (startupPage === "2") { //즐겨찾기
-                    $state.go('tab.search');
-                } else if (startupPage === "3") { //미세먼지
-                    $state.go('tab.air');
-                } else {
-                    console.error('unknown page:'+startupPage);
+            if (startupPage === "0") { //시간별날씨
+                $state.go('tab.forecast');
+            } else if (startupPage === "1") { //일별날씨
+                $state.go('tab.dailyforecast');
+            } else if (startupPage === "2") { //즐겨찾기
+                $state.go('tab.search');
+            } else if (startupPage === "3") { //대기정보
+                $state.go('tab.air');
+            } else if (startupPage === "4") { //날씨
+                $state.go('tab.weather');
+            } else {
+                console.error('unknown page:'+startupPage);
+                if (clientConfig.package === 'todayWeather') {
                     $state.go('tab.forecast');
                 }
-            }
-            else if (clientConfig.package === 'todayAir') {
-                if (startupPage === "2") { //즐겨찾기
-                    $state.go('tab.search');
-                } else if (startupPage === "3") { //대기정보
-                    $state.go('tab.air');
-                } else if (startupPage === "4") { //날씨
-                    $state.go('tab.weather');
-                } else { //대기정보
-                    console.error('unknown page:'+startupPage);
+                else if (clientConfig.package === 'todayAir') {
                     $state.go('tab.air');
                 }
             }
@@ -1535,7 +1528,7 @@ angular.module('starter', [
                         }
 
                         var top = y + amount;
-                        tabs.style[ionic.CSS.TRANSFORM] = 'translate3d(0, ' + top + 'px, 0)';
+                        tabs.style[ionic.CSS.TRANSFORM] = 'translate3d(20px, ' + top + 'px, 0)';
 
                         $scope.$root.tabsTop = top;
                         $scope.$root.$apply();
@@ -1603,7 +1596,20 @@ angular.module('starter', [
                         }
                     }
 
-                    $element.bind('scroll', onScroll);
+                    if ($scope.$root.settingsInfo.theme === 'photo') {
+                        $element.bind('scroll', onScroll);
+                    }
+                }
+            }
+        });
+
+        $compileProvider.directive('themeApply', function($document) {
+            return {
+                restrict: 'A',
+                link: function($scope, $element, $attr) {
+                    if ($scope.$root.settingsInfo.theme === 'photo') {
+                        $element.addClass('photo');
+                    }
                 }
             }
         });

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -1,6 +1,6 @@
 angular.module('controller.forecastctrl', [])
     .controller('ForecastCtrl', function ($scope, WeatherInfo, WeatherUtil, Util, Purchase, $stateParams,
-                                          $location, $ionicHistory, $translate, Units, Push) {
+                                          $rootScope, $location, $ionicHistory, $translate, Units, Push) {
         var ASPECT_RATIO_16_9 = 1.7;
         var colWidth;
 
@@ -411,8 +411,8 @@ angular.module('controller.forecastctrl', [])
                 if (cityData.source) {
                     $scope.source = cityData.source;
                 }
-                if ($scope.settingsInfo.showWeatherPhotos == '1') {
-                    $scope.photo = cityData.photo || 'img/bg.png'; //이전에 저장된 cityData의 경우 photo가 없을 수 있음
+                if ($rootScope.settingsInfo.theme == 'photo') {
+                    $scope.photo = 'linear-gradient(to bottom, rgba(0,0,0,0.3) 95%, rgba(255,255,255,0.9)), url('+cityData.photo+'), url(img/bg.png)';
                 }
 
                 dayTable = cityData.dayChart[0].values;
@@ -744,6 +744,29 @@ angular.module('controller.forecastctrl', [])
         $scope.$on('applyEvent', function(event, sender) {
             Util.ga.trackEvent('apply', 'sender', sender);
             applyWeatherData();
+        });
+
+        $scope.$on('loadWeatherPhotosEvent', function(event, sender) {
+            Util.ga.trackEvent('loadWeatherPhotos', 'sender', sender);
+
+            try {
+                if ($rootScope.settingsInfo.theme == 'photo') {
+                    var cityIndex = WeatherInfo.getCityIndex();
+                    var cityData = WeatherInfo.getCityOfIndex(cityIndex);
+                    if (cityData === null || cityData.address === null || cityData.dayChart == null) {
+                        Util.ga.trackEvent('weather', 'error', 'fail to getCityOfIndex', cityIndex);
+                        console.log("fail to getCityOfIndex");
+                        return;
+                    }
+
+                    $scope.photo = 'linear-gradient(to bottom, rgba(0,0,0,0.3) 95%, rgba(255,255,255,0.9)), url('+cityData.photo+'), url(img/bg.png)';
+                }
+            }
+            catch(err) {
+                Util.ga.trackEvent('weather', 'error', err.toString());
+                Util.ga.trackException(err, false);
+                return;
+            }
         });
 
         var strOkay = "OK";

--- a/client/www/js/controller.searchctrl.js
+++ b/client/www/js/controller.searchctrl.js
@@ -65,22 +65,21 @@ angular.module('controller.searchctrl', [])
         };
 
         function goPage() {
-            var startupPage;
-            var settingsInfo = TwStorage.get("settingsInfo");
-            if (settingsInfo !== null) {
-                startupPage = settingsInfo.startupPage;
-            }
+            var startupPage = $rootScope.settingsInfo.startupPage;
 
-            if (startupPage === "1") { //일별날씨
+            if (startupPage === "0") { //시간별날씨
+                $location.path('/tab/forecast');
+            }
+            else if (startupPage === "1") { //일별날씨
                 $location.path('/tab/dailyforecast');
             }
             else if (startupPage === "3") { //대기정보
                 $location.path('/tab/air');
             }
-            else if (startupPage === "4") { //대기정보
+            else if (startupPage === "4") { //날씨
                 $location.path('/tab/weather');
             }
-            else { //시간별날씨
+            else {
                 if (clientConfig.package === 'todayWeather') {
                     $location.path('/tab/forecast');
                 }
@@ -502,30 +501,7 @@ angular.module('controller.searchctrl', [])
             }
 
             WeatherInfo.setCityIndex(index);
-
-            var startupPage;
-            var settingsInfo = TwStorage.get("settingsInfo");
-            if (settingsInfo !== null) {
-                startupPage = settingsInfo.startupPage;
-            }
-
-            if (startupPage === "1") { //일별날씨
-                $location.path('/tab/dailyforecast');
-            }
-            else if (startupPage === "3") { //대기정보
-                $location.path('/tab/air');
-            }
-            else { //시간별날씨
-                if (clientConfig.package === 'todayWeather') {
-                    $location.path('/tab/forecast');
-                }
-                else if (clientConfig.package === 'todayAir') {
-                    $location.path('/tab/air');
-                }
-                else {
-                    $location.path('/tab/forecast');
-                }
-            }
+            goPage();
         };
 
         function updateCurrentPositionWeather() {

--- a/client/www/js/controller.setting.radio.js
+++ b/client/www/js/controller.setting.radio.js
@@ -37,21 +37,15 @@ angular.module('controller.setting.radio', [])
                     }
                 }
             }
-            else if (this.type === 'startupPage' || this.type === 'refreshInterval' || this.type === 'showWeatherPhotos') {
-                var settingsInfo = TwStorage.get("settingsInfo");
-                if (settingsInfo === null) {
-                    settingsInfo = {
-                        startupPage: "0", //시간별날씨
-                        refreshInterval: "0", //수동
-                        showWeatherPhotos: '1' //켜짐
-                    };
-                }
-                settingsInfo[this.type] = value;
-                TwStorage.set("settingsInfo", settingsInfo);
-                $rootScope.settingsInfo = settingsInfo;
+            else if (this.type === 'startupPage' || this.type === 'refreshInterval' || this.type === 'theme') {
+                $rootScope.settingsInfo[this.type] = value;
+                TwStorage.set("settingsInfo", $rootScope.settingsInfo);
 
                 if (this.type === 'refreshInterval') {
                     $rootScope.$broadcast('reloadEvent', 'setRefreshInterval');
+                } else if (this.type === 'theme') {
+                    $rootScope.iconsImgPath = window.theme[$rootScope.settingsInfo.theme].icons;
+                    $rootScope.weatherImgPath = window.theme[$rootScope.settingsInfo.theme].weather;
                 }
             }
             else {

--- a/client/www/js/controller.settingctrl.js
+++ b/client/www/js/controller.settingctrl.js
@@ -16,23 +16,6 @@ angular.module('controller.settingctrl', [])
             if (ionic.Platform.isIOS()) {
                 menuContent = angular.element(document.getElementsByClassName('menu-content')[0]);
             }
-
-            var settingsInfo = TwStorage.get("settingsInfo");
-            if (settingsInfo === null) {
-                settingsInfo = {
-                    startupPage: "0", //시간별날씨
-                    refreshInterval: "0", //수동
-                    showWeatherPhotos: '1' //켜짐
-                };
-                if (clientConfig.package === 'todayAir') {
-                    settingsInfo.startupPage = "3"; //대기정보
-                    settingsInfo.showWeatherPhotos = "0"; //off
-                }
-                TwStorage.set("settingsInfo", settingsInfo);
-            }
-
-            console.info(settingsInfo);
-            $rootScope.settingsInfo = settingsInfo;
         }
 
         $scope.clickMenu = function (menu) {
@@ -166,10 +149,10 @@ angular.module('controller.settingctrl', [])
                     return {label: $scope.getRefreshIntervalValueStr(value), value: value};
                 });
             }
-            else if (name === 'showWeatherPhotos') {
-                title = 'LOC_SHOW_WEATHER_PHOTOS';
-                list = ['0', '1'].map(function (value) {
-                    return {label: $scope.getShowWeatherPhotosValueStr(value), value: value};
+            else if (name === 'theme') {
+                title = 'LOC_THEME_SETTING';
+                list = ['photo', 'light'].map(function (value) {
+                    return {label: $scope.getThemeValueStr(value), value: value};
                 });
             }
             console.info(JSON.stringify({name: name, title: title, value: $rootScope.settingsInfo[name], list: list}));
@@ -216,13 +199,13 @@ angular.module('controller.settingctrl', [])
             return 'N/A'
         };
 
-        $scope.getShowWeatherPhotosValueStr = function (value) {
-            //console.log('getShowWeatherPhotosValueStr v='+value);
+        $scope.getThemeValueStr = function (value) {
+            //console.log('getThemeValueStr v='+value);
             switch(value) {
-                case '0':
-                    return 'LOC_OFF';
-                case '1':
-                    return 'LOC_ON';
+                case 'photo':
+                    return 'LOC_WEATHER_PHOTO_THEME';
+                case 'light':
+                    return 'LOC_LIGHT_THEME';
             }
             return 'N/A'
         };

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -1038,11 +1038,10 @@ angular.module('controller.tabctrl', [])
         function setRefreshTimer() {
             clearTimeout(refreshTimer);
 
-            var settingsInfo = TwStorage.get("settingsInfo");
-            if (settingsInfo != null && settingsInfo.refreshInterval !== "0") {
+            if ($rootScope.settingsInfo != null && $rootScope.settingsInfo.refreshInterval !== "0") {
                 refreshTimer = setTimeout(function () {
                     $scope.$broadcast('reloadEvent', 'refreshTimer');
-                }, parseInt(settingsInfo.refreshInterval)*60*1000);
+                }, parseInt($rootScope.settingsInfo.refreshInterval)*60*1000);
             }
         }
 

--- a/client/www/js/service.storage.js
+++ b/client/www/js/service.storage.js
@@ -1,5 +1,5 @@
 angular.module('service.storage', [])
-    .factory('TwStorage', function($q, Util) {
+    .factory('TwStorage', function($rootScope, $q, Util) {
         var obj = {};
         var suiteName;
         var oldSuiteName = 'net.wizardfactory.todayweather_preferences'; // only android
@@ -156,9 +156,14 @@ angular.module('service.storage', [])
             var that = this;
 
             var settingsInfo = that.get("settingsInfo");
-            if (settingsInfo !== null && settingsInfo.showWeatherPhotos == undefined) {
-                settingsInfo.showWeatherPhotos = '0'; //꺼짐
-                that.set("settingsInfo", settingsInfo);
+            if (settingsInfo !== null) {
+                if (settingsInfo.theme == undefined) {
+                    settingsInfo.theme = 'light'; //밝은 테마
+                    that.set("settingsInfo", settingsInfo);
+                }
+                $rootScope.settingsInfo = settingsInfo; // 저장된 설정값으로 업데이트
+            } else {
+                that.set("settingsInfo", $rootScope.settingsInfo); // 초기값 저장
             }
         };
 
@@ -192,6 +197,21 @@ angular.module('service.storage', [])
         obj.init = function () {
             var that = this;
             var deferred = $q.defer();
+
+            // settingInfo 초기값을 rootScope에 저장
+            if (clientConfig.package === 'todayAir') {
+                $rootScope.settingsInfo = {
+                    startupPage: "3", //대기정보
+                    refreshInterval: "0", //수동
+                    theme: "light" //밝은 테마
+                };
+            } else {
+                $rootScope.settingsInfo = {
+                    startupPage: "0", //시간별날씨
+                    refreshInterval: "0", //수동
+                    theme: "photo" //날씨 사진 테마
+                };
+            }
 
             if (_hasAppPreferences()) {
                 suitePrefs = plugins.appPreferences.suite(suiteName);

--- a/client/www/js/service.weatherinfo.js
+++ b/client/www/js/service.weatherinfo.js
@@ -17,9 +17,11 @@ angular.module('service.weatherinfo', [])
                 city.dayTable = null;
                 city.dayChart = null;
                 city.disable = true; // 현재 위치 off
+                city.photo = null;
             } else {
                 city = item;
                 city.disable = item.disable === undefined ? false : item.disable;
+                city.photo = item.photo === undefined ? null : item.photo;
             }
             city.loadTime = null;
             cities.push(city);
@@ -148,6 +150,7 @@ angular.module('service.weatherinfo', [])
             if (that.getIndexOfCity(city) === -1) {
                 city.disable = false;
                 city.loadTime = new Date();
+                city.photo = WeatherUtil.findWeatherPhoto(city.currentWeather);
                 cities.push(city);
                 that.saveCities();
                 return true;
@@ -253,6 +256,17 @@ angular.module('service.weatherinfo', [])
             city.loadTime = new Date();
             city.photo = WeatherUtil.findWeatherPhoto(city.currentWeather);
 
+            that.saveCities();
+        };
+
+        obj.updatePhotos = function () {
+            var that = this;
+
+            for (var i = 0; i < cities.length; i += 1) {
+                if (cities[i].photo === null) {
+                    cities[i].photo = WeatherUtil.findWeatherPhoto(cities[i].currentWeather);
+                }
+            }
             that.saveCities();
         };
 

--- a/client/www/locales/de.json
+++ b/client/www/locales/de.json
@@ -301,9 +301,11 @@
   "LOC_AIR_FORECAST_SOURCE" : "Prognosequelle",
   "LOC_KAQ_DESCRIPTION": "Atmospheric quality forecasting data is provided by Anyang University Climate Energy Environment Convergence Research Institute (abbreviated name: Anyang University, Climate Convergence Research Institute, Director: Professor of Environmental Energy Engineering)",
   "LOC_AIRKOREA_DESCRIPTION": "The Ministry of Environment of Korea is predicting the air pollution concentration to minimize the public health damage caused by air pollution.",
-  "LOC_SHOW_WEATHER_PHOTOS": "Wetter Fotos",
-  "LOC_OFF": "aus",
-  "LOC_ON": "auf",
+  "LOC_THEME_SETTING": "Theme setting",
+  "LOC_WEATHER_PHOTO_THEME": "Weather photo theme",
+  "LOC_LIGHT_THEME": "Light theme",
+  "LOC_BLUE_THEME": "Blue theme",
+  "LOC_DARK_THEME": "Dark theme",
   "LOC_AIR_QUALITY_IS_GOOD" : "Die Luftqualität wird als gut bewertet",
   "LOC_AIR_QUALITY_IS_MODERATE" : "Die Luftqualität wird als befriedigend bewertet"
 }

--- a/client/www/locales/en.json
+++ b/client/www/locales/en.json
@@ -301,9 +301,11 @@
   "LOC_AIR_FORECAST_SOURCE" : "Forecast source",
   "LOC_KAQ_DESCRIPTION": "Atmospheric quality forecasting data is provided by Anyang University Climate Energy Environment Convergence Research Institute (abbreviated name: Anyang University, Climate Convergence Research Institute, Director: Professor of Environmental Energy Engineering)",
   "LOC_AIRKOREA_DESCRIPTION": "The Ministry of Environment of Korea is predicting the air pollution concentration to minimize the public health damage caused by air pollution.",
-  "LOC_SHOW_WEATHER_PHOTOS": "Weather photos",
-  "LOC_OFF": "Off",
-  "LOC_ON": "On",
+  "LOC_THEME_SETTING": "Theme setting",
+  "LOC_WEATHER_PHOTO_THEME": "Weather photo theme",
+  "LOC_LIGHT_THEME": "Light theme",
+  "LOC_BLUE_THEME": "Blue theme",
+  "LOC_DARK_THEME": "Dark theme",
   "LOC_AIR_QUALITY_IS_GOOD" : "Air quality is good",
   "LOC_AIR_QUALITY_IS_MODERATE" : "Air quality is moderate"
 }

--- a/client/www/locales/ja.json
+++ b/client/www/locales/ja.json
@@ -301,9 +301,11 @@
   "LOC_AIR_FORECAST_SOURCE" : "予報資料",
   "LOC_KAQ_DESCRIPTION": "Atmospheric quality forecasting data is provided by Anyang University Climate Energy Environment Convergence Research Institute (abbreviated name: Anyang University, Climate Convergence Research Institute, Director: Professor of Environmental Energy Engineering)",
   "LOC_AIRKOREA_DESCRIPTION": "The Ministry of Environment of Korea is predicting the air pollution concentration to minimize the public health damage caused by air pollution.",
-  "LOC_SHOW_WEATHER_PHOTOS": "天気の写真",
-  "LOC_OFF": "オフ",
-  "LOC_ON": "に",
+  "LOC_THEME_SETTING": "Theme setting",
+  "LOC_WEATHER_PHOTO_THEME": "Weather photo theme",
+  "LOC_LIGHT_THEME": "Light theme",
+  "LOC_BLUE_THEME": "Blue theme",
+  "LOC_DARK_THEME": "Dark theme",
   "LOC_AIR_QUALITY_IS_GOOD" : "大気の状態が良いです",
   "LOC_AIR_QUALITY_IS_MODERATE" : "大気の状態は普通です"
 }

--- a/client/www/locales/ko.json
+++ b/client/www/locales/ko.json
@@ -301,9 +301,11 @@
   "LOC_AIR_FORECAST_SOURCE" : "예보자료",
   "LOC_KAQ_DESCRIPTION": "대기질 예보자료는 '안양대학교 기후에너지환경융합연구소(약칭: 안양대학교 기후융합연구소, 소장: 환경에너지공학과 구윤서 교수)'에서 제공하는 자료입니다.",
   "LOC_AIRKOREA_DESCRIPTION": "환경부는 대기오염으로 인한 국민 건강 피해를 최소화 하기 위해 대기오염 농도를 예보하고 있습니다.",
-  "LOC_SHOW_WEATHER_PHOTOS": "날씨 사진 표시",
-  "LOC_OFF": "끄기",
-  "LOC_ON": "켜기",
+  "LOC_THEME_SETTING": "테마 설정",
+  "LOC_WEATHER_PHOTO_THEME": "날씨 사진 테마",
+  "LOC_LIGHT_THEME": "밝은 테마",
+  "LOC_BLUE_THEME": "파란색 테마",
+  "LOC_DARK_THEME": "어두운 테마",
   "LOC_AIR_QUALITY_IS_GOOD" : "대기상태가 좋아요",
   "LOC_AIR_QUALITY_IS_MODERATE" : "대기상태는 보통입니다"
 }

--- a/client/www/locales/zh-CN.json
+++ b/client/www/locales/zh-CN.json
@@ -301,9 +301,11 @@
   "LOC_AIR_FORECAST_SOURCE" : "预测材料",
   "LOC_KAQ_DESCRIPTION": "Atmospheric quality forecasting data is provided by Anyang University Climate Energy Environment Convergence Research Institute (abbreviated name: Anyang University, Climate Convergence Research Institute, Director: Professor of Environmental Energy Engineering)",
   "LOC_AIRKOREA_DESCRIPTION": "The Ministry of Environment of Korea is predicting the air pollution concentration to minimize the public health damage caused by air pollution.",
-  "LOC_SHOW_WEATHER_PHOTOS": "天气照片",
-  "LOC_OFF": "离",
-  "LOC_ON": "上",
+  "LOC_THEME_SETTING": "Theme setting",
+  "LOC_WEATHER_PHOTO_THEME": "Weather photo theme",
+  "LOC_LIGHT_THEME": "Light theme",
+  "LOC_BLUE_THEME": "Blue theme",
+  "LOC_DARK_THEME": "Dark theme",
   "LOC_AIR_QUALITY_IS_GOOD" : "空气状况好",
   "LOC_AIR_QUALITY_IS_MODERATE" : "空气状况一般"
 }

--- a/client/www/locales/zh-TW.json
+++ b/client/www/locales/zh-TW.json
@@ -301,9 +301,11 @@
   "LOC_AIR_FORECAST_SOURCE" : "預測材料",
   "LOC_KAQ_DESCRIPTION": "Atmospheric quality forecasting data is provided by Anyang University Climate Energy Environment Convergence Research Institute (abbreviated name: Anyang University, Climate Convergence Research Institute, Director: Professor of Environmental Energy Engineering)",
   "LOC_AIRKOREA_DESCRIPTION": "The Ministry of Environment of Korea is predicting the air pollution concentration to minimize the public health damage caused by air pollution.",
-  "LOC_SHOW_WEATHER_PHOTOS": "天氣照片",
-  "LOC_OFF": "離",
-  "LOC_ON": "上",
+  "LOC_THEME_SETTING": "Theme setting",
+  "LOC_WEATHER_PHOTO_THEME": "Weather photo theme",
+  "LOC_LIGHT_THEME": "Light theme",
+  "LOC_BLUE_THEME": "Blue theme",
+  "LOC_DARK_THEME": "Dark theme",
   "LOC_AIR_QUALITY_IS_GOOD" : "空氣狀況好",
   "LOC_AIR_QUALITY_IS_MODERATE" : "空氣狀況一般"
 }

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -178,20 +178,15 @@
                 </tr>
             </table>
         </div>
-
         <div class="card" ng-if="stnList">
-            <div class="card-title">{{"LOC_STATION"|translate}}({{airCodeName|translate}})</div>
+            <div class="card-title">{{"LOC_STATION"|translate}} ({{airCodeName|translate}})</div>
             <div class="card-scroll">
                 <table class="rowgroup-hspacing-box">
                     <tr>
-                        <td ng-repeat="last in stnList"
-                            ng-class="{selected:$index===stnIndex}"
+                        <td ng-repeat="last in stnList" ng-class="{selected:$index===stnIndex}"
                             ng-click="setStation($index)" style="width: 110px;">
                             <p>{{last.stationName}}</p>
-                            <i ng-bind-html="getSentimentIcon(last.grade)"
-                               class="material-icons"
-                               ng-style="{'color': grade2Color(last.grade)}"></i>
-                            <br>
+                            <i ng-bind-html="getSentimentIcon(last.grade)" class="material-icons" ng-style="{'color': grade2Color(last.grade)}"></i><br>
                             <span ng-style="{'color': grade2Color(last.grade)}">{{aqiCode==='aqi'?last.str:last.value}}</span>
                         </td>
                     </tr>

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -31,11 +31,11 @@
                 style="padding: 0 4px;margin-right: 4px"></button>
     </ion-nav-buttons>
     <ion-content delegate-handle="body" direction="y" zooming="false" scrollbar-x="false" scrollbar-y="false"
-                 has-bouncing="false" tabs-shrink bar-scrolled class="main-content">
+                 has-bouncing="false" tabs-shrink bar-scrolled theme-apply class="main-content">
         <div class="card">
             <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()" class="row row-no-padding"
-                 ng-class="photo?'photo':'no-photo'" ng-style="{'min-height':headerHeight+'px'}">
-                <div class="photo-box" ng-style="{'background-image': 'linear-gradient(to bottom, rgba(255,255,255,0) 100%, rgba(255,255,255,1)), url('+photo+')'}"></div>
+                 ng-style="{'min-height':headerHeight+'px'}">
+                <div class="photo-box" ng-style="{'background-image': photo}"></div>
                 <div class="main-box-arrow" ng-click="onSwipeRight()" ng-if="cityCount > 1">
                     <span class="icon-left ion-chevron-left"></span>
                 </div>

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -31,11 +31,11 @@
                 style="padding: 0 4px;margin-right: 4px"></button>
     </ion-nav-buttons>
     <ion-content delegate-handle="body" direction="y" zooming="false" scrollbar-x="false" scrollbar-y="false"
-                 has-bouncing="false" tabs-shrink bar-scrolled class="main-content">
+                 has-bouncing="false" tabs-shrink bar-scrolled theme-apply class="main-content">
         <div class="card">
             <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()" class="row row-no-padding"
-                 ng-class="photo?'photo':'no-photo'" ng-style="{'min-height':headerHeight+'px'}">
-                <div class="photo-box" ng-style="{'background-image': 'linear-gradient(to bottom, rgba(255,255,255,0) 100%, rgba(255,255,255,1)), url('+photo+')'}"></div>
+                 ng-style="{'min-height':headerHeight+'px'}">
+                <div class="photo-box" ng-style="{'background-image': photo}"></div>
                 <div class="main-box-arrow" ng-click="onSwipeRight()" ng-if="cityCount > 1">
                     <span class="icon-left ion-chevron-left"></span>
                 </div>


### PR DESCRIPTION
1. ios에서 body 위치가 header bar 아래에 있는 문제 수정
    1. ios에서 main-content의 top이 0으로 설정되지 않아 !important 속성 추가
    2. ios의 경우 header bar에 status bar도 포함되어 있으므로 md-page-header의 padding-top을 64px로 설정
2. 날씨 사진 표시 설정 대신 테마 설정으로 변경
    1. 날씨 사진 표시 off는 밝은 테마로, on은 날씨 사진 테마로 처리
    2. theme.js에 각 테마별로 default icons, weather 경로 설정
    3. app.run 호출 시, 테마가 변경되면 icons, weather의 imgPath 설정
    4. md-page-header의 .photo, no-photo class 제거
    5. theme-apply directive 추가, forecast, dailyforecast의 ion-content에 추가
        1. ion-content가 로드될 때 photo class 추가
        2. stateChangeStart 이벤트가 발생하면 photo class 제거
3. SettingCtrl 대신 TwStorage의 init에서 settingsInfo 초기값 설정 및 $rootScope.settingsInfo 값 설정 처리
    1. TwStorage의 init에서 $rootScope.settingsInfo에 초기값 설정
    2. 저장된 settingsInfo 값이 없으면 $rootScope.settingsInfo를 TwStorage에 저장
    3. 저장된 settingsInfo 값이 있으면 그 값을 $rootScope.settingsInfo에 업데이트
4. TwStorage의 settingsInfo 대신 $rootScope의 settingsInfo를 사용하도록 변경
    1. TwStorage의 init 이후에는 $rootScope.settingsInfo가 항상 값이 있음
5. city의 photo 설정
    1. createCity에서 city의 photo 초기값 설정
    2. addCity에서 현재 날씨에 맞는 city의 photo 설정
6. chrome에서 리로드 시에 에러나는 문제 수정(WeatherUtil.loadWeatherPhotos()이 끝나면 start 페이지로 이동하도록 하여 발생하는 문제임)
    1. 기존 start 페이지 이동 시점 롤백
    2. WeatherUtil.loadWeatherPhotos()을 비동기 처리로 수정
    3. WeatherUtil.loadWeatherPhotos()이 끝나면 cityList의 photo가 없는 경우 설정 처리 및 forecast/dailyforecast의 photo 업데이트