### PR TITLE
TW-242 upgrade new relic agent

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -42,7 +42,7 @@
     "jwt-simple": "^0.3.0",
     "mongoose": "^5.0.15",
     "morgan": "~1.6.1",
-    "newrelic": "^1.24.1",
+    "newrelic": "^4.0.0",
     "node-gcm": "^0.14.0",
     "request": "^2.60.0",
     "serve-favicon": "~2.3.0",


### PR DESCRIPTION
- mongoose update이후 db query 추적이 안됨, 버전업해도 안되는듯하지만 현재 버전이 오래되어 업그레이드 진행