### PR TITLE
TW-145 날씨 사진 테마 지원 #1855

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -1614,6 +1614,33 @@ angular.module('starter', [
             }
         });
 
+        $compileProvider.directive("photoUrl", [function () {
+            return {
+                restrict: "A",
+                scope: {
+                    photoUrl: '='
+                },
+                link: function (scope, element, attributes) {
+                    scope.$watch('photoUrl', function(newValue) {
+                        if (newValue == undefined) {
+                            return;
+                        }
+
+                        var image = new Image();
+                        image.onload = function () {
+                            scope.$apply(function () {
+                                element.css({ backgroundImage: 'linear-gradient(to bottom, rgba(0,0,0,0.3) 95%, rgba(255,255,255,0.9)), url("' + newValue + '")' });
+                            });
+                        };
+                        image.onerror = function () {
+                            element.css({ backgroundImage: 'url("img/bg.png")' });
+                        };
+                        image.src = newValue;
+                    });
+                }
+            };
+        }]);
+
         // Ionic uses AngularUI Router which uses the concept of states
         // Learn more here: https://github.com/angular-ui/ui-router
         // Set up the various states which the app can be in.

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -412,7 +412,7 @@ angular.module('controller.forecastctrl', [])
                     $scope.source = cityData.source;
                 }
                 if ($rootScope.settingsInfo.theme == 'photo') {
-                    $scope.photo = 'linear-gradient(to bottom, rgba(0,0,0,0.3) 95%, rgba(255,255,255,0.9)), url('+cityData.photo+'), url(img/bg.png)';
+                    $scope.photo = cityData.photo;
                 }
 
                 dayTable = cityData.dayChart[0].values;
@@ -759,7 +759,7 @@ angular.module('controller.forecastctrl', [])
                         return;
                     }
 
-                    $scope.photo = 'linear-gradient(to bottom, rgba(0,0,0,0.3) 95%, rgba(255,255,255,0.9)), url('+cityData.photo+'), url(img/bg.png)';
+                    $scope.photo = cityData.photo;
                 }
             }
             catch(err) {

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -35,7 +35,7 @@
         <div class="card">
             <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()" class="row row-no-padding"
                  ng-style="{'min-height':headerHeight+'px'}">
-                <div class="photo-box" ng-style="{'background-image': photo}"></div>
+                <div class="photo-box" photo-url="photo"></div>
                 <div class="main-box-arrow" ng-click="onSwipeRight()" ng-if="cityCount > 1">
                     <span class="icon-left ion-chevron-left"></span>
                 </div>

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -35,7 +35,7 @@
         <div class="card">
             <div md-page-header on-swipe-left="onSwipeLeft()" on-swipe-right="onSwipeRight()" class="row row-no-padding"
                  ng-style="{'min-height':headerHeight+'px'}">
-                <div class="photo-box" ng-style="{'background-image': photo}"></div>
+                <div class="photo-box" photo-url="photo"></div>
                 <div class="main-box-arrow" ng-click="onSwipeRight()" ng-if="cityCount > 1">
                     <span class="icon-left ion-chevron-left"></span>
                 </div>


### PR DESCRIPTION
* 날씨 사진 표시 방법 변경
 - 새로운 날씨 사진이 로드되기 전까지 이전 날씨 사진이 표시되어 깜박거리거나 기본 이미지가 잠깐 보이는 문제 수정됨
 1. photo-url이 변경되면 directive에서 Image를 생성하여 이미지를 로드
 2. 이미지 로드가 되면 background-image에 linear-gradient 효과를 주고 로드한 이미지를 설정
 3. 이미지 로드가 실패하면 background-image에 기본 이미지인 img/bg.png을 설정