### PR TITLE
TW-323 초기 인터넷이 안된 경우 날씨 사진이 표시 안됨

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -344,10 +344,6 @@ angular.module('starter', [
             $rootScope.weatherImgPath = window.theme[$rootScope.settingsInfo.theme].weather;
 
             WeatherInfo.loadCities();
-            WeatherUtil.loadWeatherPhotos().finally(function () {
-                WeatherInfo.updatePhotos();
-                $rootScope.$broadcast('loadWeatherPhotosEvent');
-            });
             if (Push.init() === true) {
                 //show notify alert info popup
                 setTimeout(function () {
@@ -357,6 +353,10 @@ angular.module('starter', [
             }
             Purchase.init();
             Units.loadUnits();
+
+            window.addEventListener('online',  function () {
+                WeatherInfo.loadWeatherPhotos();
+            });
 
             var daumServiceKeys = TwStorage.get("daumServiceKeys");
             if (daumServiceKeys == undefined || daumServiceKeys.length != clientConfig.daumServiceKeys.length) {

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -577,7 +577,7 @@ angular.module('controller.forecastctrl', [])
                     el.scrollLeft = getTodayPosition('short');
                 }
                 else {
-                    console.error('chart scroll is null');
+                    //console.error('chart scroll is null');
                 }
 
                 el = document.getElementById('chartMidScroll');
@@ -585,7 +585,7 @@ angular.module('controller.forecastctrl', [])
                     el.scrollLeft = getTodayPosition('mid');
                 }
                 else {
-                    console.error('chart scroll is null');
+                    //console.error('chart scroll is null');
                 }
             }, 300);
         }

--- a/client/www/js/controller.searchctrl.js
+++ b/client/www/js/controller.searchctrl.js
@@ -127,7 +127,7 @@ angular.module('controller.searchctrl', [])
                     city.currentWeather = {};
                 }
                 if (!city.currentWeather.skyIcon) {
-                    city.currentWeather.skyIcon = 'Sun';
+                    city.currentWeather.skyIcon = 'sun';
                 }
                 if (city.currentWeather.t1h === undefined) {
                     city.currentWeather.t1h = '-';


### PR DESCRIPTION
* 앱 실행 시 날씨 사진을 가져오지 못한 경우, network 연결이 되거나 날씨 정보가 업데이트될 때 날씨 사진을 재로드 처리
* WeatherUtil.findWeatherPhoto()에서 tag 검색되지 않는 문제
 - currentWeather.skyIcon의 기본값을 'Sun' 대신 'sun'으로 변경
* chart scroll의 console.error 주석 처리
 - 시간별날씨, 일별날씨에서는 하나만 있기 때문에 항상 에러로 표시되어 주석 처리함