### PR TITLE
TW-384 airUnit=aircn으로 전국날씨 요청시에 서버 죽는 문제

### DIFF
--- a/server/routes/v000803/route.nation.js
+++ b/server/routes/v000803/route.nation.js
@@ -78,13 +78,18 @@ function getSidoArpltn(req, res, next) {
     KecoCtrl.getSidoArpltn(function (err, arpltnList) {
         if (err) {
             log.error(err);
-            return next();
+            return next(err);
         }
 
-        arpltnList.forEach(function (arpltn) {
-            KecoCtrl.recalculateValue(arpltn, airUnit);
-        });
-        req.air = arpltnList;
+        try {
+            arpltnList.forEach(function (arpltn) {
+                KecoCtrl.recalculateValue(arpltn, airUnit);
+            });
+            req.air = arpltnList;
+        }
+        catch (err) {
+           return next(err);
+        }
         next();
     });
 }


### PR DESCRIPTION
- 비정상적인 aircn에 대한 예외처리