### PR TITLE
TW-407 iPhoneX에서 상단 TopBox의 높이 조절

### DIFF
--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -138,7 +138,7 @@ angular.module('controller.forecastctrl', [])
             }
         };
 
-        var regionSize;
+        // var regionSize;
         // var regionSumSize;
         var bigDigitSize;
         //var bigTempPointSize;
@@ -189,9 +189,9 @@ angular.module('controller.forecastctrl', [])
             //var topTimeSize = mainHeight * 0.026;
             //$scope.topTimeSize = topTimeSize<16.8?topTimeSize:16.8;
 
-            regionSize = mainHeight * 0.0306 * padding; //0.051
-            regionSize = regionSize<33.04?regionSize:33.04;
-            $scope.regionSize = regionSize;
+            // regionSize = mainHeight * 0.0306 * padding; //0.051
+            // regionSize = regionSize<33.04?regionSize:33.04;
+            // $scope.regionSize = regionSize;
 
             // regionSumSize = mainHeight * 0.0336 * padding; //0.047
             // regionSumSize = regionSumSize<30.45?regionSumSize:30.45;

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -1394,8 +1394,10 @@ angular.module('controller.tabctrl', [])
                 contentRatio = 0.68;
             }
 
-            //빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
-            $scope.headerHeight = $scope.bodyHeight * headerRatio + 44;
+            // 빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
+            // 최대 크기로 설정된 경우 [md-page-header]의 최대 height은 320px이므로 최대 크기로 제한
+            // = [md-page-header]의 padding-top(64px) + padding-bottom(22px) + bigDigitSize(142.1px) + summary 3lines
+            $scope.headerHeight = Math.min($scope.bodyHeight * headerRatio + 44, 320);
             $scope.mainHeight = $scope.bodyHeight * contentRatio;
         };
 


### PR DESCRIPTION
TW-407 iPhoneX에서 상단 TopBox의 높이 조절
* bodyHeight를 기준으로 특정 비율로 TopBox의 높이를 설정하고 있어 iPhoneX의 경우 너무 크게 설정됨
 - 최대 크기로 설정된 경우 TopBox의 최대 높이는 320px이므로 320px을 넘지 않도록 제한함
 - [md-page-header]의 padding-top(64px) + padding-bottom(22px) + bigDigitSize(142.1px) + summary 3lines = 320px
* 사용하지 않는 설정값 주석 처리