### PR TITLE
TW-97 시간별 습도, 풍향, 풍속 정보 표시 #1852

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -572,8 +572,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
         background: rgba(0, 0, 0, 0.1);
         border-radius: 5%;
         position: absolute;
-        left: 10px;
-        bottom: 0px;
+        right: 10px;
         font-size: 13px;
         .chart-label-today {
           margin: 5px;
@@ -586,6 +585,23 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
           border-left: 13px solid #9e9e9e;
           padding-left: 5px;
           height: 13px;
+        }
+      }
+      .chart-separator {
+        height: 1px;
+        background-color: #d9e5f2;
+        opacity: 0.3;
+      }
+      .chart-expander {
+        height: 24px;
+        margin-bottom: -10px;
+        div {
+          width: 100%;
+          position: absolute;
+          text-align: center;
+        }
+        i {
+          color: #444;
         }
       }
       .air-std-table {
@@ -743,6 +759,14 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
           border-left: 13px solid #fff;
         }
       }
+      .chart-separator {
+        background-color: #ddd;
+      }
+      .chart-expander {
+        i {
+          color: #ddd;
+        }
+      }
     }
   }
 }
@@ -840,6 +864,14 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
           border-left: 13px solid #d0d0d0;
         }
       }
+      .chart-separator {
+        background-color: #fff;
+      }
+      .chart-expander {
+        i {
+          color: #fff;
+        }
+      }
     }
   }
 }
@@ -935,6 +967,14 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
         }
         .chart-label-yesterday {
           border-left: 13px solid #d0d0d0;
+        }
+      }
+      .chart-separator {
+        background-color: #fff;
+      }
+      .chart-expander {
+        i {
+          color: #fff;
         }
       }
     }

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -935,6 +935,211 @@ angular.module('starter', [
             };
         });
 
+        $compileProvider.directive('ngShortDetailChart', function() {
+            return {
+                restrict: 'A',
+                transclude: true,
+                link: function (scope, iElement) {
+                    var margin = 12;
+                    var textTop = 12;
+                    var width, height, x, y;
+                    var svg;
+
+                    function initSvg() {
+                        console.log('scope watch');
+
+                        x = d3.scale.ordinal().rangeBands([0, width]);
+                        y = d3.scale.linear().range([height, 0]);
+
+                        if (svg != undefined) {
+                            svg.selectAll("*").remove();
+                            svg.attr('width', width)
+                                .attr('height', height);
+                        }
+                        else {
+                            svg = d3.select(iElement[0]).append('svg')
+                                .attr('width', width)
+                                .attr('height', height);
+                        }
+                    }
+
+                    //parent element의 heigt가 변경되면, svg에 있는 모든 element를 지우고, height를 변경 다시 그림.
+                    //chart가 나오지 않는 경우에는 height가 0이므로 그때는 동작하지 않음.
+                    //element height는 광고 제거,추가 그리고 시간별,요일별 로 변경될때 변경됨.
+                    scope.$watch(function () {
+                        return iElement[0].getBoundingClientRect().height;
+                    }, function(newValue) {
+                        if (newValue === 0 || newValue === height) {
+                            return;
+                        }
+                        width = iElement[0].getBoundingClientRect().width;
+                        height = iElement[0].getBoundingClientRect().height;
+
+                        if (!(scope.timeChart == undefined)) {
+                            initSvg();
+                            chart();
+                        }
+                    });
+
+                    var chart = function () {
+                        var data = scope.timeChart;
+
+                        if (x == undefined || y == undefined || svg == undefined || data == undefined) {
+                            return;
+                        }
+
+                        x.domain(d3.range(data[0].values.length));
+
+                        d3.svg.axis()
+                            .scale(x)
+                            .orient('bottom');
+
+                        var currentRect = svg.selectAll('.current-rect').data(function () {
+                            return [data[1].currentIndex];
+                        });
+
+                        currentRect.enter().append('rect')
+                            .attr('class', 'current-rect');
+
+                        currentRect
+                            .attr('x', function (index) {
+                                return x.rangeBand() * index + x.rangeBand() / 2 + 0.5;
+                            })
+                            .attr('y', function () {
+                                return 0;
+                            })
+                            .attr('width', x.rangeBand() - 0.5)
+                            .attr('height', height);
+
+                        currentRect.exit().remove();
+
+                        // draw guideLine
+                        var guideLines = svg.selectAll('.guide-line')
+                            .data(function () {
+                                return data[1].values;
+                            });
+
+                        guideLines.enter().append('line')
+                            .attr('class', function (d) {
+                                if (d.value.time === 24) {
+                                    return 'guide-vivid-line';
+                                } else {
+                                    return 'guide-line';
+                                }
+                            })
+                            .attr('x1', function (d, i) {
+                                return x.rangeBand() * i + x.rangeBand() / 2+0.5;
+                            })
+                            .attr('x2', function (d, i) {
+                                return x.rangeBand() * i + x.rangeBand() / 2+0.5;
+                            })
+                            .attr('y1', 0)
+                            .attr('y2', height);
+
+                        guideLines.exit().remove();
+
+                        var hourlyTables = svg.selectAll('.hourly-table')
+                            .data(function () {
+                                return data[1].values;
+                            });
+
+                        var hourObject = hourlyTables.enter()
+                            .append('g')
+                            .attr('class', 'hourly-table');
+
+                        hourObject.append("svg:image")
+                            .attr("xlink:href", function (d) {
+                                return scope.iconsImgPath + "/wind_direction.png";
+                            })
+                            .attr("x", function (d, i) {
+                                return x.rangeBand() * i - scope.smallImageSize/2;
+                            })
+                            .attr("y", margin / 2)
+                            .attr("width", scope.smallImageSize)
+                            .attr("height", scope.smallImageSize)
+                            .attr('transform', function (d, i) {
+                                return 'rotate(' + d.value.vec + ', ' + (x.rangeBand() * i) + ', ' + (margin + scope.smallImageSize) / 2 + ')';
+                            });
+
+                        hourObject.append("text")
+                            .attr('class', 'chart-text')
+                            .attr("x", function (d, i) {
+                                return x.rangeBand() * i;
+                            })
+                            .attr("y", function(){
+                                return margin / 2 + scope.smallImageSize + textTop;
+                            })
+                            .text(function (d) {
+                                return d.value.wsd;
+                            })
+                            .append('tspan')
+                            .attr('class', 'chart-unit-text')
+                            .text(function () {
+                                return scope.getWindSpdUnit();
+                            });
+
+                        hourObject.append("svg:image")
+                            .attr("xlink:href", function (d) {
+                                var reh = d.value.reh? d.value.reh - d.value.reh % 10 : '00';
+                                return scope.iconsImgPath + "/humidity_" + reh +".png";
+                            })
+                            .attr("x", function (d, i) {
+                                return x.rangeBand() * i - scope.smallImageSize/2;
+                            })
+                            .attr("y", function () {
+                                return margin / 2 + scope.smallImageSize + textTop + margin;
+                            })
+                            .attr("width", scope.smallImageSize)
+                            .attr("height", scope.smallImageSize);
+
+                        hourObject.append("text")
+                            .attr('class', 'chart-text')
+                            .attr("x", function (d, i) {
+                                return x.rangeBand() * i;
+                            })
+                            .attr("y", function () {
+                                return margin / 2 + scope.smallImageSize * 2 + textTop + margin + textTop;
+                            })
+                            .text(function (d) {
+                                return d.value.reh;
+                            })
+                            .append('tspan')
+                            .attr('class', 'chart-unit-text')
+                            .text('%');
+
+                        hourObject.filter(function(d, i) {
+                            return i == 0;
+                        }).remove();
+                    };
+
+                    scope.$watch('timeWidth', function(newValue) {
+                        //guide에서 나올때, 점들이 모이는 증상이 있음.
+                        if (newValue == undefined || newValue == width) {
+                            console.log('new value is undefined or already set same width='+width);
+                            return;
+                        }
+
+                        console.log('update timeWidth='+newValue);
+                        width = newValue;
+
+                        return;
+                    });
+
+                    scope.$watch('timeChart', function (newVal) {
+                        if (newVal) {
+                            console.log("update timeChart");
+                            if (scope.timeChart == undefined) {
+                                console.log("time chart is undefined");
+                                return;
+                            }
+                            initSvg();
+                            chart();
+                        }
+                    });
+                }
+            };
+        });
+
         $compileProvider.directive('ngMidChart', function() {
             return {
                 restrict: 'A',

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -535,6 +535,7 @@ angular.module('controller.forecastctrl', [])
                 if ($scope.forecastType === 'short' || $scope.forecastType === 'weather' ) {
                     var chartShortHeight = $scope.mainHeight - (143 + padding);
                     $scope.chartShortHeight = chartShortHeight < 300 ? chartShortHeight : 300;
+                    $scope.chartShortDetailHeight = $scope.smallImageSize * 2 + 17 * 2 + 12 * 2;
                 }
                 if ($scope.forecastType === 'mid' || $scope.forecastType === 'weather' ) {
                     var chartMidHeight = $scope.mainHeight - (136 + padding);

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -138,7 +138,7 @@ angular.module('controller.forecastctrl', [])
             }
         };
 
-        // var regionSize;
+        var regionSize;
         // var regionSumSize;
         var bigDigitSize;
         //var bigTempPointSize;
@@ -189,9 +189,9 @@ angular.module('controller.forecastctrl', [])
             //var topTimeSize = mainHeight * 0.026;
             //$scope.topTimeSize = topTimeSize<16.8?topTimeSize:16.8;
 
-            // regionSize = mainHeight * 0.0306 * padding; //0.051
-            // regionSize = regionSize<33.04?regionSize:33.04;
-            // $scope.regionSize = regionSize;
+            regionSize = mainHeight * 0.0306 * padding; //0.051
+            regionSize = regionSize<33.04?regionSize:33.04;
+            $scope.regionSize = regionSize;
 
             // regionSumSize = mainHeight * 0.0336 * padding; //0.047
             // regionSumSize = regionSumSize<30.45?regionSumSize:30.45;

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -535,7 +535,7 @@ angular.module('controller.forecastctrl', [])
                 if ($scope.forecastType === 'short' || $scope.forecastType === 'weather' ) {
                     var chartShortHeight = $scope.mainHeight - (143 + padding);
                     $scope.chartShortHeight = chartShortHeight < 300 ? chartShortHeight : 300;
-                    $scope.chartShortDetailHeight = $scope.smallImageSize * 2 + 17 * 2 + 12 * 2;
+                    $scope.chartShortDetailHeight = $scope.smallImageSize * 2 + 17 * 2 + 12 * 2; // margin + image + text + image + text + margin
                 }
                 if ($scope.forecastType === 'mid' || $scope.forecastType === 'weather' ) {
                     var chartMidHeight = $scope.mainHeight - (136 + padding);

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -138,7 +138,7 @@ angular.module('controller.forecastctrl', [])
             }
         };
 
-        var regionSize;
+        // var regionSize;
         // var regionSumSize;
         var bigDigitSize;
         //var bigTempPointSize;
@@ -189,9 +189,9 @@ angular.module('controller.forecastctrl', [])
             //var topTimeSize = mainHeight * 0.026;
             //$scope.topTimeSize = topTimeSize<16.8?topTimeSize:16.8;
 
-            regionSize = mainHeight * 0.0306 * padding; //0.051
-            regionSize = regionSize<33.04?regionSize:33.04;
-            $scope.regionSize = regionSize;
+            // regionSize = mainHeight * 0.0306 * padding; //0.051
+            // regionSize = regionSize<33.04?regionSize:33.04;
+            // $scope.regionSize = regionSize;
 
             // regionSumSize = mainHeight * 0.0336 * padding; //0.047
             // regionSumSize = regionSumSize<30.45?regionSumSize:30.45;

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -1394,8 +1394,10 @@ angular.module('controller.tabctrl', [])
                 contentRatio = 0.68;
             }
 
-            //빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
-            $scope.headerHeight = $scope.bodyHeight * headerRatio + 44;
+            // 빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
+            // 최대 크기로 설정된 경우 [md-page-header]의 최대 height은 320px이므로 최대 크기로 제한
+            // = [md-page-header]의 padding-top(64px) + padding-bottom(22px) + bigDigitSize(142.1px) + summary 3lines
+            $scope.headerHeight = Math.min($scope.bodyHeight * headerRatio + 44, 320);
             $scope.mainHeight = $scope.bodyHeight * contentRatio;
         };
 

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -1394,10 +1394,8 @@ angular.module('controller.tabctrl', [])
                 contentRatio = 0.68;
             }
 
-            // 빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
-            // 최대 크기로 설정된 경우 [md-page-header]의 최대 height은 320px이므로 최대 크기로 제한
-            // = [md-page-header]의 padding-top(64px) + padding-bottom(22px) + bigDigitSize(142.1px) + summary 3lines
-            $scope.headerHeight = Math.min($scope.bodyHeight * headerRatio + 44, 320);
+            //빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
+            $scope.headerHeight = $scope.bodyHeight * headerRatio + 44;
             $scope.mainHeight = $scope.bodyHeight * contentRatio;
         };
 

--- a/client/www/templates/ta-tab-weather.html
+++ b/client/www/templates/ta-tab-weather.html
@@ -76,11 +76,19 @@
                             </div>
                         </div>
                         <div ng-short-chart class="chart-content" ng-style="{'height':chartShortHeight+'px'}"></div>
+                        <div class="chart-label" ng-style="{'top':(chartShortHeight - 10)+'px'}" ng-if="timeChart">
+                            <div class="chart-label-today">{{"LOC_THIS_DAY_TEMP"|translate}}</div>
+                            <div class="chart-label-yesterday">{{"LOC_PREVIOUS_DAY_TEMP"|translate}}</div>
+                        </div>
+                        <div class="chart-separator"></div>
+                        <div ng-short-detail-chart class="chart-content" ng-style="{'height':chartShortDetailHeight+'px'}" ng-if="expand=='expand_less'"></div>
+                        <div class="chart-separator"></div>
+                        <div class="chart-expander">
+                            <div ng-init="expand='expand_more'" ng-click="expand=(expand=='expand_less')?'expand_more':'expand_less'">
+                                <i class="material-icons">{{expand}}</i>
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <div class="chart-label" ng-if="timeChart">
-                    <div class="chart-label-today">{{"LOC_THIS_DAY_TEMP"|translate}}</div>
-                    <div class="chart-label-yesterday">{{"LOC_PREVIOUS_DAY_TEMP"|translate}}</div>
                 </div>
             </div>
           </div>

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -76,11 +76,19 @@
                             </div>
                         </div>
                         <div ng-short-chart class="chart-content" ng-style="{'height':chartShortHeight+'px'}"></div>
+                        <div class="chart-label" ng-style="{'top':(chartShortHeight - 10)+'px'}" ng-if="timeChart">
+                            <div class="chart-label-today">{{"LOC_THIS_DAY_TEMP"|translate}}</div>
+                            <div class="chart-label-yesterday">{{"LOC_PREVIOUS_DAY_TEMP"|translate}}</div>
+                        </div>
+                        <div class="chart-separator"></div>
+                        <div ng-short-detail-chart class="chart-content" ng-style="{'height':chartShortDetailHeight+'px'}" ng-if="expand=='expand_less'"></div>
+                        <div class="chart-separator"></div>
+                        <div class="chart-expander">
+                            <div ng-init="expand='expand_more'" ng-click="expand=(expand=='expand_less')?'expand_more':'expand_less'">
+                                <i class="material-icons">{{expand}}</i>
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <div class="chart-label" ng-if="timeChart">
-                    <div class="chart-label-today">{{"LOC_THIS_DAY_TEMP"|translate}}</div>
-                    <div class="chart-label-yesterday">{{"LOC_PREVIOUS_DAY_TEMP"|translate}}</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
TW-97 시간별 습도, 풍향, 풍속 정보 표시 #1852
* 시간별 차트 하단에 펴기/접기 버튼 표시
  - 초기값은 펴기 버튼 상태
* 펴기/접기 버튼 클릭 시 풍향/풍속/습도를 표시
  - 풍향은 wind_direction.png 이미지를 회전시켜 처리
* TodayAir의 날씨 페이지에도 동일하게 적용, 테마 지원