### PR TITLE
TW-284 [iOS] 상태바 컬러 조정

### DIFF
--- a/client/www/index.html
+++ b/client/www/index.html
@@ -154,7 +154,7 @@
     </ion-side-menu>
 
     <ion-side-menu-content drag-content="false" ng-class="isMenuOpen() ? 'menu-open' : ''" class="body-content">
-        <ion-nav-bar class="bar-clear"></ion-nav-bar>
+        <ion-nav-bar class="bar-clear" style="visibility: hidden"></ion-nav-bar>
         <ion-nav-view></ion-nav-view>
     </ion-side-menu-content>
 

--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -278,7 +278,12 @@ angular.module('starter', [
             body.removeClass('search forecast dailyforecast air start setting push');
             body.addClass($rootScope.state);
 
-            if (window.StatusBar) {
+            var navbars = angular.element(document.querySelectorAll('ion-nav-bar'));
+            for (var i = 0; i < navbars.length; i++) {
+                navbars[i].style.visibility = "visible";
+            }
+
+            if (window.StatusBar && ionic.Platform.isIOS()) {
                 if ($rootScope.settingsInfo.theme === 'light') {
                     StatusBar.styleDefault();
                 } else { //photo, dark, old
@@ -1959,7 +1964,12 @@ angular.module('starter', [
         $ionicConfigProvider.views.transition("android");
 
         if (window.StatusBar) {
-            StatusBar.styleLightContent();
+            if (ionic.Platform.isIOS()) {
+                StatusBar.styleLightContent();
+            }
+            else {
+                StatusBar.backgroundColorByHexString('#111');
+            }
         }
 
         // Enable Native Scrolling on Android

--- a/client/www/js/controller.setting.radio.js
+++ b/client/www/js/controller.setting.radio.js
@@ -48,7 +48,7 @@ angular.module('controller.setting.radio', [])
                     $rootScope.iconsImgPath = window.theme[$rootScope.settingsInfo.theme].icons;
                     $rootScope.weatherImgPath = window.theme[$rootScope.settingsInfo.theme].weather;
 
-                    if (window.StatusBar) {
+                    if (window.StatusBar && ionic.Platform.isIOS()) {
                         if ($rootScope.settingsInfo.theme === 'light') {
                             StatusBar.styleDefault();
                         } else { //photo, dark, old


### PR DESCRIPTION
TW-284 [iOS] 상태바 컬러 조정
* iOS의 상태바 색상 처리 작업으로 android에서 문제가 발생함
 - iOS에서는 상태바 영역이 HeaderBar 영역과 겹쳐서 테마에 따라 다른 색상으로 표시되어야 함.
 - Android에서는 항상 어두운 상태바로 표시되므로 테마에 따라 StatusBar의 styleDefault()과 styleLightContent() 설정하는 코드는 iOS에서만 처리되도록 조건문 추가
* 앱 실행 시 SplashScreen이 내려가고 페이지가 로드되기 전에 body가 보이는 상태일 때 navBar가 흰색으로 표시되는 문제 수정
 - navBar를 hidden으로 설정한 후 실제 페이지가 로드되면 visible 상태로 변경하도록 시점 조절함