### PR TITLE
TW-409 화면 사이즈에 따라 TopBox, 차트의 사이즈를 비율로 계산하는 코드 정리

### DIFF
--- a/client/scss/ionic.app.scss
+++ b/client/scss/ionic.app.scss
@@ -302,6 +302,9 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
           span {
             vertical-align: super;
           }
+          img {
+            vertical-align: bottom;
+          }
         }
         .main-box-air-title {
           margin: auto;
@@ -322,7 +325,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
         }
         .main-box-summary {
           font-size: 21px;
-          line-height: 21px;
+          line-height: 24px;
           i {
             font-size: 24px;
             vertical-align: bottom;
@@ -330,7 +333,7 @@ $font-family-base: -apple-system, "Roboto", "Noto", "Helvetica Neue", sans-serif
         }
         .main-box-air-summary {
           font-size: 21px;
-          line-height: 21px;
+          line-height: 24px;
           i {
             font-size: 24px;
             vertical-align: bottom;

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -1,7 +1,6 @@
 angular.module('controller.forecastctrl', [])
     .controller('ForecastCtrl', function ($scope, WeatherInfo, WeatherUtil, Util, Purchase, $stateParams,
                                           $rootScope, $location, $ionicHistory, $translate, Units, Push, TwStorage) {
-        var ASPECT_RATIO_16_9 = 1.7;
         var colWidth;
 
         $scope.showDetailWeather = false;
@@ -138,90 +137,16 @@ angular.module('controller.forecastctrl', [])
             }
         };
 
-        var regionSize;
-        // var regionSumSize;
-        var bigDigitSize;
-        //var bigTempPointSize;
-        var bigSkyStateSize;
-        //var smallTimeSize;
-        var smallImageSize;
-        //var smallDigitSize;
-        var showAqi = false;
-        var headerE;
-
         function init() {
             //identifyUser();
             $ionicHistory.clearHistory();
             $scope.initSize();
 
-            colWidth = Math.min($scope.bodyWidth / 7, 60);
-            headerE = angular.element(document.querySelector('[md-page-header]'));
+            var headerE = angular.element(document.querySelector('[md-page-header]'));
             headerE.css('min-height', $scope.headerHeight+'px');
 
-            var padding = 1;
-            var smallPadding = 1;
-
-            //iphone 4 480-20(status bar)
-            if (($scope.bodyHeight === 460 || $scope.bodyHeight === 480) && $scope.bodyWidth === 320) {
-                padding = 1.125;
-                smallPadding = 1.1;
-            }
-            //iphone 5 568-20(status bar)
-            if (($scope.bodyHeight === 548 || $scope.bodyHeight === 568) && $scope.bodyWidth === 320) {
-                smallPadding = 1.1;
-            }
-
-            if ($scope.bodyHeight >= 640) {
-                //대부분의 android와 iPhone6부터 aqi보여줌.
-                showAqi = true;
-            }
-            else if (Purchase.accountLevel != Purchase.ACCOUNT_LEVEL_FREE
-                && $scope.bodyHeight / $scope.bodyWidth >= ASPECT_RATIO_16_9) {
-                //free이상의 유저이며, 16:9 이상 비율은 aqi보여줌.
-                showAqi = true;
-            }
-
-            var mainHeight = $scope.bodyHeight - 100;
-            if ($scope.bodyHeight / $scope.bodyWidth > 1.8) {
-                mainHeight *= 0.95
-            }
-
-            //var topTimeSize = mainHeight * 0.026;
-            //$scope.topTimeSize = topTimeSize<16.8?topTimeSize:16.8;
-
-            regionSize = mainHeight * 0.0306 * padding; //0.051
-            regionSize = regionSize<33.04?regionSize:33.04;
-            $scope.regionSize = regionSize;
-
-            // regionSumSize = mainHeight * 0.0336 * padding; //0.047
-            // regionSumSize = regionSumSize<30.45?regionSumSize:30.45;
-            // $scope.regionSumSize = regionSumSize;
-
-            bigDigitSize = mainHeight * 0.12264 * padding; //0.2193
-            bigDigitSize = bigDigitSize<142.1?bigDigitSize:142.1;
-            $scope.bigDigitSize = bigDigitSize;
-
-            //bigTempPointSize = mainHeight * 0.03384 * padding; //0.0423
-            //bigTempPointSize = bigTempPointSize<27.4?bigTempPointSize:27.4;
-
-            bigSkyStateSize = mainHeight * 0.11264 * padding; //0.1408
-            bigSkyStateSize = bigSkyStateSize<91.2?bigSkyStateSize:91.2;
-            $scope.bigSkyStateSize = bigSkyStateSize;
-
-            //smallTimeSize = mainHeight * 0.0299 * smallPadding;
-            //smallTimeSize = smallTimeSize<19.37?smallTimeSize:19.37;
-
-            smallImageSize = mainHeight * 0.0512 * smallPadding;
-            smallImageSize = smallImageSize<33.17?smallImageSize:33.17;
-            $scope.smallImageSize = smallImageSize;
-
-            //smallDigitSize = mainHeight * 0.0320 * smallPadding;
-            //smallDigitSize = smallDigitSize<20.73?smallDigitSize:20.73;
-
-            $scope.expand = TwStorage.get("expandShortChart");
-            if ($scope.expand === null) {
-                $scope.expand = false; // 기본값은 short-detail-chart가 숨겨진 상태
-            }
+            colWidth = Math.min($scope.bodyWidth / 7, 60);
+            $scope.smallImageSize = colWidth - colWidth * 0.2 * 2;
 
             var fav = parseInt($stateParams.fav);
             if (!isNaN(fav)) {
@@ -335,6 +260,9 @@ angular.module('controller.forecastctrl', [])
          */
         function getShortTableHeight(displayItemCount) {
             var val = 0;
+            if (displayItemCount == undefined || displayItemCount == 0) {
+                displayItemCount = 3;
+            }
             if (displayItemCount >= 1) {
                 //sky
                 val += $scope.smallImageSize;
@@ -433,7 +361,7 @@ angular.module('controller.forecastctrl', [])
                 dayTable = cityData.dayChart[0].values;
 
                 $scope.timeWidth = colWidth * cityData.timeTable.length;
-                $scope.dayWidth = colWidth * dayTable.length;
+                $scope.dayWidth = (colWidth * dayTable.length < $scope.bodyWidth) ? $scope.bodyWidth : colWidth * dayTable.length;
 
                 $scope.currentWeather = cityData.currentWeather;
 
@@ -505,45 +433,21 @@ angular.module('controller.forecastctrl', [])
 
                 // To share weather information for apple watch.
                 // AppleWatch.setWeatherData(cityData);
-                var padding = 0;
 
-                //의미상으로 배너 여부이므로, TwAds.enabledAds가 맞지만 loading이 느려, account level로 함.
-                //광고 제거 버전했을 때, AQI가 보이게 padding맞춤. 나머지 14px는 chart에서 사용됨.
-                if (Purchase.accountLevel == Purchase.ACCOUNT_LEVEL_FREE) {
-                    padding += 36;
+                var contentHeight = $scope.headerHeight - 44 - 5; // headerBar height = 44px, bottom padding = 5px
+                if (ionic.Platform.isIOS()) {
+                    contentHeight -= 20; // statusBar height = 20px
                 }
-
-                //16:9 이상의 부분은 padding으로 넘겨 여유 공간으로 사용함
-                if ($scope.bodyHeight > 0 && $scope.bodyWidth > 0) {
-                    if ($scope.bodyHeight / $scope.bodyWidth >= 2) {
-                        padding += parseInt(($scope.bodyHeight - ($scope.bodyWidth * 1.77)) / 2);
-                    }
-                }
-
-                if ($scope.bodyHeight === 480) {
-                    //iphone4
-                    padding -= 32;
-                }
-                else if (ionic.Platform.isAndroid()) {
-                    //status bar
-                    padding += 24;
-                    if ($scope.bodyHeight <= 512) {
-                        //view2 4:3
-                        padding -= 32;
-                    }
-                }
-
-                if (showAqi) {
-                    padding += 36;
-                }
-
                 if ($scope.forecastType === 'short' || $scope.forecastType === 'weather' ) {
-                    var chartShortHeight = $scope.mainHeight - (143 + padding);
+                    //var chartShortHeight = getShortTableHeight(cityData.timeChart[1].displayItemCount) + contentHeight;
+                    var chartShortHeight = getShortTableHeight(cityData.timeChart[1].displayItemCount) + $scope.bigFontSize * 2;
                     $scope.chartShortHeight = chartShortHeight < 300 ? chartShortHeight : 300;
-                    $scope.chartShortDetailHeight = $scope.smallImageSize * 2 + 17 * 2 + 12 * 2; // margin + image + text + image + text + margin
+                    // margin(12px) + image + text(15px) + image + text(15px) + margin(12px)
+                    $scope.chartShortDetailHeight = 12 * 2 + $scope.smallImageSize * 2 + 15 * 2;
                 }
                 if ($scope.forecastType === 'mid' || $scope.forecastType === 'weather' ) {
-                    var chartMidHeight = $scope.mainHeight - (136 + padding);
+                    //var chartMidHeight = getMidTableHeight(cityData.dayChart[0].displayItemCount) + contentHeight * 0.7;
+                    var chartMidHeight = getMidTableHeight(cityData.dayChart[0].displayItemCount) + $scope.bigFontSize * 1.5;
                     $scope.chartMidHeight = chartMidHeight < 300 ? chartMidHeight : 300;
                 }
 

--- a/client/www/js/controller.forecastctrl.js
+++ b/client/www/js/controller.forecastctrl.js
@@ -147,6 +147,11 @@ angular.module('controller.forecastctrl', [])
 
             colWidth = Math.min($scope.bodyWidth / 7, 60);
             $scope.smallImageSize = colWidth - colWidth * 0.2 * 2;
+            
+            $scope.expand = TwStorage.get("expandShortChart");
+            if ($scope.expand === null) {
+                $scope.expand = false; // 기본값은 short-detail-chart가 숨겨진 상태
+            }
 
             var fav = parseInt($stateParams.fav);
             if (!isNaN(fav)) {

--- a/client/www/js/controller.tabctrl.js
+++ b/client/www/js/controller.tabctrl.js
@@ -1372,31 +1372,29 @@ angular.module('controller.tabctrl', [])
                 $scope.bodyWidth = 360;
             }
 
-            var headerRatio = 0.4;
-            var contentRatio = 0.6;
-            if ($scope.bodyWidth >= $scope.tabletWidth && $scope.bodyWidth < $scope.bodyHeight) {
-                headerRatio = 0.4;
-                contentRatio = 0.6;
+            var headerRatio = 5 / 12;
+            if ($scope.bodyHeight < 600) {
+                headerRatio = 2 / 5;
             }
-            else if ($scope.bodyHeight >= 730) {
-                //note5, nexus5x, iphone 5+
-                if (ionic.Platform.isIOS()) {
-                    headerRatio = 0.40;
-                    contentRatio = 0.60;
-                }
-                else {
-                    headerRatio = 0.32;
-                    contentRatio = 0.68;
-                }
+            else if (600 <= $scope.bodyHeight && $scope.bodyHeight < 840) {
+                headerRatio = 3 / 8;
             }
-            else {
-                headerRatio = 0.32;
-                contentRatio = 0.68;
-            }
+            var contentRatio = 1 - headerRatio;
 
-            //빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
-            $scope.headerHeight = $scope.bodyHeight * headerRatio + 44;
+            // 빠르게 변경될때, header가 disable-user-behavior class가 추가되면서 화면이 올라가는 문제
+            $scope.headerHeight = ($scope.bodyHeight * headerRatio < 192) ? 192 : ($scope.bodyHeight * headerRatio);
             $scope.mainHeight = $scope.bodyHeight * contentRatio;
+
+            var contentWidth = $scope.bodyWidth * 0.8;
+            var contentHeight = $scope.headerHeight - 44 - 5; // headerBar height = 44px, bottom padding = 5px
+            if (ionic.Platform.isIOS()) {
+                contentHeight -= 20; // statusBar height = 20px
+            }
+            contentHeight -= 24 * 3; // line-height = 24px
+
+            var bigFontSize = (contentWidth / 4 < contentHeight * 0.9) ? (contentWidth / 4) : (contentHeight * 0.9);
+            $scope.bigFontSize = bigFontSize < 142.1 ? bigFontSize : 142.1;
+            $scope.bigImageSize = $scope.bigFontSize * 0.9;
         };
 
         var strWeather = "Weather";

--- a/client/www/templates/ta-tab-weather.html
+++ b/client/www/templates/ta-tab-weather.html
@@ -41,11 +41,11 @@
                 </div>
                 <div class="main-box" ng-if="currentWeather">
                     <div class="main-box-forecast-content">
-                        <div ng-style="::{'font-size':bigDigitSize+'px'}">
-                            {{getTemp(currentWeather.t1h)}}<span ng-if="currentWeather" ng-style="::{'font-size':bigDigitSize/2+'px'}">˚</span>
+                        <div ng-style="::{'font-size':bigFontSize+'px'}">
+                            {{getTemp(currentWeather.t1h)}}<span ng-if="currentWeather" ng-style="::{'font-size':bigFontSize/2+'px'}">˚</span>
                         </div>
                         <div style="margin: auto">
-                            <img id="imgBigSkyStateSize" ng-style="::{'height':bigSkyStateSize+'px'}" ng-src="{{::weatherImgPath}}/{{currentWeather.skyIcon}}.png">
+                            <img id="imgBigSkyStateSize" ng-style="::{'height':bigImageSize+'px'}" ng-src="{{::weatherImgPath}}/{{currentWeather.skyIcon}}.png">
                         </div>
                     </div>
                     <div class="main-box-summary">

--- a/client/www/templates/tab-air.html
+++ b/client/www/templates/tab-air.html
@@ -42,7 +42,7 @@
                     <div class="main-box-air-title">
                         {{mainName|translate}}
                     </div>
-                    <div class="main-box-air-content" ng-style="{'color': grade2Color(airCodeGrade)}">
+                    <div class="main-box-air-content" ng-style="{'color': grade2Color(airCodeGrade), 'font-size': bigFontSize+'px'}">
                         {{mainInfo}}<span>{{getAirCodeUnit(aqiCode)}}</span>
                     </div>
                     <div class="main-box-air-summary">
@@ -50,7 +50,7 @@
                         <i class="material-icons" ng-bind-html="getSentimentIcon(airCodeGrade)" ng-style="{'color': grade2Color(airCodeGrade)}"></i>
                         <span ng-if="airCodeActionGuide">{{airCodeActionGuide}}</span>
                     </div>
-                    <div class="main-box-air-summary" style="display: inline-flex; margin-top: 4px" ng-click="goWeather()">
+                    <div class="main-box-air-summary" style="display: inline-flex;" ng-click="goWeather()">
                         <div>
                             <img id="imgBigSkyStateSize" ng-src="{{::weatherImgPath}}/{{currentWeather.skyIcon}}.png">
                         </div>

--- a/client/www/templates/tab-dailyforecast.html
+++ b/client/www/templates/tab-dailyforecast.html
@@ -41,11 +41,11 @@
                 </div>
                 <div class="main-box" ng-if="currentWeather">
                     <div class="main-box-forecast-content">
-                        <div ng-style="::{'font-size':bigDigitSize+'px'}">
-                            {{getTemp(currentWeather.t1h)}}<span ng-if="currentWeather" ng-style="::{'font-size':bigDigitSize/2+'px'}">˚</span>
+                        <div ng-style="::{'font-size':bigFontSize+'px'}">
+                            {{getTemp(currentWeather.t1h)}}<span ng-if="currentWeather" ng-style="::{'font-size':bigFontSize/2+'px'}">˚</span>
                         </div>
                         <div style="margin: auto">
-                            <img id="imgBigSkyStateSize" ng-style="::{'height':bigSkyStateSize+'px'}" ng-src="{{::weatherImgPath}}/{{currentWeather.skyIcon}}.png">
+                            <img id="imgBigSkyStateSize" ng-style="::{'height':bigImageSize+'px'}" ng-src="{{::weatherImgPath}}/{{currentWeather.skyIcon}}.png">
                         </div>
                     </div>
                     <div class="main-box-summary">

--- a/client/www/templates/tab-forecast.html
+++ b/client/www/templates/tab-forecast.html
@@ -41,11 +41,11 @@
                 </div>
                 <div class="main-box" ng-if="currentWeather">
                     <div class="main-box-forecast-content">
-                        <div ng-style="::{'font-size':bigDigitSize+'px'}">
-                            {{getTemp(currentWeather.t1h)}}<span ng-if="currentWeather" ng-style="::{'font-size':bigDigitSize/2+'px'}">˚</span>
+                        <div ng-style="::{'font-size':bigFontSize+'px'}">
+                            {{getTemp(currentWeather.t1h)}}<span ng-if="currentWeather" ng-style="::{'font-size':bigFontSize/2+'px'}">˚</span>
                         </div>
                         <div style="margin: auto">
-                            <img id="imgBigSkyStateSize" ng-style="::{'height':bigSkyStateSize+'px'}" ng-src="{{::weatherImgPath}}/{{currentWeather.skyIcon}}.png">
+                            <img id="imgBigSkyStateSize" ng-style="::{'height':bigImageSize+'px'}" ng-src="{{::weatherImgPath}}/{{currentWeather.skyIcon}}.png">
                         </div>
                     </div>
                     <div class="main-box-summary">


### PR DESCRIPTION
TW-409 화면 사이즈에 따라 TopBox, 차트의 사이즈를 비율로 계산하는 코드 정리
* material design에서 정의된 해상도에 따른 column의 수에 맞게 bodyHeight를 분할하는 비율을 변경하여 TopBox의 높이 설정
 - 최소 크기를 기준으로 계산된 TopBox 최소 높이 보장 처리
 - TopBox에 표시되는 큰 이미지와 큰 글자 크기도 비율에 맞게 계산
 - 시간별 날씨 차트의 작은 이미지 크기는 column width에 따라 계산
 - 사용하지 않는 크기값 제거
 - 일별 차트의 경우 가로보기 화면에서 가로 전체가 채워지게 column width 설정
* 각 차트의 높이는 실제 텍스트 + 이미지 + 마진 크기로 계산되도록 함