### PR TITLE
TW-422 wrong timeoffset for tokyo

### DIFF
--- a/server/controllers/timezone.controller.js
+++ b/server/controllers/timezone.controller.js
@@ -302,7 +302,11 @@ class TimezoneController{
      * @private
      */
     _getGeoByTimezone(timezone, callback){
-        let encodedUrl = 'https://maps.googleapis.com/maps/api/geocode/json?address='+timezone+'&language=en&key=' + this._googleKey;
+        let encodedUrl = 'https://maps.googleapis.com/maps/api/geocode/json?address=';
+        if(timezone === 'Asia/Tokyo'){
+             timezone = 'Tokyo';
+        }
+        encodedUrl += timezone + '&language=en' + '&key=' + this._googleKey;
         encodedUrl = encodeURI(encodedUrl);
         log.info(encodedUrl);
 


### PR DESCRIPTION
- Added workaround code which swap string from "Asia/Tokyo" to "Tokyo".
  : In case of Japan, the server would use "Asia/Tokyo" string as TimezoneID and query it via Google API in order to get present geocode for Japan. But Google API would return Chicago's geocode